### PR TITLE
[Patch] Default quaternion rotations to identity instead of zero

### DIFF
--- a/Sources/UntoldEngine/ECS/Components.swift
+++ b/Sources/UntoldEngine/ECS/Components.swift
@@ -20,7 +20,10 @@ import simd
 
 public class LocalTransformComponent: Component {
     public var position: simd_float3 = .zero
-    public var rotation: simd_quatf = .init()
+    // simd_quatf() is the zero quaternion, not identity: it rotates every vector
+    // to zero, so entities created via registerComponent would silently zero out
+    // any math done with their default rotation.
+    public var rotation: simd_quatf = .init(ix: 0, iy: 0, iz: 0, r: 1)
     public var scale: simd_float3 = .one
 
     public var space: simd_float4x4 = .identity
@@ -255,8 +258,8 @@ public class CameraComponent: Component {
     public var yAxis: simd_float3 = .init(0.0, 0.0, 0.0)
     public var zAxis: simd_float3 = .init(0.0, 0.0, 0.0)
 
-    // quaternion
-    public var rotation: simd_quatf = .init()
+    // quaternion (identity; simd_quatf() would be the zero quaternion)
+    public var rotation: simd_quatf = .init(ix: 0, iy: 0, iz: 0, r: 1)
     var localOrientation: simd_float3 = .init(0.0, 0.0, 0.0)
     public var localPosition: simd_float3 = .init(0.0, 0.0, 0.0)
     var orbitTarget: simd_float3 = .init(0.0, 0.0, 0.0)

--- a/Sources/UntoldEngine/Systems/TransformSystem.swift
+++ b/Sources/UntoldEngine/Systems/TransformSystem.swift
@@ -353,7 +353,7 @@ public func rotateTo(entityId: EntityID, rotation: simd_quatf) {
 public func getRotationQuaternion(entityId: EntityID) -> simd_quatf {
     guard let localTransformComponent = scene.get(component: LocalTransformComponent.self, for: entityId) else {
         handleError(.noLocalTransformComponent, entityId)
-        return simd_quatf()
+        return simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
     }
 
     return localTransformComponent.rotation


### PR DESCRIPTION
## What changed

- `LocalTransformComponent.rotation` and `CameraComponent.rotation` now default to the identity quaternion `simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)` instead of `simd_quatf()`.
- `getRotationQuaternion`'s missing-component error path also returns identity instead of the zero quaternion.

## Why

`simd_quatf()` is the **zero** quaternion (0, 0, 0, 0), not identity: `q.act(v)` maps every vector to the zero vector, and multiplying any quaternion by it collapses to zero. Entities created through `registerComponent` therefore started with an invalid rotation. Discovered while developing animation root motion: root-motion deltas rotated by the entity's default rotation silently vanished.

## Audit of remaining `simd_quatf()` uses (left unchanged on purpose)

- **MathUtils.swift** (`quaternion_lookAt`, `transformMatrix3nToQuaternion`, `transformEulerAnglesToQuaternion`): the local `var q = simd_quatf()` is fully overwritten in every branch before returning — safe.
- **SceneRootTransform.swift**: uses the zero quat consistently as its own "no rotation" sentinel (property default, `reset()`, `isIdentity`), and many tests reset it with `rotation = simd_quatf()`. Changing that sentinel would flip `isIdentity` to false for existing callers and push a degenerate rotation matrix into render paths — deliberately out of scope; worth a separate cleanup.

## Notes for reviewers

- Full test suite passes (`swift test`).
- `swiftformat --lint` passes on both changed files.
- Serialized scenes that omit `rotation` now deserialize with identity instead of the zero quaternion (the serializer leaves the component default in place when the field is nil) — a strict improvement.
