### PR TITLE
[Feature] Compiled animation clip sampling and pose layer foundation

### DIFF
--- a/Sources/UntoldEngine/Animation/ClipSampler.swift
+++ b/Sources/UntoldEngine/Animation/ClipSampler.swift
@@ -1,0 +1,154 @@
+//
+//  ClipSampler.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import simd
+
+/// Samples a `CompiledAnimationClip` into a `PoseBuffer` without allocating.
+///
+/// Keyframe intervals are located with a binary search seeded by a per-joint
+/// cursor hint: playback advances monotonically, so consecutive frames almost
+/// always hit the hint (or its successor) and skip the search entirely.
+/// Cursors are hints only — a stale or wrong cursor changes nothing but
+/// speed.
+///
+/// The interpolation semantics intentionally reproduce
+/// `Animation.interpolateKeyframes` exactly (clamping before the first key,
+/// per-channel wrapping on the channel's own last key time, non-repeating
+/// clamp on the last key) so the compiled path is a drop-in replacement for
+/// the string-keyed path; the equality is enforced by unit tests.
+struct ClipSampler {
+    private var rotationCursors: [Int] = []
+    private var translationCursors: [Int] = []
+    private var boundClip: ObjectIdentifier?
+
+    /// Samples the clip at `time` into `pose`.
+    ///
+    /// `duration` and `speed` come from the live `AnimationClip` at the call
+    /// site: the outer wrap uses the clip duration and the channel lookup
+    /// time is scaled by the clip speed, matching
+    /// `Skeleton.updateWorldPose(at:animationClip:)`.
+    mutating func sample(
+        _ clip: CompiledAnimationClip,
+        time: Float,
+        duration: Float,
+        speed: Float,
+        into pose: inout PoseBuffer
+    ) {
+        bind(clip)
+        pose.resize(jointCount: clip.jointCount)
+
+        let channelTime = fmod(time, duration) * speed
+
+        for index in 0 ..< clip.jointCount {
+            let channel = clip.channels[index]
+
+            guard channel.animated else {
+                pose.translations[index] = clip.restTranslations[index]
+                pose.rotations[index] = clip.restRotations[index]
+                continue
+            }
+
+            pose.rotations[index] = sampleChannel(
+                times: channel.rotationTimes,
+                values: channel.rotationValues,
+                repeats: channel.repeats,
+                at: channelTime,
+                cursor: &rotationCursors[index],
+                interpolate: simd_slerp
+            ) ?? clip.restRotations[index]
+
+            pose.translations[index] = sampleChannel(
+                times: channel.translationTimes,
+                values: channel.translationValues,
+                repeats: channel.repeats,
+                at: channelTime,
+                cursor: &translationCursors[index],
+                interpolate: { a, b, t in a + (b - a) * t }
+            ) ?? clip.restTranslations[index]
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    /// Resets cursor storage when the sampled clip changes.
+    private mutating func bind(_ clip: CompiledAnimationClip) {
+        let identifier = ObjectIdentifier(clip)
+        guard boundClip != identifier else { return }
+        boundClip = identifier
+        rotationCursors = [Int](repeating: 1, count: clip.jointCount)
+        translationCursors = [Int](repeating: 1, count: clip.jointCount)
+    }
+
+    /// Locates the keyframe interval containing `time` and interpolates.
+    /// Returns nil when the channel is empty or no interval matches, in
+    /// which case the caller falls back to the rest pose.
+    private func sampleChannel<Value>(
+        times: [Float],
+        values: [Value],
+        repeats: Bool,
+        at time: Float,
+        cursor: inout Int,
+        interpolate: (Value, Value, Float) -> Value
+    ) -> Value? {
+        guard let lastTime = times.last else { return nil }
+
+        if times[0] >= time {
+            return values[0]
+        }
+        if time >= lastTime, !repeats {
+            return values[values.count - 1]
+        }
+
+        let wrappedTime = fmod(time, lastTime)
+        guard let index = findInterval(times: times, at: wrappedTime, cursor: &cursor) else {
+            return nil
+        }
+
+        let previousTime = times[index - 1]
+        let nextTime = times[index]
+        let t = (wrappedTime - previousTime) / (nextTime - previousTime)
+        return interpolate(values[index - 1], values[index], t)
+    }
+
+    /// Finds the smallest index `i` in `1..<times.count` with
+    /// `time < times[i]`, trying the cursor hint (and its successor) before
+    /// falling back to binary search.
+    private func findInterval(times: [Float], at time: Float, cursor: inout Int) -> Int? {
+        let count = times.count
+        guard count > 1 else { return nil }
+
+        let hint = cursor
+        if hint >= 1, hint < count, time < times[hint], hint == 1 || times[hint - 1] <= time {
+            return hint
+        }
+        let next = hint + 1
+        if hint >= 1, next < count, time < times[next], times[next - 1] <= time {
+            cursor = next
+            return next
+        }
+
+        var low = 1
+        var high = count - 1
+        var found = count
+        while low <= high {
+            let mid = (low + high) / 2
+            if time < times[mid] {
+                found = mid
+                high = mid - 1
+            } else {
+                low = mid + 1
+            }
+        }
+
+        guard found < count else { return nil }
+        cursor = found
+        return found
+    }
+}

--- a/Sources/UntoldEngine/Animation/CompiledAnimationClip.swift
+++ b/Sources/UntoldEngine/Animation/CompiledAnimationClip.swift
@@ -1,0 +1,100 @@
+//
+//  CompiledAnimationClip.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import simd
+
+/// An `AnimationClip` resolved against a specific `Skeleton` for fast
+/// per-frame sampling.
+///
+/// `AnimationClip` keys channels by joint string path, which forces a
+/// dictionary lookup per joint per frame. Compilation performs that
+/// resolution once: channels land in arrays index-aligned with
+/// `Skeleton.jointPaths`, and joints the clip does not animate get their
+/// rest-pose fallback precomputed. After compilation, sampling touches only
+/// flat arrays.
+///
+/// Instances are immutable snapshots of the clip's keyframe data; live
+/// per-play values (`duration`, `speed`) are passed at sample time so
+/// behavior tracks the source clip exactly.
+///
+/// See docs/Architecture/animationPoseLayer.md.
+final class CompiledAnimationClip {
+    struct Channel {
+        /// Whether the source clip authored a channel for this joint.
+        /// Unanimated joints sample straight from the rest-pose fallbacks.
+        let animated: Bool
+        let repeats: Bool
+        let rotationTimes: [Float]
+        let rotationValues: [simd_quatf]
+        let translationTimes: [Float]
+        let translationValues: [simd_float3]
+
+        static let unanimated = Channel(
+            animated: false,
+            repeats: true,
+            rotationTimes: [],
+            rotationValues: [],
+            translationTimes: [],
+            translationValues: []
+        )
+    }
+
+    let name: String
+    let jointCount: Int
+
+    /// Index-aligned with `Skeleton.jointPaths`.
+    let channels: [Channel]
+
+    /// Decomposed local rest pose, used as the per-channel fallback and as
+    /// the constant local scale folded back in during matrix construction.
+    let restTranslations: [simd_float3]
+    let restRotations: [simd_quatf]
+    let restScales: [simd_float3]
+
+    init(clip: AnimationClip, skeleton: Skeleton) {
+        name = clip.name
+        jointCount = skeleton.jointPaths.count
+
+        var channels: [Channel] = []
+        var restTranslations: [simd_float3] = []
+        var restRotations: [simd_quatf] = []
+        var restScales: [simd_float3] = []
+        channels.reserveCapacity(jointCount)
+        restTranslations.reserveCapacity(jointCount)
+        restRotations.reserveCapacity(jointCount)
+        restScales.reserveCapacity(jointCount)
+
+        for (index, jointPath) in skeleton.jointPaths.enumerated() {
+            let rest = skeleton.restTransform[index]
+            let scale = AnimationClip.localScale(from: rest)
+            restScales.append(scale)
+            restRotations.append(AnimationClip.localRotation(from: rest, scale: scale))
+            restTranslations.append(simd_float3(rest.columns.3.x, rest.columns.3.y, rest.columns.3.z))
+
+            if let animation = clip.jointAnimation[jointPath] {
+                channels.append(Channel(
+                    animated: true,
+                    repeats: animation.repeatAnimation,
+                    rotationTimes: animation.rotations.map(\.time),
+                    rotationValues: animation.rotations.map(\.value),
+                    translationTimes: animation.translations.map(\.time),
+                    translationValues: animation.translations.map(\.value)
+                ))
+            } else {
+                channels.append(.unanimated)
+            }
+        }
+
+        self.channels = channels
+        self.restTranslations = restTranslations
+        self.restRotations = restRotations
+        self.restScales = restScales
+    }
+}

--- a/Sources/UntoldEngine/Animation/PoseBuffer.swift
+++ b/Sources/UntoldEngine/Animation/PoseBuffer.swift
@@ -1,0 +1,39 @@
+//
+//  PoseBuffer.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import simd
+
+/// A local-space skeleton pose in structure-of-arrays form, indexed by
+/// skeleton joint index (same order as `Skeleton.jointPaths`).
+///
+/// This is the canonical runtime pose representation: rotations stay as
+/// quaternions and translations as vectors so poses can be blended and
+/// offset without decomposing matrices. The rest-pose local scale is not
+/// stored here; it is folded in when world matrices are built
+/// (see `Skeleton.updateWorldPose(from:localScales:)`), matching the
+/// runtime animation format, which carries no scale channels.
+///
+/// See docs/Architecture/animationPoseLayer.md.
+struct PoseBuffer {
+    var translations: [simd_float3] = []
+    var rotations: [simd_quatf] = []
+
+    var jointCount: Int {
+        translations.count
+    }
+
+    /// Ensures storage for `jointCount` joints. Reuses existing storage when
+    /// the count already matches, so steady-state sampling never allocates.
+    mutating func resize(jointCount: Int) {
+        guard translations.count != jointCount else { return }
+        translations = [simd_float3](repeating: .zero, count: jointCount)
+        rotations = [simd_quatf](repeating: simd_quatf(ix: 0, iy: 0, iz: 0, r: 1), count: jointCount)
+    }
+}

--- a/Sources/UntoldEngine/ECS/Components.swift
+++ b/Sources/UntoldEngine/ECS/Components.swift
@@ -164,12 +164,23 @@ public class AnimationComponent: Component {
     var pause: Bool = false
     var playbackSpeed: Float = 1.0
     var currentTime: Float = 0.0
+
+    // Compiled sampling state (see docs/Architecture/animationPoseLayer.md):
+    // clips resolved against this entity's skeleton, plus the per-entity
+    // sampler cursors and local pose the frame update writes into.
+    var compiledClips: [String: CompiledAnimationClip] = [:]
+    var sampler = ClipSampler()
+    var localPose = PoseBuffer()
+
     public required init() {}
 
     func cleanUp() {
         animationClips.removeAll()
         currentAnimation?.cleanUp()
         currentAnimation = nil
+        compiledClips.removeAll()
+        sampler = ClipSampler()
+        localPose = PoseBuffer()
     }
 
     func getAllAnimationClips() -> [String] {
@@ -178,6 +189,18 @@ public class AnimationComponent: Component {
 
     func removeAnimationClip(animationClip: String) {
         animationClips.removeValue(forKey: animationClip)
+        compiledClips.removeValue(forKey: animationClip)
+    }
+
+    /// Returns the compiled form of `clip` resolved against `skeleton`,
+    /// compiling and caching it on first use.
+    func compiledClip(for clip: AnimationClip, skeleton: Skeleton) -> CompiledAnimationClip {
+        if let cached = compiledClips[clip.name], cached.jointCount == skeleton.jointPaths.count {
+            return cached
+        }
+        let compiled = CompiledAnimationClip(clip: clip, skeleton: skeleton)
+        compiledClips[clip.name] = compiled
+        return compiled
     }
 }
 

--- a/Sources/UntoldEngine/Mesh/Skeleton.swift
+++ b/Sources/UntoldEngine/Mesh/Skeleton.swift
@@ -17,6 +17,11 @@ class Skeleton {
     var restTransform: [simd_float4x4]
     var currentPose: [simd_float4x4]
 
+    /// Scratch storage for the compiled sampling path; reused across frames
+    /// so pose composition never allocates in steady state.
+    private var worldPoseScratch: [simd_float4x4] = []
+    private var inverseBindTransform: [simd_float4x4] = []
+
     init?(mdlSkeleton: MDLSkeleton?) {
         guard let mdlSkeleton, !mdlSkeleton.jointPaths.isEmpty else { return nil }
 
@@ -57,7 +62,50 @@ class Skeleton {
         jointPaths.compactMap { self.jointPaths.firstIndex(of: $0) }
     }
 
-    /// Updates the skeleton's world pose based on animation data
+    /// Updates the skeleton's world pose from a sampled local-space pose.
+    /// Local matrices are rebuilt as T * R * S(rest scale), the hierarchy is
+    /// composed, and the inverse bind transforms are applied — matching
+    /// `updateWorldPose(at:animationClip:)` output for the same pose.
+    func updateWorldPose(from localPose: PoseBuffer, localScales: [simd_float3]) {
+        let jointCount = jointPaths.count
+        guard localPose.jointCount == jointCount, localScales.count == jointCount else {
+            handleError(.noSkeletonPose)
+            return
+        }
+
+        if worldPoseScratch.count != jointCount {
+            worldPoseScratch = [simd_float4x4](repeating: .identity, count: jointCount)
+        }
+        if inverseBindTransform.count != jointCount {
+            inverseBindTransform = bindTransform.map(\.inverse)
+        }
+        if currentPose.count != jointCount {
+            currentPose = [simd_float4x4](repeating: .identity, count: jointCount)
+        }
+
+        for index in 0 ..< jointCount {
+            let localMatrix = simd_float4x4(translation: localPose.translations[index])
+                * simd_float4x4(localPose.rotations[index])
+                * simd_float4x4(scale: localScales[index])
+            if let parentIndex = parentIndices[index] {
+                worldPoseScratch[index] = worldPoseScratch[parentIndex] * localMatrix
+            } else {
+                worldPoseScratch[index] = localMatrix
+            }
+        }
+
+        for index in 0 ..< jointCount {
+            currentPose[index] = worldPoseScratch[index] * inverseBindTransform[index]
+        }
+    }
+
+    /// Updates the skeleton's world pose based on animation data.
+    ///
+    /// This is the legacy string-keyed sampling path. The engine's frame
+    /// update routes through the compiled path
+    /// (`updateWorldPose(from:localScales:)`); this method is retained as
+    /// the reference implementation that the compiled path is tested
+    /// against for equality.
     func updateWorldPose(at currentTime: Float, animationClip: AnimationClip) {
         let time = fmod(currentTime, animationClip.duration)
 
@@ -324,7 +372,7 @@ class AnimationClip {
         return float4x4(translation: translation) * float4x4(rotation) * float4x4(scale: fallbackScale)
     }
 
-    private static func localScale(from matrix: float4x4) -> SIMD3<Float> {
+    static func localScale(from matrix: float4x4) -> SIMD3<Float> {
         SIMD3<Float>(
             simd_length(SIMD3<Float>(matrix.columns.0.x, matrix.columns.0.y, matrix.columns.0.z)),
             simd_length(SIMD3<Float>(matrix.columns.1.x, matrix.columns.1.y, matrix.columns.1.z)),
@@ -332,7 +380,7 @@ class AnimationClip {
         )
     }
 
-    private static func localRotation(from matrix: float4x4, scale: SIMD3<Float>) -> simd_quatf {
+    static func localRotation(from matrix: float4x4, scale: SIMD3<Float>) -> simd_quatf {
         let epsilon: Float = 0.000001
         let sx = max(scale.x, epsilon)
         let sy = max(scale.y, epsilon)

--- a/Sources/UntoldEngine/Systems/AnimationSystem.swift
+++ b/Sources/UntoldEngine/Systems/AnimationSystem.swift
@@ -165,9 +165,20 @@ private func updateAnimationSystem(deltaTime: Float) {
 
         guard let animationClip = animationComponent.currentAnimation else { continue }
 
+        let compiledClip = animationComponent.compiledClip(
+            for: animationClip,
+            skeleton: skeletonComponent.skeleton
+        )
+        animationComponent.sampler.sample(
+            compiledClip,
+            time: animationComponent.currentTime,
+            duration: animationClip.duration,
+            speed: animationClip.speed,
+            into: &animationComponent.localPose
+        )
         skeletonComponent.skeleton.updateWorldPose(
-            at: animationComponent.currentTime,
-            animationClip: animationClip
+            from: animationComponent.localPose,
+            localScales: compiledClip.restScales
         )
 
         // Update the skin for each mesh in the render component

--- a/Tests/UntoldEngineTests/AnimationCompiledSamplerTests.swift
+++ b/Tests/UntoldEngineTests/AnimationCompiledSamplerTests.swift
@@ -1,0 +1,398 @@
+//
+//  AnimationCompiledSamplerTests.swift
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import simd
+@testable import UntoldEngine
+import XCTest
+
+@MainActor
+final class AnimationCompiledSamplerTests: XCTestCase {
+    // MARK: - Fixtures
+
+    /// 4-joint skeleton: root → hips → spine, plus a leg hanging off hips.
+    /// Rest transforms carry translations, a rotation, and one non-uniform
+    /// scale so every code path in matrix reconstruction is exercised.
+    /// Bind transforms are non-identity so the inverse-bind multiply matters.
+    private func makeSkeleton() -> Skeleton {
+        let restRoot = simd_float4x4(translation: simd_float3(0, 1, 0))
+        let restHips = simd_float4x4(translation: simd_float3(0, 0.2, 0.1))
+            * simd_float4x4(simd_quatf(angle: 0.3, axis: simd_float3(0, 1, 0)))
+        let restSpine = simd_float4x4(translation: simd_float3(0, 0.5, 0))
+            * simd_float4x4(scale: simd_float3(1.5, 2.0, 1.0))
+        let restLeg = simd_float4x4(translation: simd_float3(0.15, -0.4, 0))
+            * simd_float4x4(simd_quatf(angle: -0.2, axis: simd_float3(1, 0, 0)))
+
+        let bindRoot = simd_float4x4(translation: simd_float3(0, 1, 0))
+        let bindHips = bindRoot * simd_float4x4(translation: simd_float3(0, 0.2, 0.1))
+        let bindSpine = bindHips * simd_float4x4(translation: simd_float3(0, 0.5, 0))
+        let bindLeg = bindHips * simd_float4x4(translation: simd_float3(0.15, -0.4, 0))
+
+        let runtimeSkeleton = RuntimeSkeleton(
+            jointPaths: ["root", "root/hips", "root/hips/spine", "root/hips/leg"],
+            parentIndices: [nil, 0, 1, 1],
+            bindTransforms: [bindRoot, bindHips, bindSpine, bindLeg],
+            restTransforms: [restRoot, restHips, restSpine, restLeg]
+        )
+
+        guard let skeleton = Skeleton(runtimeSkeleton: runtimeSkeleton) else {
+            fatalError("Failed to build test skeleton")
+        }
+        return skeleton
+    }
+
+    /// Walk-style clip: root has translation+rotation keys, hips is
+    /// rotation-only (must keep its rest translation), spine has a single
+    /// keyframe, leg is unanimated (must keep its full rest transform).
+    private func makeWalkClip() -> AnimationClip {
+        let rootChannel = RuntimeAnimationChannel(
+            jointPath: "root",
+            translations: [
+                .init(time: 0.0, value: simd_float3(0, 1, 0)),
+                .init(time: 0.5, value: simd_float3(0, 1.1, 0.5)),
+                .init(time: 1.5, value: simd_float3(0, 0.95, 1.4)),
+                .init(time: 2.0, value: simd_float3(0, 1, 2)),
+            ],
+            rotations: [
+                .init(time: 0.0, value: quatValue(angle: 0.0)),
+                .init(time: 1.0, value: quatValue(angle: 0.4)),
+                .init(time: 2.0, value: quatValue(angle: 0.0)),
+            ]
+        )
+        let hipsChannel = RuntimeAnimationChannel(
+            jointPath: "root/hips",
+            rotations: [
+                .init(time: 0.0, value: quatValue(angle: 0.1)),
+                .init(time: 0.7, value: quatValue(angle: -0.3)),
+                .init(time: 2.0, value: quatValue(angle: 0.1)),
+            ]
+        )
+        let spineChannel = RuntimeAnimationChannel(
+            jointPath: "root/hips/spine",
+            rotations: [
+                .init(time: 0.25, value: quatValue(angle: 0.6)),
+            ]
+        )
+
+        let runtimeClip = RuntimeAnimationClip(
+            name: "walk",
+            duration: 2.0,
+            channels: [rootChannel, hipsChannel, spineChannel]
+        )
+        return AnimationClip(runtimeClip: runtimeClip)
+    }
+
+    private func makeIdleClip() -> AnimationClip {
+        let rootChannel = RuntimeAnimationChannel(
+            jointPath: "root",
+            rotations: [
+                .init(time: 0.0, value: quatValue(angle: 0.05)),
+                .init(time: 1.0, value: quatValue(angle: -0.05)),
+            ]
+        )
+        let runtimeClip = RuntimeAnimationClip(
+            name: "idle",
+            duration: 1.0,
+            channels: [rootChannel]
+        )
+        return AnimationClip(runtimeClip: runtimeClip)
+    }
+
+    private func quatValue(angle: Float) -> SIMD4<Float> {
+        let q = simd_quatf(angle: angle, axis: simd_normalize(simd_float3(0.2, 1, 0.1)))
+        return SIMD4<Float>(q.imag.x, q.imag.y, q.imag.z, q.real)
+    }
+
+    // MARK: - Helpers
+
+    private func legacyPose(skeleton: Skeleton, clip: AnimationClip, at time: Float) -> [simd_float4x4] {
+        skeleton.updateWorldPose(at: time, animationClip: clip)
+        return skeleton.currentPose
+    }
+
+    private func compiledPose(
+        skeleton: Skeleton,
+        clip: AnimationClip,
+        compiled: CompiledAnimationClip,
+        sampler: inout ClipSampler,
+        pose: inout PoseBuffer,
+        at time: Float
+    ) -> [simd_float4x4] {
+        sampler.sample(compiled, time: time, duration: clip.duration, speed: clip.speed, into: &pose)
+        skeleton.updateWorldPose(from: pose, localScales: compiled.restScales)
+        return skeleton.currentPose
+    }
+
+    private func assertPosesEqual(
+        _ lhs: [simd_float4x4],
+        _ rhs: [simd_float4x4],
+        accuracy: Float = 1e-4,
+        _ message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(lhs.count, rhs.count, message, file: file, line: line)
+        for jointIndex in lhs.indices {
+            for column in 0 ..< 4 {
+                for row in 0 ..< 4 {
+                    XCTAssertEqual(
+                        lhs[jointIndex][column][row],
+                        rhs[jointIndex][column][row],
+                        accuracy: accuracy,
+                        "\(message) — joint \(jointIndex), column \(column), row \(row)",
+                        file: file,
+                        line: line
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: - Equality gate: compiled path vs legacy path
+
+    func testCompiledPathMatchesLegacyPathAtRepresentativeTimes() {
+        let skeleton = makeSkeleton()
+        let clip = makeWalkClip()
+        let compiled = CompiledAnimationClip(clip: clip, skeleton: skeleton)
+        var sampler = ClipSampler()
+        var pose = PoseBuffer()
+
+        // Start, mid-interval, exact keys, near-wrap, wrap boundary, beyond
+        // duration, and before the spine channel's single key.
+        let sampleTimes: [Float] = [0.0, 0.1, 0.25, 0.5, 0.7, 0.777, 1.0, 1.5, 1.999, 2.0, 2.5, 5.25]
+
+        for time in sampleTimes {
+            let expected = legacyPose(skeleton: skeleton, clip: clip, at: time)
+            let actual = compiledPose(
+                skeleton: skeleton, clip: clip, compiled: compiled,
+                sampler: &sampler, pose: &pose, at: time
+            )
+            assertPosesEqual(expected, actual, "Pose mismatch at t=\(time)")
+        }
+    }
+
+    func testCompiledPathMatchesLegacyPathOverSequentialPlayback() {
+        let skeleton = makeSkeleton()
+        let clip = makeWalkClip()
+        let compiled = CompiledAnimationClip(clip: clip, skeleton: skeleton)
+        var sampler = ClipSampler()
+        var pose = PoseBuffer()
+
+        // Simulates real playback across three loops at ~90 Hz so cursor
+        // hints are exercised, including across the wrap.
+        var time: Float = 0
+        let deltaTime: Float = 1.0 / 90.0
+        while time < clip.duration * 3 {
+            let expected = legacyPose(skeleton: skeleton, clip: clip, at: time)
+            let actual = compiledPose(
+                skeleton: skeleton, clip: clip, compiled: compiled,
+                sampler: &sampler, pose: &pose, at: time
+            )
+            assertPosesEqual(expected, actual, "Pose mismatch during playback at t=\(time)")
+            time += deltaTime
+        }
+    }
+
+    func testCompiledPathMatchesLegacyPathWithClipSpeed() {
+        let skeleton = makeSkeleton()
+        let clip = makeWalkClip()
+        clip.speed = 1.75
+        let compiled = CompiledAnimationClip(clip: clip, skeleton: skeleton)
+        var sampler = ClipSampler()
+        var pose = PoseBuffer()
+
+        for time in stride(from: Float(0), through: 4.0, by: 0.13) {
+            let expected = legacyPose(skeleton: skeleton, clip: clip, at: time)
+            let actual = compiledPose(
+                skeleton: skeleton, clip: clip, compiled: compiled,
+                sampler: &sampler, pose: &pose, at: time
+            )
+            assertPosesEqual(expected, actual, "Pose mismatch with speed 1.75 at t=\(time)")
+        }
+    }
+
+    // MARK: - Sampler correctness against hand-computed values
+
+    func testTranslationInterpolationMidway() {
+        let skeleton = makeSkeleton()
+        let clip = makeWalkClip()
+        let compiled = CompiledAnimationClip(clip: clip, skeleton: skeleton)
+        var sampler = ClipSampler()
+        var pose = PoseBuffer()
+
+        // Root translation keys: t=0.5 → (0, 1.1, 0.5), t=1.5 → (0, 0.95, 1.4).
+        // Midpoint t=1.0 lerps to (0, 1.025, 0.95).
+        sampler.sample(compiled, time: 1.0, duration: clip.duration, speed: 1, into: &pose)
+        let translation = pose.translations[0]
+        XCTAssertEqual(translation.x, 0.0, accuracy: 1e-5)
+        XCTAssertEqual(translation.y, 1.025, accuracy: 1e-5)
+        XCTAssertEqual(translation.z, 0.95, accuracy: 1e-5)
+    }
+
+    func testExactKeyframeHit() {
+        let skeleton = makeSkeleton()
+        let clip = makeWalkClip()
+        let compiled = CompiledAnimationClip(clip: clip, skeleton: skeleton)
+        var sampler = ClipSampler()
+        var pose = PoseBuffer()
+
+        sampler.sample(compiled, time: 0.5, duration: clip.duration, speed: 1, into: &pose)
+        let translation = pose.translations[0]
+        XCTAssertEqual(translation.y, 1.1, accuracy: 1e-5)
+        XCTAssertEqual(translation.z, 0.5, accuracy: 1e-5)
+    }
+
+    func testRotationOnlyChannelKeepsRestTranslation() {
+        let skeleton = makeSkeleton()
+        let clip = makeWalkClip()
+        let compiled = CompiledAnimationClip(clip: clip, skeleton: skeleton)
+        var sampler = ClipSampler()
+        var pose = PoseBuffer()
+
+        sampler.sample(compiled, time: 0.35, duration: clip.duration, speed: 1, into: &pose)
+
+        // Hips channel is rotation-only; its rest translation must survive.
+        let hipsRest = skeleton.restTransform[1]
+        XCTAssertEqual(pose.translations[1].x, hipsRest.columns.3.x, accuracy: 1e-6)
+        XCTAssertEqual(pose.translations[1].y, hipsRest.columns.3.y, accuracy: 1e-6)
+        XCTAssertEqual(pose.translations[1].z, hipsRest.columns.3.z, accuracy: 1e-6)
+    }
+
+    func testUnanimatedJointKeepsRestPose() {
+        let skeleton = makeSkeleton()
+        let clip = makeWalkClip()
+        let compiled = CompiledAnimationClip(clip: clip, skeleton: skeleton)
+        var sampler = ClipSampler()
+        var pose = PoseBuffer()
+
+        sampler.sample(compiled, time: 1.234, duration: clip.duration, speed: 1, into: &pose)
+
+        // Leg has no channel: its decomposed rest pose must come through.
+        XCTAssertFalse(compiled.channels[3].animated)
+        let legRest = skeleton.restTransform[3]
+        XCTAssertEqual(pose.translations[3].x, legRest.columns.3.x, accuracy: 1e-6)
+        XCTAssertEqual(pose.translations[3].y, legRest.columns.3.y, accuracy: 1e-6)
+        XCTAssertEqual(pose.translations[3].z, legRest.columns.3.z, accuracy: 1e-6)
+    }
+
+    func testWrapDoesNotSnap() {
+        let skeleton = makeSkeleton()
+        let clip = makeWalkClip()
+        let compiled = CompiledAnimationClip(clip: clip, skeleton: skeleton)
+        var sampler = ClipSampler()
+        var pose = PoseBuffer()
+
+        // Sampling just past the duration must equal sampling the wrapped time.
+        var wrappedSampler = ClipSampler()
+        var wrappedPose = PoseBuffer()
+        sampler.sample(compiled, time: 2.25, duration: clip.duration, speed: 1, into: &pose)
+        wrappedSampler.sample(compiled, time: 0.25, duration: clip.duration, speed: 1, into: &wrappedPose)
+
+        for jointIndex in 0 ..< compiled.jointCount {
+            XCTAssertEqual(
+                simd_length(pose.translations[jointIndex] - wrappedPose.translations[jointIndex]),
+                0, accuracy: 1e-5,
+                "Translation mismatch across wrap at joint \(jointIndex)"
+            )
+        }
+    }
+
+    // MARK: - Cursor behavior
+
+    func testCursorHintsMatchFreshSamplerResults() {
+        let skeleton = makeSkeleton()
+        let clip = makeWalkClip()
+        let compiled = CompiledAnimationClip(clip: clip, skeleton: skeleton)
+        var warmSampler = ClipSampler()
+        var warmPose = PoseBuffer()
+
+        var time: Float = 0
+        while time < clip.duration * 2 {
+            warmSampler.sample(compiled, time: time, duration: clip.duration, speed: 1, into: &warmPose)
+
+            var freshSampler = ClipSampler()
+            var freshPose = PoseBuffer()
+            freshSampler.sample(compiled, time: time, duration: clip.duration, speed: 1, into: &freshPose)
+
+            for jointIndex in 0 ..< compiled.jointCount {
+                XCTAssertEqual(
+                    simd_length(warmPose.translations[jointIndex] - freshPose.translations[jointIndex]),
+                    0, accuracy: 1e-6,
+                    "Warm cursor diverged from fresh sampler at t=\(time), joint \(jointIndex)"
+                )
+            }
+            time += 0.037
+        }
+    }
+
+    func testSwitchingClipsResetsCursorsCorrectly() {
+        let skeleton = makeSkeleton()
+        let walkClip = makeWalkClip()
+        let idleClip = makeIdleClip()
+        let compiledWalk = CompiledAnimationClip(clip: walkClip, skeleton: skeleton)
+        let compiledIdle = CompiledAnimationClip(clip: idleClip, skeleton: skeleton)
+        var sampler = ClipSampler()
+        var pose = PoseBuffer()
+
+        // Advance well into the walk clip, then switch to idle.
+        sampler.sample(compiledWalk, time: 1.8, duration: walkClip.duration, speed: 1, into: &pose)
+        sampler.sample(compiledIdle, time: 0.3, duration: idleClip.duration, speed: 1, into: &pose)
+
+        var freshSampler = ClipSampler()
+        var freshPose = PoseBuffer()
+        freshSampler.sample(compiledIdle, time: 0.3, duration: idleClip.duration, speed: 1, into: &freshPose)
+
+        for jointIndex in 0 ..< compiledIdle.jointCount {
+            let delta = simd_length(pose.rotations[jointIndex].vector - freshPose.rotations[jointIndex].vector)
+            XCTAssertEqual(delta, 0, accuracy: 1e-6, "Clip switch produced stale sampling at joint \(jointIndex)")
+        }
+    }
+
+    // MARK: - Steady-state storage behavior
+
+    func testPoseBufferStorageIsStableAcrossSamples() {
+        let skeleton = makeSkeleton()
+        let clip = makeWalkClip()
+        let compiled = CompiledAnimationClip(clip: clip, skeleton: skeleton)
+        var sampler = ClipSampler()
+        var pose = PoseBuffer()
+
+        sampler.sample(compiled, time: 0, duration: clip.duration, speed: 1, into: &pose)
+        let warmedCount = pose.jointCount
+
+        let warmBase = pose.translations.withUnsafeBufferPointer { UnsafeRawPointer($0.baseAddress!) }
+
+        var time: Float = 0.011
+        while time < clip.duration * 2 {
+            sampler.sample(compiled, time: time, duration: clip.duration, speed: 1, into: &pose)
+            time += 0.011
+        }
+
+        let steadyBase = pose.translations.withUnsafeBufferPointer { UnsafeRawPointer($0.baseAddress!) }
+        XCTAssertEqual(steadyBase, warmBase, "PoseBuffer storage was reallocated during steady-state sampling")
+        XCTAssertEqual(pose.jointCount, warmedCount)
+    }
+
+    func testSamplingPerformance() {
+        let skeleton = makeSkeleton()
+        let clip = makeWalkClip()
+        let compiled = CompiledAnimationClip(clip: clip, skeleton: skeleton)
+        var sampler = ClipSampler()
+        var pose = PoseBuffer()
+
+        measure {
+            var time: Float = 0
+            for _ in 0 ..< 10000 {
+                sampler.sample(compiled, time: time, duration: clip.duration, speed: 1, into: &pose)
+                skeleton.updateWorldPose(from: pose, localScales: compiled.restScales)
+                time += 1.0 / 90.0
+            }
+        }
+    }
+}

--- a/docs/Architecture/animationPoseLayer.md
+++ b/docs/Architecture/animationPoseLayer.md
@@ -1,0 +1,272 @@
+# Animation Pose Layer
+
+Status: **design — pending review**
+Branch: `feature/animation_pose_layer`
+
+## Purpose
+
+This document specifies the first milestone (M1) of the data-driven character
+animation effort: a runtime **pose layer** that upgrades the engine's skeletal
+animation from "one clip, hard cuts, no locomotion" to a foundation that
+supports motion matching and, later, learned controllers.
+
+The overall roadmap (see *Context* below) is:
+
+| Milestone | Deliverable |
+|---|---|
+| **M1 (this doc)** | Indexed pose representation, allocation-free clip sampling, inertialized transitions, root motion |
+| M2 | Two-bone foot IK using the existing ray-picking systems |
+| M3 | Motion matching: feature database, nearest-neighbour search, trajectory queries from `SteeringSystem` |
+| M4 | Demo: AI character locomoting over real terrain on visionOS with no animation state machine |
+| Later | Learned Motion Matching (network compression of the database); physics-based controllers |
+
+M1 is valuable on its own even if nothing after it ships: every consumer of
+`changeAnimation` gets smooth transitions, and locomotion clips stop sliding.
+
+## Context: what exists today
+
+- `Skeleton` (`Sources/UntoldEngine/Mesh/Skeleton.swift`) stores parallel
+  arrays of `simd_float4x4` keyed by joint **string paths**.
+- `AnimationClip.jointAnimation` is a `[String: Animation]` dictionary; every
+  joint lookup, every frame, hashes a string path.
+- `Animation.interpolateKeyframes` builds a `(previous, next)` tuple **array
+  per joint per channel per frame** and linear-scans it — an allocation and an
+  O(keys) walk in the hottest loop of the system.
+- `changeAnimation` swaps `currentAnimation` with an instant pop; `currentTime`
+  is not even reset, so the new clip starts at an arbitrary phase.
+- Root joint translation is baked into the pose: a walk clip drags the mesh
+  away from the entity transform, then snaps back on loop
+  (`updateWorldPose` wraps with `fmod`).
+- The per-skin joint `MTLBuffer` is single-buffered and CPU-written while
+  earlier frames may still read it (contrast `TripleBuffer.swift` used for
+  per-mesh uniforms).
+
+None of this matters at "one idle clip per entity". All of it matters when a
+controller samples multiple clips per frame and transitions constantly.
+
+## Design
+
+Four pieces, deliberately layered so each lands as its own PR with tests.
+
+### 1. Indexed pose representation + compiled clips
+
+New directory `Sources/UntoldEngine/Animation/`.
+
+**Pose buffer** — structure-of-arrays, local space, indexed by skeleton joint
+index (same order as `Skeleton.jointPaths`):
+
+```swift
+struct PoseBuffer {
+    var translations: [simd_float3]   // local, per joint
+    var rotations: [simd_quatf]       // local, per joint
+    // scale is not animated by the runtime format; the rest-pose local
+    // scale is folded in when matrices are built (matches current
+    // AnimationClip.getPose behavior).
+}
+```
+
+Local quaternions + translations are the canonical runtime representation.
+Matrices are derived at the end of the frame; nothing blends matrices. (The 6D
+rotation representation from the research plan is a *network I/O* format for
+M3+/ML; it does not appear in the runtime.)
+
+**Compiled clip** — built once when a clip is bound to a skeleton:
+
+```swift
+final class CompiledAnimationClip {
+    let name: String
+    let duration: Float
+    // Per skeleton-joint channel, index-aligned with Skeleton.jointPaths.
+    // Joints the clip does not animate fall back to the rest pose at
+    // compile time — no per-frame dictionary miss handling.
+    let rotationTimes: [[Float]]      // per joint, sorted
+    let rotationValues: [[simd_quatf]]
+    let translationTimes: [[Float]]
+    let translationValues: [[simd_float3]]
+    // Root motion metadata (section 3)
+    let rootDisplacementPerLoop: simd_float3
+    let rootYawPerLoop: Float
+}
+```
+
+The string-path → index resolution happens exactly once, at compile time,
+using the existing `Skeleton.mapJoints`. The existing `AnimationClip` remains
+the loader-facing type; `AnimationComponent` gains a lazily-built
+`compiledClips: [String: CompiledAnimationClip]` cache keyed by clip name.
+
+**Sampler** — allocation-free, binary search with a per-player cursor hint
+(consecutive frames advance monotonically, so the hint hits almost always):
+
+```swift
+struct ClipSampler {
+    var cursor: [Int]   // per-joint last keyframe index hint
+    mutating func sample(_ clip: CompiledAnimationClip, at time: Float,
+                         into pose: inout PoseBuffer)
+}
+```
+
+`Skeleton` gains one method to close the loop with the existing renderer:
+
+```swift
+func updateWorldPose(from localPose: PoseBuffer)
+```
+
+which composes the hierarchy exactly like the current `computeWorldPose`
+(including the inverse-bind multiply) and writes `currentPose`. GPU skinning,
+shaders, and `Skin.updateJointMatrices` are untouched.
+
+**Compatibility gate:** unit tests sample the same clip through the old path
+(`AnimationClip.getPose`) and the new path and assert per-joint equality
+within epsilon. The old sampling code is removed only after that test is
+green; `AnimationSystem.update` then routes through the compiled path
+unconditionally.
+
+### 2. Inertialized transitions
+
+Replaces nothing (there is no blending today) and does not introduce
+crossfades. On `changeAnimation`, instead of popping:
+
+1. Sample the **outgoing** state one last time (pose + per-joint velocity,
+   estimated by finite difference over the previous frame).
+2. Compute the per-joint **offset** from the incoming clip's pose at its
+   start time: translation offset as a vector, rotation offset as a rotation
+   vector (quaternion log), plus offset velocities.
+3. Each frame, decay the offset toward zero with a critically damped
+   spring (Daniel Holden's inertialization formulation, halflife-parameterized)
+   and add it on top of the incoming clip's sampled pose.
+
+State lives in a `PoseTransition` struct on `AnimationComponent` (offset
+buffers + halflife + remaining flag). Cost: two `PoseBuffer`s per entity and
+a few fused multiply-adds per joint — no second clip is sampled after the
+transition frame, which is the point of inertialization vs. crossfade.
+
+Public API — extend, don't break:
+
+```swift
+public func changeAnimation(entityId: EntityID, name: String,
+                            transitionHalflife: Float = 0.1,
+                            withPause: Bool = false)
+```
+
+`transitionHalflife: 0` reproduces today's hard cut. `currentTime` resets to
+0 on change (bug fix; noted in the PR).
+
+### 3. Root motion
+
+Opt-in per entity (default off — existing content behaves exactly as today):
+
+```swift
+public func setRootMotionEnabled(entityId: EntityID, _ enabled: Bool)
+```
+
+When enabled, for the designated root joint (the first joint with a `nil`
+parent, overridable by joint path):
+
+- The sampler extracts the root's **horizontal translation delta and yaw
+  delta** per frame in character space. Loop wrap is handled with the
+  precomputed `rootDisplacementPerLoop` / `rootYawPerLoop`: when the clip
+  time wraps, the delta is `(end→loopEnd) + (loopStart→newTime)` rather than
+  the raw negative jump.
+- Those deltas are applied to the entity via the existing
+  `translateBy` / `rotateBy` (`TransformSystem`), rotated into world space by
+  the entity's current orientation.
+- The root joint's horizontal translation and yaw are **removed from the
+  pose** (vertical motion, pitch and roll stay — a stumbling zombie leans).
+
+This runs inside `AnimationSystem.update`, which executes before
+`PhysicsSystem` in the frame (`UntoldEngine.swift` update order), so physics
+and steering see the post-root-motion transform in the same frame.
+
+### 4. Joint buffer frames-in-flight fix
+
+Independent `[Patch]` PR: `Skin.jointTransformsBuffer` becomes a ring of
+`totalPerMeshUniformBuffers()` buffers indexed by the frame-in-flight counter,
+mirroring the existing per-mesh uniform pattern, with the bind site in
+`RenderPasses.swift` selecting the current slot. Today's single buffer is a
+latent CPU-write/GPU-read race that becomes visible tearing the moment poses
+change every frame on multiple entities.
+
+## Extensibility: where the plugin seam is
+
+A recurring question: should this live outside the engine as a plugin, with
+the engine exposing only a minimal API — so a game could swap in a different
+animation system later?
+
+The realistic future is not "one game uses a different animation system"; it
+is "one *scene* uses several at once": crowd characters on motion matching,
+props on plain clip playback, a hero character on a learned controller. That
+argues for a seam **per entity**, not a globally replaceable system. The
+layering is:
+
+```
+┌────────────────────────────────────────────────────────┐
+│ Controllers (pluggable, per entity)                    │
+│   built-in clip player · motion matching (M3) · ML     │
+├────────────────────────────────────────────────────────┤
+│ Pose machinery (engine-owned, this doc)                │
+│   PoseBuffer · compiled clips · sampler ·              │
+│   inertialization · root motion application ·          │
+│   hierarchy compose · skinning upload                  │
+└────────────────────────────────────────────────────────┘
+```
+
+The contract between the layers is small: *given an entity and a delta time,
+fill a `PoseBuffer` (local space) and optionally report a root-motion delta*.
+Everything below that line is machinery every controller needs and should not
+be reimplemented per plugin; everything above it is strategy.
+
+Consequences for M1:
+
+- The machinery is built **in-engine** (as decided), but `AnimationSystem`'s
+  update is structured as *evaluate controller → inertialize → apply root
+  motion → compose → skin* from the start, with the existing clip player as
+  the built-in controller. No public protocol yet.
+- The controller interface (`PoseBuffer` + an `AnimationPoseController`
+  protocol + registration) is **published only when M3 exists** — motion
+  matching is the first real external consumer, and freezing a public API
+  before a second implementation has exercised it reliably produces the
+  wrong API. Publishing it is a small `[Feature]` PR at that point; under
+  the repo's auto-semver it must be additive.
+- Until then nothing new is `public`; the engine's API surface (and semver)
+  is untouched by PRs ①–②.
+
+## What M1 does not do
+
+- No motion database, feature vectors, or nearest-neighbour search (M3).
+- No IK (M2).
+- No layered/partial-body blending, no state machines — the target
+  architecture (motion matching) does not need them.
+- No new shaders or metallib changes; skinning stays as-is.
+- No changes to the `.untold` format or the Blender exporter. (M3 will need
+  an offline motion-database builder that consumes `.untold` clips; format
+  additions are deferred until then.)
+
+## PR breakdown
+
+Per the contribution guidelines (one feature per PR, tests required,
+how-to guide for new systems):
+
+1. `[Feature]` Compiled clips + allocation-free pose sampling — internal,
+   behavior-identical, gated by the old-vs-new equality test.
+2. `[Patch]` Joint transform buffer frames-in-flight ring.
+3. `[Feature]` Inertialized animation transitions — public API change,
+   how-to guide (`docs/API/UsingAnimationTransitions.md`), demo snippet.
+4. `[Feature]` Root motion — public API, how-to guide, test with a synthetic
+   clip whose root displacement is known analytically.
+
+## Testing
+
+- **Equality gate:** old sampler vs. compiled sampler, all clips in the test
+  assets, epsilon 1e-5.
+- **Sampler correctness:** synthetic clips with hand-computed keyframe values
+  (mid-key interpolation, exact-key hits, wrap, single-key channels, unanimated
+  joints preserving rest translation/scale).
+- **Inertialization:** offset decays monotonically to zero within ~4×
+  halflife; zero halflife reproduces a hard cut; pose is continuous (C0) at
+  the transition frame by construction.
+- **Root motion:** synthetic 4-key straight-walk clip — accumulated entity
+  displacement over exactly N loops equals N × known displacement; no snap at
+  the wrap frame.
+- **Performance guard:** the sampler's buffers must not grow after warm-up
+  (steady-state sampling reuses `PoseBuffer` and scratch storage), plus a
+  `measure`-based regression test over many sequential frames.


### PR DESCRIPTION
## Summary

First piece of a larger animation effort (design notes in `docs/Architecture/animationPoseLayer.md`, included in this PR): smooth clip transitions, root motion, and eventually motion-matching-driven characters. This PR lays the runtime foundation — skeletal clip sampling moves from per-frame string-keyed dictionary lookups with allocating linear keyframe scans to a compiled path:

- **`CompiledAnimationClip`** — a clip resolved once against its skeleton: channels land in joint-index-aligned flat arrays, rest-pose fallbacks precomputed. No per-frame string hashing.
- **`ClipSampler`** — allocation-free sampling into a **`PoseBuffer`** (local-space quaternions + translations, SoA). Keyframe intervals found by binary search seeded with per-joint cursor hints, so sequential playback skips the search almost always.
- **`Skeleton.updateWorldPose(from:localScales:)`** — hierarchy compose from a sampled pose with reused scratch storage and precomputed inverse bind transforms (previously every bind matrix was inverted every frame).
- `AnimationSystem.update` routes through the compiled path. The legacy string-keyed path is retained as the reference implementation the equality tests run against.

Behavior is intentionally identical to the legacy path, including its edge cases (clamping before the first key, per-channel wrap on the channel's own last key time, rest translation preserved for rotation-only channels, unanimated joints keeping their rest pose). No public API changes.

Follow-up PRs are ready and will be opened in order as this merges: per-entity animation policy (the entity tier of discussion #801), inertialized transitions for `changeAnimation`, and opt-in root motion.

## Testing

`AnimationCompiledSamplerTests` (12 tests, all passing):
- Equality gate: compiled path vs legacy path at hand-picked edge times **and** across three full clip loops of sequential 90 Hz playback (exercises cursor hints across wraps), plus a clip-speed variant
- Hand-computed interpolation values, exact-key hits, wrap continuity
- Rotation-only channels keep rest translation; unanimated joints keep rest pose
- Clip switching resets sampler cursors correctly
- Steady-state sampling never reallocates pose storage; `measure` baseline for regression tracking

Related suites (ECS, ComponentRegistry, scene loading contract, native format) still pass.