### PR TITLE
This PR hardens remote asset loading in two places

### DIFF
--- a/Sources/UntoldEngine/Systems/AssetDiskCache.swift
+++ b/Sources/UntoldEngine/Systems/AssetDiskCache.swift
@@ -12,6 +12,10 @@
 import CryptoKit
 import Foundation
 
+enum AssetDiskCacheError: Error, Equatable {
+    case pathTraversalAttempt(String)
+}
+
 /// Persistent disk cache for remote assets.
 ///
 /// `.untold` payloads are content-addressed and never expire — they are evicted
@@ -198,7 +202,7 @@ actor AssetDiskCache {
     /// predictable relative path (`Textures/foo.png`) so that `NativeFormatLoader`
     /// can find them using the cache directory as its `baseURL`.
     func storeAtRelativePath(_ relativePath: String, data: Data) throws {
-        let targetURL = cacheDir.appendingPathComponent(relativePath)
+        let targetURL = try resolvedCacheURL(forRelativePath: relativePath)
         let dir = targetURL.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         try data.write(to: targetURL)
@@ -206,10 +210,26 @@ actor AssetDiskCache {
 
     /// Returns `true` if a file already exists at `relativePath` inside the cache directory.
     func fileExists(atRelativePath relativePath: String) -> Bool {
-        FileManager.default.fileExists(atPath: cacheDir.appendingPathComponent(relativePath).path)
+        guard let targetURL = try? resolvedCacheURL(forRelativePath: relativePath) else {
+            return false
+        }
+        return FileManager.default.fileExists(atPath: targetURL.path)
     }
 
     // MARK: - Internals
+
+    private func resolvedCacheURL(forRelativePath relativePath: String) throws -> URL {
+        let cacheRoot = cacheDir.standardizedFileURL
+        let targetURL = cacheRoot.appendingPathComponent(relativePath).standardizedFileURL
+        let rootPath = cacheRoot.path
+        let targetPath = targetURL.path
+
+        guard targetPath == rootPath || targetPath.hasPrefix(rootPath + "/") else {
+            throw AssetDiskCacheError.pathTraversalAttempt(relativePath)
+        }
+
+        return targetURL
+    }
 
     /// Builds a stable, filesystem-safe cache key from the full URL string.
     private func cacheKey(for url: URL) -> String {

--- a/Sources/UntoldEngine/Systems/GeometryStreamingSystem+TileStreaming.swift
+++ b/Sources/UntoldEngine/Systems/GeometryStreamingSystem+TileStreaming.swift
@@ -768,7 +768,12 @@ extension GeometryStreamingSystem {
     /// so callers can clean up their entities and abort the load.
     /// Local file URLs are returned unchanged without any network I/O.
     func resolveAssetURL(_ url: URL, label: String) async -> URL? {
-        guard url.scheme == "https" || url.scheme == "http" else {
+        if url.scheme?.lowercased() == "http" {
+            let error = RemoteAssetDownloader.DownloadError.insecureScheme("http")
+            Logger.logError(message: "[TileStreaming] Remote download failed for \(label): \(error)")
+            return nil
+        }
+        guard url.scheme?.lowercased() == "https" else {
             return url
         }
         do {

--- a/Sources/UntoldEngine/Systems/RegistrationSystem.swift
+++ b/Sources/UntoldEngine/Systems/RegistrationSystem.swift
@@ -2168,8 +2168,10 @@ public func loadTiledScene(
     Task {
         do {
             let localURL: URL
-            if manifestURL.scheme == "https" || manifestURL.scheme == "http" {
+            if manifestURL.scheme?.lowercased() == "https" {
                 localURL = try await RemoteAssetDownloader.shared.localURL(for: manifestURL)
+            } else if manifestURL.scheme?.lowercased() == "http" {
+                throw RemoteAssetDownloader.DownloadError.insecureScheme("http")
             } else {
                 localURL = manifestURL
             }

--- a/Sources/UntoldEngine/Systems/RemoteAssetDownloader.swift
+++ b/Sources/UntoldEngine/Systems/RemoteAssetDownloader.swift
@@ -24,11 +24,14 @@ actor RemoteAssetDownloader {
     // MARK: - Error
 
     enum DownloadError: Error, LocalizedError {
+        case insecureScheme(String)
         case httpError(Int)
         case cacheEvictedAfter304
 
         var errorDescription: String? {
             switch self {
+            case let .insecureScheme(scheme):
+                return "Refusing to download over '\(scheme)': only https:// is permitted"
             case let .httpError(code): return "HTTP \(code)"
             case .cacheEvictedAfter304: return "304 Not Modified but cached file was evicted"
             }
@@ -57,6 +60,10 @@ actor RemoteAssetDownloader {
     ///
     /// - Throws: `DownloadError` or a `URLError` on network failure.
     func localURL(for remoteURL: URL) async throws -> URL {
+        guard remoteURL.scheme?.lowercased() == "https" else {
+            throw DownloadError.insecureScheme(remoteURL.scheme?.lowercased() ?? "none")
+        }
+
         // Fast path: already in cache.
         if let cached = await AssetDiskCache.shared.localURL(for: remoteURL) {
             return cached

--- a/Tests/UntoldEngineTests/AssetDiskCacheTests.swift
+++ b/Tests/UntoldEngineTests/AssetDiskCacheTests.swift
@@ -169,6 +169,27 @@ final class AssetDiskCacheTests: XCTestCase {
         XCTAssertTrue(isDir.boolValue)
     }
 
+    func testStoreAtRelativePathRejectsTraversal() async throws {
+        let cache = makeCache()
+
+        do {
+            try await cache.storeAtRelativePath("../outside.txt", data: Data("owned".utf8))
+            XCTFail("Expected traversal attempt to be rejected")
+        } catch let error as AssetDiskCacheError {
+            XCTAssertEqual(error, .pathTraversalAttempt("../outside.txt"))
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheDir.deletingLastPathComponent().appendingPathComponent("outside.txt").path))
+    }
+
+    func testFileExistsAtRelativePathRejectsTraversal() async {
+        let cache = makeCache()
+
+        let exists = await cache.fileExists(atRelativePath: "../outside.txt")
+
+        XCTAssertFalse(exists)
+    }
+
     // MARK: - LRU eviction
 
     func testLRUEvictsOldestEntries() async throws {

--- a/Tests/UntoldEngineTests/RemoteAssetDownloaderTests.swift
+++ b/Tests/UntoldEngineTests/RemoteAssetDownloaderTests.swift
@@ -17,7 +17,7 @@ final class RemoteAssetDownloaderTests: XCTestCase {
         let downloader = RemoteAssetDownloader()
 
         do {
-            _ = try await downloader.localURL(for: URL(string: "http://example.com/scene.json")!)
+            _ = try await downloader.localURL(for: XCTUnwrap(URL(string: "http://example.com/scene.json")))
             XCTFail("Expected insecure HTTP URL to be rejected")
         } catch let error as RemoteAssetDownloader.DownloadError {
             XCTAssertEqual(error.errorDescription, "Refusing to download over 'http': only https:// is permitted")

--- a/Tests/UntoldEngineTests/RemoteAssetDownloaderTests.swift
+++ b/Tests/UntoldEngineTests/RemoteAssetDownloaderTests.swift
@@ -1,0 +1,37 @@
+//
+//  RemoteAssetDownloaderTests.swift
+//  UntoldEngineTests
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+@testable import UntoldEngine
+import XCTest
+
+final class RemoteAssetDownloaderTests: XCTestCase {
+    func testLocalURLRejectsHTTPURLs() async throws {
+        let downloader = RemoteAssetDownloader()
+
+        do {
+            _ = try await downloader.localURL(for: URL(string: "http://example.com/scene.json")!)
+            XCTFail("Expected insecure HTTP URL to be rejected")
+        } catch let error as RemoteAssetDownloader.DownloadError {
+            XCTAssertEqual(error.errorDescription, "Refusing to download over 'http': only https:// is permitted")
+        }
+    }
+
+    func testLocalURLRejectsMissingScheme() async throws {
+        let downloader = RemoteAssetDownloader()
+
+        do {
+            _ = try await downloader.localURL(for: URL(fileURLWithPath: "/tmp/local-file"))
+            XCTFail("Expected non-HTTPS URL to be rejected")
+        } catch let error as RemoteAssetDownloader.DownloadError {
+            XCTAssertEqual(error.errorDescription, "Refusing to download over 'file': only https:// is permitted")
+        }
+    }
+}


### PR DESCRIPTION
1. Prevents path traversal when caching textures referenced from downloaded .untold files. 
2. Enforces HTTPS for remote manifest and tile downloads.