### PR TITLE
Added default components to the create entity function

### DIFF
--- a/Sources/UntoldEngine/Systems/RegistrationSystem.swift
+++ b/Sources/UntoldEngine/Systems/RegistrationSystem.swift
@@ -12,7 +12,15 @@ import MetalKit
 
 public func createEntity() -> EntityID {
     globalEntityCounter += 1
-    return scene.newEntity()
+    let entity = scene.newEntity()
+    makeSpatial(entityId: entity)   // attach LocalTransform, WorldTransform, Scenegraph
+    return entity
+}
+
+public func makeSpatial(entityId: EntityID) {
+    registerComponent(entityId: entityId, componentType: LocalTransformComponent.self)
+    registerComponent(entityId: entityId, componentType: WorldTransformComponent.self)
+    registerComponent(entityId: entityId, componentType: ScenegraphComponent.self)
 }
 
 public func registerComponent(entityId: EntityID, componentType: (some Component).Type) {

--- a/Tests/UntoldEngineTests/ECSTests.swift
+++ b/Tests/UntoldEngineTests/ECSTests.swift
@@ -128,11 +128,13 @@ final class ECSTests: XCTestCase {
         let components = getAllEntityComponentsTypes(entityId: entityId)
 
         // Assert
-        XCTAssertEqual(components.count, 2, "Expected entity to have 2 components")
+        XCTAssertEqual(components.count, 4, "Expected entity to have 4 components")
 
         let expectedTypes: Set<ObjectIdentifier> = [
-            ObjectIdentifier(RenderComponent.self),
+            ObjectIdentifier(ScenegraphComponent.self),
             ObjectIdentifier(LocalTransformComponent.self),
+            ObjectIdentifier(RenderComponent.self),
+            ObjectIdentifier(WorldTransformComponent.self)
         ]
 
         let actualTypes = Set(components.map { ObjectIdentifier($0) })


### PR DESCRIPTION
when calling createEntity(), the function will add spatial default components to the entity