### PR TITLE
Crash on first render in multi-platform SwiftUI app (size-dependent resources initialized before MTKView has non-zero size)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ xcuserdata
 *.xccheckout
 *.moved-aside
 *.xcuserstate
+.swiftpm
 
 UntoldEngine4D/.DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ Sources/UntoldEngine/UntoldEngineKernels/UntoldEngineKernels.air
 docs/_site/
 docs/.jekyll-cache/
 
+.vscode/

--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,25 @@ let package = Package(
         // .visionOS(.v1),
     ],
     products: [
-        .library(name: "UntoldEngine", targets: ["UntoldEngine"]),
-        .executable(name: "DemoGame", targets: ["DemoGame"]),
-        .executable(name: "StarterGame", targets: ["StarterGame"]),
+        // Library product for the engine
+        .library(
+            name: "UntoldEngine",
+            targets: ["UntoldEngine"]
+        ),
+        // Executable for the demo game
+        .executable(
+            name: "DemoGame",
+            targets: ["DemoGame"]
+        ),
+        // Executable for the starter template
+        .executable(
+            name: "StarterGame",
+            targets: ["StarterGame"]
+        ),
+        .executable(
+            name: "SwiftUIDemo",
+            targets: ["SwiftUIDemo"]
+        ),
     ],
     targets: [
         .target(
@@ -73,9 +89,29 @@ let package = Package(
                 .linkedFramework("AppKit", .when(platforms: [.macOS])),
             ]
         ),
-
-        .testTarget(name: "UntoldEngineTests", dependencies: ["UntoldEngine"], path: "Tests/UntoldEngineTests"),
-        .testTarget(name: "UntoldEngineRenderTests", dependencies: ["UntoldEngine"], path: "Tests/UntoldEngineRenderTests"),
+        .executableTarget(
+            name: "SwiftUIDemo",
+            dependencies: ["UntoldEngine"],
+            path: "Sources/SwiftUIDemo",
+            linkerSettings: [
+                .linkedFramework("Metal"),
+                .linkedFramework("QuartzCore", .when(platforms: [.iOS, .macOS])),
+                .linkedFramework("Cocoa", .when(platforms: [.macOS])),
+                .linkedFramework("UIKit", .when(platforms: [.iOS]))
+            ]
+        ),
+        // Test target for unit tests
+        .testTarget(
+            name: "UntoldEngineTests",
+            dependencies: ["UntoldEngine"],
+            path: "Tests/UntoldEngineTests"
+        ),
+        // Render-specific test target
+        .testTarget(
+            name: "UntoldEngineRenderTests",
+            dependencies: ["UntoldEngine"],
+            path: "Tests/UntoldEngineRenderTests"
+        ),
     ]
 )
 

--- a/Sources/SwiftUIDemo/ContentView.swift
+++ b/Sources/SwiftUIDemo/ContentView.swift
@@ -1,0 +1,28 @@
+//
+//  ContentView.swift
+//  UntoldEngine
+//
+//  Created by Javier Segura Perez on 20/9/25.
+//
+
+import SwiftUI
+import UntoldEngine
+import simd
+import MetalKit
+
+struct ContentView: View {
+    var mtkView: MTKView
+    var renderer: UntoldRenderer?
+    
+    init() {
+        self.renderer = UntoldRenderer.create()
+        self.mtkView = self.renderer?.metalView ?? MTKView( )
+        self.renderer?.initResources( )
+    }
+    
+    var body: some View {
+        VStack {
+            SceneView( mtkView: mtkView )
+        }
+    }
+}

--- a/Sources/SwiftUIDemo/Info.plist
+++ b/Sources/SwiftUIDemo/Info.plist
@@ -1,0 +1,7 @@
+//
+//  Info.plist.swift
+//  UntoldEngine
+//
+//  Created by Javier Segura Perez on 20/9/25.
+//
+

--- a/Sources/SwiftUIDemo/Info.plist
+++ b/Sources/SwiftUIDemo/Info.plist
@@ -1,7 +1,7 @@
-//
-//  Info.plist.swift
-//  UntoldEngine
-//
-//  Created by Javier Segura Perez on 20/9/25.
-//
-
+{
+	CFBundleExecutable = "$(EXECUTABLE_NAME)";
+	CFBundleVersion = 1;
+	"CFBundleShortVersionString" = "1.0";
+	CFBundleName = SwiftUIDemoApp;
+	CFBundleIdentifier = "com.untoldengine.swiftuidemoapp";
+}

