### PR TITLE
[Patch] Fix joint transforms buffer CPU/GPU race with per-frame ring

### DIFF
--- a/Sources/UntoldEngine/Mesh/Mesh+GPUMemory.swift
+++ b/Sources/UntoldEngine/Mesh/Mesh+GPUMemory.swift
@@ -91,9 +91,11 @@ extension Skin {
     var gpuMemorySize: Int {
         var totalSize = 0
 
-        // Joint transforms buffer
-        if let buffer = jointTransformsBuffer {
-            totalSize += buffer.length
+        // Joint transforms ring (one buffer per in-flight frame slot)
+        if let ring = jointTransformsRing {
+            for buffer in ring.buffers {
+                totalSize += buffer.length
+            }
         }
 
         return totalSize

--- a/Sources/UntoldEngine/Mesh/Skeleton.swift
+++ b/Sources/UntoldEngine/Mesh/Skeleton.swift
@@ -110,10 +110,71 @@ class Skeleton {
     }
 }
 
+/// Ring of joint-transform buffers so the CPU never rewrites a buffer a
+/// previous frame's GPU work may still be reading.
+///
+/// The animation update runs before the renderer waits on
+/// `commandBufferSemaphore`, so a write can overlap all
+/// `maxInFlightCommandBuffers` frames still executing — the ring therefore
+/// holds one extra slot. Each `write` rotates to the next buffer;
+/// `currentBuffer` is always the most recently written one, so a skin that
+/// stops animating keeps binding a buffer the CPU no longer touches.
+///
+/// This is a class so `Skin` copies (which already share their `MTLBuffer`
+/// storage) also share the write cursor.
+final class JointTransformsRing {
+    private(set) var buffers: [MTLBuffer]
+    private var writeIndex: Int = 0
+    let jointCount: Int
+
+    /// All buffers are pre-filled with identity matrices so the bind pose
+    /// renders correctly before any animation write occurs.
+    init?(jointCount: Int) {
+        let slotCount = maxInFlightCommandBuffers + 1
+        let bufferSize = jointCount * MemoryLayout<simd_float4x4>.stride
+        var buffers: [MTLBuffer] = []
+        buffers.reserveCapacity(slotCount)
+
+        for _ in 0 ..< slotCount {
+            guard let buffer = renderInfo.device.makeBuffer(length: bufferSize) else {
+                handleError(.bufferAllocationFailed, "joint transforms: \(bufferSize) bytes for \(jointCount) joints — device likely under memory pressure")
+                return nil
+            }
+            let pointer = buffer.contents().bindMemory(to: simd_float4x4.self, capacity: jointCount)
+            for jointIndex in 0 ..< jointCount {
+                pointer[jointIndex] = matrix_identity_float4x4
+            }
+            buffers.append(buffer)
+        }
+
+        self.buffers = buffers
+        self.jointCount = jointCount
+    }
+
+    /// The buffer render passes should bind: the most recently written slot.
+    var currentBuffer: MTLBuffer {
+        buffers[writeIndex]
+    }
+
+    /// Rotates to the next slot and fills it via `fill`, which receives a
+    /// typed pointer to the slot's contents.
+    func write(_ fill: (UnsafeMutablePointer<simd_float4x4>) -> Void) {
+        let nextIndex = (writeIndex + 1) % buffers.count
+        let pointer = buffers[nextIndex].contents().bindMemory(to: simd_float4x4.self, capacity: jointCount)
+        fill(pointer)
+        writeIndex = nextIndex
+    }
+}
+
 struct Skin {
     var jointPaths: [String] = []
     var skinToSkeletonMap: [Int] = [] // Maps skin joints to skeleton joints
-    var jointTransformsBuffer: MTLBuffer! // Buffer holding joint transforms
+    var jointTransformsRing: JointTransformsRing!
+
+    /// The joint transforms buffer render passes bind this frame.
+    var jointTransformsBuffer: MTLBuffer! {
+        jointTransformsRing?.currentBuffer
+    }
 
     /// Initializes a Skin object with an animation bind component and a skeleton
     init?(animationBindComponent: MDLAnimationBindComponent?, skeleton: Skeleton?) {
@@ -125,78 +186,59 @@ struct Skin {
         jointPaths = animationBindComponent.jointPaths ?? skeleton.jointPaths
         skinToSkeletonMap = skeleton.mapJoints(from: jointPaths)
 
-        guard let buffer = Skin.createBuffer(for: jointPaths.count) else {
+        guard let ring = JointTransformsRing(jointCount: jointPaths.count) else {
             handleError(.jointBufferFailed)
             return nil
         }
-        jointTransformsBuffer = buffer
+        jointTransformsRing = ring
     }
 
     init?(runtimeSkin: RuntimeSkinBinding) {
         skinToSkeletonMap = runtimeSkin.skinToSkeletonMap
         jointPaths = runtimeSkin.skinToSkeletonMap.map { "joint_\($0)" }
 
-        guard let buffer = Skin.createBuffer(for: jointPaths.count) else {
+        guard let ring = JointTransformsRing(jointCount: jointPaths.count) else {
             handleError(.jointBufferFailed)
             return nil
         }
-        jointTransformsBuffer = buffer
+        jointTransformsRing = ring
     }
 
     /// Initialize a skin object with zero data-for entities with no armature
     init?() {
-        guard let buffer = Skin.createBuffer(for: 1) else {
+        guard let ring = JointTransformsRing(jointCount: 1) else {
             handleError(.jointBufferFailed)
             return nil
         }
 
-        jointTransformsBuffer = buffer
+        jointTransformsRing = ring
     }
 
     /// Clean up
     mutating func cleanUp() {
-        jointTransformsBuffer = nil
+        jointTransformsRing = nil
         jointPaths.removeAll()
         skinToSkeletonMap.removeAll()
     }
 
-    /// Updates the joint transform matrices in the buffer using the skeleton's current pose
+    /// Updates the joint transform matrices in the next ring slot using the
+    /// skeleton's current pose
     func updateJointMatrices(skeleton: Skeleton?) {
         guard let skeletonPose = skeleton?.currentPose else {
             handleError(.noSkeletonPose)
             return
         }
 
-        guard let pointer = Skin.bindBuffer(jointTransformsBuffer, jointCount: jointPaths.count) else {
+        guard let ring = jointTransformsRing else {
             handleError(.jointBindFailed)
             return
         }
 
-        for (index, skinIndex) in skinToSkeletonMap.enumerated() {
-            pointer[index] = skeletonPose[skinIndex]
+        ring.write { pointer in
+            for (index, skinIndex) in skinToSkeletonMap.enumerated() {
+                pointer[index] = skeletonPose[skinIndex]
+            }
         }
-    }
-
-    // MARK: - Private Helpers
-
-    /// Creates a Metal buffer for storing joint transform matrices, pre-filled with
-    /// identity matrices so the bind pose renders correctly before any animation runs.
-    private static func createBuffer(for jointCount: Int) -> MTLBuffer? {
-        let bufferSize = jointCount * MemoryLayout<simd_float4x4>.stride
-        guard let buffer = renderInfo.device.makeBuffer(length: bufferSize) else {
-            handleError(.bufferAllocationFailed, "joint transforms: \(bufferSize) bytes for \(jointCount) joints — device likely under memory pressure")
-            return nil
-        }
-        let ptr = buffer.contents().bindMemory(to: simd_float4x4.self, capacity: jointCount)
-        for i in 0 ..< jointCount {
-            ptr[i] = matrix_identity_float4x4
-        }
-        return buffer
-    }
-
-    /// Binds the Metal buffer and returns a typed pointer
-    private static func bindBuffer(_ buffer: MTLBuffer, jointCount: Int) -> UnsafeMutablePointer<simd_float4x4>? {
-        buffer.contents().bindMemory(to: simd_float4x4.self, capacity: jointCount)
     }
 }
 

--- a/Tests/UntoldEngineRenderTests/GPUMemoryTest.swift
+++ b/Tests/UntoldEngineRenderTests/GPUMemoryTest.swift
@@ -395,10 +395,13 @@ final class GPUMemoryTest: BaseRenderSetup {
             // Should have at least one joint's worth of memory
             XCTAssertGreaterThan(skinMemory, 0, "Skin should have GPU memory for joint transforms")
 
-            // Verify it matches the buffer length
-            if let buffer = testSkin.jointTransformsBuffer {
-                XCTAssertEqual(skinMemory, buffer.length,
-                               "Skin GPU memory should equal joint transforms buffer length")
+            // Verify it matches the whole ring (one buffer per in-flight
+            // frame slot plus one; jointTransformsBuffer is only the
+            // currently bound slot).
+            if let ring = testSkin.jointTransformsRing {
+                let ringTotal = ring.buffers.reduce(0) { $0 + $1.length }
+                XCTAssertEqual(skinMemory, ringTotal,
+                               "Skin GPU memory should equal the total of all joint ring slots")
             }
             return
         }
@@ -406,10 +409,13 @@ final class GPUMemoryTest: BaseRenderSetup {
         // When: Calculate skin GPU memory
         let skinMemory = skin.gpuMemorySize
 
-        // Then: Verify it matches joint transforms buffer
-        if let buffer = skin.jointTransformsBuffer {
-            XCTAssertEqual(skinMemory, buffer.length,
-                           "Skin GPU memory should equal joint transforms buffer length")
+        // Then: Verify it matches the whole ring (one buffer per in-flight
+        // frame slot plus one; jointTransformsBuffer is only the currently
+        // bound slot).
+        if let ring = skin.jointTransformsRing {
+            let ringTotal = ring.buffers.reduce(0) { $0 + $1.length }
+            XCTAssertEqual(skinMemory, ringTotal,
+                           "Skin GPU memory should equal the total of all joint ring slots")
         }
 
         XCTAssertGreaterThan(skinMemory, 0, "Skin should have positive GPU memory")

--- a/Tests/UntoldEngineTests/JointTransformsRingTests.swift
+++ b/Tests/UntoldEngineTests/JointTransformsRingTests.swift
@@ -1,0 +1,182 @@
+//
+//  JointTransformsRingTests.swift
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import MetalKit
+import simd
+@testable import UntoldEngine
+import XCTest
+
+// Tests for the joint transforms buffer ring. The CPU animation update runs
+// before the renderer waits on the command-buffer semaphore, so a single
+// shared buffer can be rewritten while up to maxInFlightCommandBuffers frames
+// still read it on the GPU. The ring guarantees every write lands in a buffer
+// no in-flight frame can be reading.
+
+@MainActor
+final class JointTransformsRingTests: XCTestCase {
+    override func setUp() async throws {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            XCTFail("Failed to create Metal device")
+            return
+        }
+        renderInfo.device = device
+    }
+
+    private func matrix(filledWith value: Float) -> simd_float4x4 {
+        simd_float4x4(
+            SIMD4<Float>(repeating: value),
+            SIMD4<Float>(repeating: value),
+            SIMD4<Float>(repeating: value),
+            SIMD4<Float>(repeating: value)
+        )
+    }
+
+    private func readMatrix(_ buffer: MTLBuffer, jointIndex: Int, jointCount: Int) -> simd_float4x4 {
+        buffer.contents().bindMemory(to: simd_float4x4.self, capacity: jointCount)[jointIndex]
+    }
+
+    // MARK: - Ring construction
+
+    func testRingHoldsOneMoreSlotThanInFlightFrames() throws {
+        let ring = try XCTUnwrap(JointTransformsRing(jointCount: 4))
+        XCTAssertEqual(ring.buffers.count, maxInFlightCommandBuffers + 1)
+
+        let uniqueBuffers = Set(ring.buffers.map { ObjectIdentifier($0) })
+        XCTAssertEqual(uniqueBuffers.count, ring.buffers.count, "Ring slots must be distinct buffers")
+    }
+
+    func testAllSlotsPrefilledWithIdentity() throws {
+        let jointCount = 3
+        let ring = try XCTUnwrap(JointTransformsRing(jointCount: jointCount))
+
+        for (slot, buffer) in ring.buffers.enumerated() {
+            for jointIndex in 0 ..< jointCount {
+                let matrix = readMatrix(buffer, jointIndex: jointIndex, jointCount: jointCount)
+                XCTAssertEqual(
+                    matrix, matrix_identity_float4x4,
+                    "Slot \(slot), joint \(jointIndex) must start as identity so the bind pose renders before any animation write"
+                )
+            }
+        }
+    }
+
+    // MARK: - Write rotation
+
+    func testWriteRotatesAwayFromPreviouslyBoundBuffer() throws {
+        let ring = try XCTUnwrap(JointTransformsRing(jointCount: 1))
+
+        let boundBefore = ring.currentBuffer
+        ring.write { pointer in pointer[0] = self.matrix(filledWith: 7) }
+
+        XCTAssertNotIdentical(
+            ring.currentBuffer, boundBefore,
+            "A write must land in a different buffer than the one previous frames bound"
+        )
+        XCTAssertEqual(readMatrix(ring.currentBuffer, jointIndex: 0, jointCount: 1), matrix(filledWith: 7))
+        XCTAssertEqual(
+            readMatrix(boundBefore, jointIndex: 0, jointCount: 1), matrix_identity_float4x4,
+            "The previously bound buffer must be untouched by the write"
+        )
+    }
+
+    func testConsecutiveWritesNeverReuseAnInFlightSlot() throws {
+        let ring = try XCTUnwrap(JointTransformsRing(jointCount: 1))
+        let slotCount = ring.buffers.count
+
+        // Track which buffer each simulated frame bound. A write during
+        // frame N must not touch buffers bound by frames N-1 ... N-maxInFlight.
+        var boundHistory: [ObjectIdentifier] = []
+        for frame in 0 ..< (slotCount * 3) {
+            ring.write { pointer in pointer[0] = self.matrix(filledWith: Float(frame)) }
+            let bound = ObjectIdentifier(ring.currentBuffer)
+
+            let stillInFlight = boundHistory.suffix(maxInFlightCommandBuffers)
+            XCTAssertFalse(
+                stillInFlight.contains(bound),
+                "Frame \(frame) wrote a buffer that could still be read by an in-flight frame"
+            )
+            boundHistory.append(bound)
+        }
+    }
+
+    func testCurrentBufferAlwaysHoldsLatestWrite() throws {
+        let ring = try XCTUnwrap(JointTransformsRing(jointCount: 2))
+
+        for frame in 0 ..< 10 {
+            let value = Float(frame + 1)
+            ring.write { pointer in
+                pointer[0] = self.matrix(filledWith: value)
+                pointer[1] = self.matrix(filledWith: value * 100)
+            }
+            XCTAssertEqual(readMatrix(ring.currentBuffer, jointIndex: 0, jointCount: 2), matrix(filledWith: value))
+            XCTAssertEqual(readMatrix(ring.currentBuffer, jointIndex: 1, jointCount: 2), matrix(filledWith: value * 100))
+        }
+    }
+
+    // MARK: - Skin integration
+
+    func testSkinUpdateJointMatricesWritesMappedPose() throws {
+        let restRoot = simd_float4x4.identity
+        let restChild = simd_float4x4(translation: simd_float3(0, 1, 0))
+        let runtimeSkeleton = RuntimeSkeleton(
+            jointPaths: ["root", "root/child"],
+            parentIndices: [nil, 0],
+            bindTransforms: [restRoot, restChild],
+            restTransforms: [restRoot, restChild]
+        )
+        let skeleton = try XCTUnwrap(Skeleton(runtimeSkeleton: runtimeSkeleton))
+
+        // Skin maps its two slots to the skeleton joints in reverse order to
+        // verify skinToSkeletonMap is honored.
+        let runtimeSkin = RuntimeSkinBinding(skinToSkeletonMap: [1, 0], jointIndexData: Data(), jointWeightData: Data())
+        let skin = try XCTUnwrap(Skin(runtimeSkin: runtimeSkin))
+
+        skeleton.currentPose = [matrix(filledWith: 1), matrix(filledWith: 2)]
+        skin.updateJointMatrices(skeleton: skeleton)
+
+        let buffer = try XCTUnwrap(skin.jointTransformsBuffer)
+        XCTAssertEqual(readMatrix(buffer, jointIndex: 0, jointCount: 2), matrix(filledWith: 2))
+        XCTAssertEqual(readMatrix(buffer, jointIndex: 1, jointCount: 2), matrix(filledWith: 1))
+    }
+
+    func testSkinCopiesShareTheRingCursor() throws {
+        let runtimeSkin = RuntimeSkinBinding(skinToSkeletonMap: [0], jointIndexData: Data(), jointWeightData: Data())
+        let skin = try XCTUnwrap(Skin(runtimeSkin: runtimeSkin))
+        let skinCopy = skin
+
+        let runtimeSkeleton = RuntimeSkeleton(
+            jointPaths: ["root"],
+            parentIndices: [nil],
+            bindTransforms: [.identity],
+            restTransforms: [.identity]
+        )
+        let skeleton = try XCTUnwrap(Skeleton(runtimeSkeleton: runtimeSkeleton))
+        skeleton.currentPose = [matrix(filledWith: 5)]
+
+        skin.updateJointMatrices(skeleton: skeleton)
+
+        // The copy stored in entity mesh maps must bind the same freshly
+        // written buffer as the original.
+        XCTAssertIdentical(
+            try XCTUnwrap(skinCopy.jointTransformsBuffer),
+            try XCTUnwrap(skin.jointTransformsBuffer),
+            "Skin copies must share the ring cursor so all bind sites see the latest write"
+        )
+        XCTAssertEqual(readMatrix(skinCopy.jointTransformsBuffer, jointIndex: 0, jointCount: 1), matrix(filledWith: 5))
+    }
+
+    func testGPUMemoryAccountsForAllRingSlots() throws {
+        let runtimeSkin = RuntimeSkinBinding(skinToSkeletonMap: [0, 1, 2], jointIndexData: Data(), jointWeightData: Data())
+        let skin = try XCTUnwrap(Skin(runtimeSkin: runtimeSkin))
+
+        let perBuffer = 3 * MemoryLayout<simd_float4x4>.stride
+        XCTAssertEqual(skin.gpuMemorySize, perBuffer * (maxInFlightCommandBuffers + 1))
+    }
+}


### PR DESCRIPTION
## Summary

The per-skin joint transforms `MTLBuffer` is a **single shared buffer**: the CPU rewrites it during the animation update while up to `maxInFlightCommandBuffers` earlier frames may still be reading it on the GPU (contrast the per-mesh uniforms, which already use a per-slot ring via `totalPerMeshUniformBuffers()`). Result: skinned poses can tear under load — subtle with slow idle clips, but increasingly visible as animation gets busier.

### Fix

- `Skin` now owns a **`JointTransformsRing`** of `maxInFlightCommandBuffers + 1` identity-prefilled buffers. The `+1` is deliberate: the animation update runs **before** the renderer waits on `commandBufferSemaphore` (`RenderingSystem.swift`), so a write can overlap *all* in-flight frames, not `maxInFlight - 1`.
- Each `updateJointMatrices` rotates to the next slot and writes there. `jointTransformsBuffer` becomes a computed property returning the most recently written slot — **all 10 render-pass bind sites are untouched**.
- A skin that stops animating keeps binding its last-written buffer, which the CPU never touches again — no stale-slot flicker for paused/static skins (this is why the ring is self-rotating rather than indexed by the render frame slot).
- The ring is a reference type so `Skin` copies stored in `entityMeshMap` etc. share the write cursor.
- GPU memory accounting (`Mesh+GPUMemory`) now sums all ring slots.

## Testing

`JointTransformsRingTests` (8 tests, all passing):
- Ring holds `maxInFlightCommandBuffers + 1` distinct buffers, all identity-prefilled (bind pose renders before any write)
- A write never lands in a buffer bound by any of the last `maxInFlightCommandBuffers` simulated frames
- `currentBuffer` always holds the latest write; previously bound buffers are untouched
- `Skin.updateJointMatrices` honors `skinToSkeletonMap`; skin copies share the ring cursor; GPU memory accounts for all slots

Mesh/ECS/native-format suites still pass. Independent of any other open PR — can merge in any order.