### PR TITLE
[Patch] Revert to original culling

### DIFF
--- a/Sources/UntoldEngine/Systems/RenderingSystem.swift
+++ b/Sources/UntoldEngine/Systems/RenderingSystem.swift
@@ -12,7 +12,7 @@ func updateRenderingSystem(in view: MTKView) {
     
     if let commandBuffer = renderInfo.commandQueue.makeCommandBuffer() {
         
-        executeReduceScanFrustumCulling(commandBuffer)
+        executeFrustumCulling(commandBuffer)
         
         if let renderPassDescriptor = view.currentRenderPassDescriptor {
             renderInfo.renderPassDescriptor = renderPassDescriptor


### PR DESCRIPTION
This PR reverts frustum culling to the original version. I forgot to take into account a corner case in the optimized version of the cull.