--- a/Sources/SwiftUIDemo/SwiftUIDemoApp.swift
+++ b/Sources/SwiftUIDemo/SwiftUIDemoApp.swift
@@ -1,0 +1,18 @@
+//
+//  SwiftUIDemoApp.swift
+//  UntoldEngine
+//
+//  Created by Javier Segura Perez on 20/9/25.
+//
+
+import SwiftUI
+
+@main
+struct SwiftUIDemoApp: App {
+    
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Sources/UntoldEngine/Editor/SceneView.swift
+++ b/Sources/UntoldEngine/Editor/SceneView.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Harold Serrano on 2/19/25.
 //
-#if canImport(AppKit)
 import MetalKit
 import SwiftUI
 
@@ -35,11 +34,11 @@ public struct SceneView: ViewRepresentable {
         mtkView
     }
 
-    public func updateUIView(_: MTKView, context _: Context) {
+    public func updateUIView(_ mtkView: MTKView, context: Context) {
         updateView(mtkView, context: context)
     }
 #endif
     
     public func updateView(_ view: MTKView, context: Context) { }
 }
-#endif
+

--- a/Sources/UntoldEngine/Editor/SceneView.swift
+++ b/Sources/UntoldEngine/Editor/SceneView.swift
@@ -8,13 +8,38 @@
 import MetalKit
 import SwiftUI
 
-struct SceneView: NSViewRepresentable {
+#if os(macOS)
+public typealias ViewRepresentable = NSViewRepresentable
+#else
+public typealias ViewRepresentable = UIViewRepresentable
+#endif
+
+
+public struct SceneView: ViewRepresentable {
     var mtkView: MTKView
 
-    func makeNSView(context _: Context) -> MTKView {
+    public init( mtkView: MTKView) {
+        self.mtkView = mtkView
+    }
+    
+#if os(macOS)
+    public func makeNSView(context: Context) -> MTKView {
         mtkView
     }
 
-    func updateNSView(_: MTKView, context _: Context) {}
+    public func updateNSView( _ view: MTKView, context : Context) {
+        updateView(mtkView, context: context)
+    }
+#else
+    public func makeUIView(context: Context) -> MTKView {
+        mtkView
+    }
+
+    public func updateUIView(_: MTKView, context _: Context) {
+        updateView(mtkView, context: context)
+    }
+#endif
+    
+    public func updateView(_ view: MTKView, context: Context) { }
 }
 #endif

--- a/Sources/UntoldEngine/Renderer/UntoldEngine.swift
+++ b/Sources/UntoldEngine/Renderer/UntoldEngine.swift
@@ -86,12 +86,9 @@ public class UntoldRenderer: NSObject, MTKViewDelegate {
 
     public func initResources() {
         initBufferResources()
-
-        initTextureResources()
         initRenderPipelines()
-
-        initRenderPassDescriptors()
-        initIBLResources()
+               
+        initSizeableResources() //TODO: Find a better name function
 
         shadowSystem = ShadowSystem()
 
@@ -119,6 +116,14 @@ public class UntoldRenderer: NSObject, MTKViewDelegate {
         initFrustumCulllingCompute()
 
         Logger.log(message: "Untold Engine Starting")
+    }
+    
+    func initSizeableResources() {
+        if renderInfo.viewPort.x == 0 || renderInfo.viewPort.y == 0 { return }
+        
+        initTextureResources()
+        initRenderPassDescriptors()
+        initIBLResources()
     }
 
     func calculateDeltaTime() {
@@ -223,6 +228,8 @@ public class UntoldRenderer: NSObject, MTKViewDelegate {
 
         let viewPortSize: simd_float2 = simd_make_float2(Float(mtkViewSize.width), Float(mtkViewSize.height))
         renderInfo.viewPort = viewPortSize
+        
+        initSizeableResources()
     }
 
     func handleSceneInput() {


### PR DESCRIPTION
When adapting `SceneView` to compile on both macOS and iOS using the SwiftUI app lifecycle, we hit a crash on first render on macOS. The crash occurs because size-dependent resources are initialized before `MTKView` has a non-zero size. All the sample demos are AppKit/macOS apps where a window width/height is set prior to creating the `MTKView`, so they don’t hit this.

Three functions—`initTextureResources()`, `initRenderPassDescriptors()`, and `initIBLResources()`—require non-zero width/height. If called early, they crash.

## Steps to Reproduce
1. Create a multi-platform SwiftUI app (no `NSApp` wrapper; use SwiftUI `@main` lifecycle).
2. Embed an `MTKView` via `NSViewRepresentable`/`UIViewRepresentable`.
3. Initialize size-dependent resources during early setup (e.g., in renderer init / first `draw`).
4. Run: first render path calls `InitResources` before `MTKView` has a non-zero size → crash.

## Actual Behavior
Crash on first render because width/height are zero when initializing textures, render pass descriptors, and IBL resources.

## Expected Behavior
Renderer should defer size-dependent initialization until the `MTKView` reports a non-zero drawable size, and should re-initialize on size changes (rotation, window resize, etc.).

## Proposed Fix (working patch)
1) Guard the initial resource setup so it only runs when size is non-zero:

```swift
if renderInfo.viewPort.x > 0 && renderInfo.viewPort.y > 0 {
    initTextureResources()
    initRenderPassDescriptors()
    initIBLResources()
}
```

2) Move the (re)initialization into `MTKViewDelegate`’s resize hook so it runs when a valid size is known. Prefer `mtkView.drawableSize` (pixels) over `bounds.size` (points) to handle Retina scaling correctly:

```swift
public func mtkView(_ mtkView: MTKView, drawableSizeWillChange size: CGSize) {
    // Use drawableSize for pixel-accurate dimensions
    let drawableSize = mtkView.drawableSize
    let aspect = Float(drawableSize.width) / max(1.0, Float(drawableSize.height))

    let projectionMatrix = matrixPerspectiveRightHand(
        fovyRadians: degreesToRadians(degrees: fov), aspectRatio: aspect, nearZ: near, farZ: far
    )
    renderInfo.perspectiveSpace = projectionMatrix

    renderInfo.viewPort = simd_make_float2(Float(drawableSize.width), Float(drawableSize.height))

    // (Re)generate size-dependent resources
    initTextureResources()
    initRenderPassDescriptors()
    initIBLResources()
}
```

With this change:
- First time the view reports a non-zero drawable size, resources are correctly initialized.
- On later resizes (rotation / window resize / large screens), textures/pass descriptors are regenerated to match the new size (fixes the “stuck at default values” behavior).

## Notes
- I wrapped the 3 functions inside a `initSizeableResources()` to call from the `init` and from the `mtkView(_ mtkView: MTKView, drawableSizeWillChange _: CGSize)` 
- The SwiftUI lifecycle doesn’t guarantee a known window size at the time your renderer is constructed. Using `drawableSizeWillChange` aligns with Metal’s model and ensures resources are sized correctly.
- Consider making the size-dependent init idempotent and releasing/refreshing old textures to avoid leaks during repeated resizes.
