### PR TITLE
[Feature] Per-frame update event with UntoldView onUpdate modifier

### DIFF
--- a/Sources/UntoldEngine/Renderer/UntoldEngine.swift
+++ b/Sources/UntoldEngine/Renderer/UntoldEngine.swift
@@ -25,6 +25,8 @@ public class UntoldRenderer: NSObject, MTKViewDelegate {
     var gameUpdateCallback: ((_ deltaTime: Float) -> Void)?
     var handleInputCallback: (() -> Void)?
 
+    let frameEvents = FrameEventDispatcher()
+
     private var configuration: UntoldRendererConfig
     public var delegate: UntoldRendererDelegate?
     public var pendingResize = false
@@ -141,6 +143,16 @@ public class UntoldRenderer: NSObject, MTKViewDelegate {
     ) {
         gameUpdateCallback = gameUpdate
         handleInputCallback = handleInput
+    }
+
+    /// Subscribes to the per-frame update event. Fires once per frame after
+    /// animation/physics/game update and before rendering, regardless of `gameMode`.
+    /// The handler runs on the frame thread: main for MTKView/AR hosts, the
+    /// compositor render thread for XR. The world-access gate is held during
+    /// delivery, so scene mutation is safe inside the handler.
+    @discardableResult
+    public func onUpdate(_ handler: @escaping (UpdateEvent) -> Void) -> EventSubscription {
+        frameEvents.subscribe(handler)
     }
 
     func initResources() {
@@ -608,6 +620,12 @@ public class UntoldRenderer: NSObject, MTKViewDelegate {
 
             // user game update
             gameUpdateCallback?(timeSinceLastUpdate)
+        }
+
+        // Per-frame view update event — fires every frame regardless of gameMode
+        // (RealityKit SceneEvents.Update semantics)
+        if frameEvents.hasSubscribers {
+            frameEvents.dispatch(UpdateEvent(deltaTime: TimeInterval(timeSinceLastUpdate), renderer: self))
         }
         EngineProfiler.shared.endScope(.update)
         #if ENGINE_STATS_ENABLED

--- a/Sources/UntoldEngine/Scenes/Builder/UntoldView.swift
+++ b/Sources/UntoldEngine/Scenes/Builder/UntoldView.swift
@@ -16,6 +16,7 @@ public struct UntoldView: View {
     @State private var metalView: MTKView
     private var renderer: UntoldRenderer?
     private var content: [any NodeProtocol] = []
+    private var updateHandler: (@MainActor (UpdateEvent) -> Void)?
 
     public init(renderer: UntoldRenderer? = nil, @SceneBuilder _ content: @escaping @MainActor () -> [any NodeProtocol]) {
         self.renderer = renderer ?? UntoldRenderer.create()
@@ -24,6 +25,20 @@ public struct UntoldView: View {
     }
 
     public var body: some View {
-        SceneView(renderer: renderer)
+        SceneView(renderer: renderer, updateHandler: updateHandler)
+    }
+
+    /// Subscribes to the engine's per-frame update event (RealityKit
+    /// `SceneEvents.Update` style). The handler fires every frame on the main
+    /// thread, regardless of `gameMode`, after simulation and before rendering.
+    ///
+    /// - Warning: Do not mutate SwiftUI `@State` that this view's scene content
+    ///   depends on from inside the handler — that re-evaluates the body every
+    ///   frame and re-runs the scene builder. Keep per-frame values in a
+    ///   reference type or in the ECS.
+    public func onUpdate(_ handler: @escaping @MainActor (UpdateEvent) -> Void) -> UntoldView {
+        var copy = self
+        copy.updateHandler = handler
+        return copy
     }
 }

--- a/Sources/UntoldEngine/Scenes/SceneView.swift
+++ b/Sources/UntoldEngine/Scenes/SceneView.swift
@@ -19,28 +19,70 @@ import SwiftUI
 public struct SceneView: ViewRepresentable {
     var mtkView: MTKView
     private var renderer: UntoldRenderer?
+    private var updateHandler: (@MainActor (UpdateEvent) -> Void)?
 
     // TODO: Maybe we should thow an error on init instead of allowing nil renderer value
-    public init(renderer: UntoldRenderer? = nil) {
+    public init(renderer: UntoldRenderer? = nil, updateHandler: (@MainActor (UpdateEvent) -> Void)? = nil) {
         self.renderer = renderer ?? UntoldRenderer.create()
+        self.updateHandler = updateHandler
         mtkView = self.renderer!.metalView
     }
 
+    /// Persists across SwiftUI re-inits of the view struct; owns the frame-event
+    /// subscription so it is created once and cancelled on dismantle.
+    @MainActor
+    public final class Coordinator {
+        var handler: (@MainActor (UpdateEvent) -> Void)?
+        var subscription: EventSubscription?
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    private func connect(_ coordinator: Coordinator) {
+        coordinator.handler = updateHandler
+        guard coordinator.subscription == nil, updateHandler != nil, let renderer else { return }
+        coordinator.subscription = renderer.onUpdate { [weak coordinator] event in
+            // The MTKView delegate draws on the main thread; trap loudly if a
+            // future host ever drives this renderer off-main.
+            MainActor.assumeIsolated {
+                coordinator?.handler?(event)
+            }
+        }
+    }
+
     #if os(macOS)
-        public func makeNSView(context _: Context) -> MTKView {
-            mtkView
+        public func makeNSView(context: Context) -> MTKView {
+            connect(context.coordinator)
+            return mtkView
         }
 
         public func updateNSView(_: MTKView, context: Context) {
+            connect(context.coordinator)
             updateView(mtkView, context: context)
         }
+
+        public static func dismantleNSView(_: MTKView, coordinator: Coordinator) {
+            coordinator.subscription?.cancel()
+            coordinator.subscription = nil
+            coordinator.handler = nil
+        }
     #else
-        public func makeUIView(context _: Context) -> MTKView {
-            mtkView
+        public func makeUIView(context: Context) -> MTKView {
+            connect(context.coordinator)
+            return mtkView
         }
 
         public func updateUIView(_ mtkView: MTKView, context: Context) {
+            connect(context.coordinator)
             updateView(mtkView, context: context)
+        }
+
+        public static func dismantleUIView(_: MTKView, coordinator: Coordinator) {
+            coordinator.subscription?.cancel()
+            coordinator.subscription = nil
+            coordinator.handler = nil
         }
     #endif
 

--- a/Sources/UntoldEngine/Systems/FrameEvents.swift
+++ b/Sources/UntoldEngine/Systems/FrameEvents.swift
@@ -1,0 +1,81 @@
+//
+//  FrameEvents.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// Per-frame update event, delivered once per rendered frame regardless of `gameMode`.
+/// Mirrors RealityKit's `SceneEvents.Update`.
+public struct UpdateEvent {
+    /// Seconds elapsed since the previous frame.
+    public let deltaTime: TimeInterval
+    /// The renderer that produced this frame.
+    public let renderer: UntoldRenderer
+}
+
+/// Token returned by update subscriptions. Call `cancel()` to stop receiving events.
+/// RealityKit semantics: the subscription stays active if you discard the token;
+/// it is NOT auto-cancelled on deinit.
+public final class EventSubscription: @unchecked Sendable {
+    private let lock = NSLock()
+    private var onCancel: (() -> Void)?
+
+    init(onCancel: @escaping () -> Void) {
+        self.onCancel = onCancel
+    }
+
+    public func cancel() {
+        lock.lock()
+        let block = onCancel
+        onCancel = nil
+        lock.unlock()
+        block?()
+    }
+}
+
+/// Multicast registry for per-frame update handlers. Thread-safe: subscriptions can be
+/// created or cancelled from any thread while frames dispatch from the frame thread.
+final class FrameEventDispatcher: @unchecked Sendable {
+    private let lock = NSLock()
+    private var handlers: [UUID: (UpdateEvent) -> Void] = [:]
+
+    func subscribe(_ handler: @escaping (UpdateEvent) -> Void) -> EventSubscription {
+        let id = UUID()
+        lock.lock()
+        handlers[id] = handler
+        lock.unlock()
+        return EventSubscription { [weak self] in
+            self?.unsubscribe(id)
+        }
+    }
+
+    private func unsubscribe(_ id: UUID) {
+        lock.lock()
+        handlers.removeValue(forKey: id)
+        lock.unlock()
+    }
+
+    var hasSubscribers: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !handlers.isEmpty
+    }
+
+    func dispatch(_ event: UpdateEvent) {
+        // Snapshot under the lock, invoke outside it: handlers may subscribe or
+        // cancel reentrantly without deadlocking. A handler cancelled mid-dispatch
+        // may still receive the current frame's event.
+        lock.lock()
+        let snapshot = Array(handlers.values)
+        lock.unlock()
+        for handler in snapshot {
+            handler(event)
+        }
+    }
+}

--- a/Tests/UntoldEngineTests/FrameEventsTests.swift
+++ b/Tests/UntoldEngineTests/FrameEventsTests.swift
@@ -1,0 +1,94 @@
+//
+//  FrameEventsTests.swift
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+@testable import UntoldEngine
+import XCTest
+
+@MainActor
+final class FrameEventsTests: XCTestCase {
+    private func makeEvent(renderer: UntoldRenderer) -> UpdateEvent {
+        UpdateEvent(deltaTime: 1.0 / 60.0, renderer: renderer)
+    }
+
+    func testMulticastDispatchAndCancellation() {
+        let renderer = UntoldRenderer()
+        let dispatcher = FrameEventDispatcher()
+
+        XCTAssertFalse(dispatcher.hasSubscribers)
+
+        var firstCount = 0
+        var secondCount = 0
+        var lastDelta: TimeInterval = 0
+
+        let first = dispatcher.subscribe { event in
+            firstCount += 1
+            lastDelta = event.deltaTime
+        }
+        let second = dispatcher.subscribe { _ in
+            secondCount += 1
+        }
+
+        XCTAssertTrue(dispatcher.hasSubscribers)
+
+        dispatcher.dispatch(makeEvent(renderer: renderer))
+        XCTAssertEqual(firstCount, 1)
+        XCTAssertEqual(secondCount, 1)
+        XCTAssertEqual(lastDelta, 1.0 / 60.0, accuracy: 1e-9)
+
+        first.cancel()
+        first.cancel() // idempotent
+
+        dispatcher.dispatch(makeEvent(renderer: renderer))
+        XCTAssertEqual(firstCount, 1)
+        XCTAssertEqual(secondCount, 2)
+
+        second.cancel()
+        XCTAssertFalse(dispatcher.hasSubscribers)
+
+        dispatcher.dispatch(makeEvent(renderer: renderer))
+        XCTAssertEqual(secondCount, 2)
+    }
+
+    func testRendererOnUpdateSubscription() {
+        let renderer = UntoldRenderer()
+
+        var received: TimeInterval = -1
+        let token = renderer.onUpdate { event in
+            received = event.deltaTime
+        }
+
+        XCTAssertTrue(renderer.frameEvents.hasSubscribers)
+
+        renderer.frameEvents.dispatch(makeEvent(renderer: renderer))
+        XCTAssertEqual(received, 1.0 / 60.0, accuracy: 1e-9)
+
+        token.cancel()
+        XCTAssertFalse(renderer.frameEvents.hasSubscribers)
+    }
+
+    func testCancellationDuringDispatchIsSafe() {
+        let renderer = UntoldRenderer()
+        let dispatcher = FrameEventDispatcher()
+
+        var token: EventSubscription?
+        var count = 0
+        token = dispatcher.subscribe { _ in
+            count += 1
+            token?.cancel() // reentrant cancel while dispatching
+        }
+
+        dispatcher.dispatch(makeEvent(renderer: renderer))
+        XCTAssertEqual(count, 1)
+        XCTAssertFalse(dispatcher.hasSubscribers)
+
+        dispatcher.dispatch(makeEvent(renderer: renderer))
+        XCTAssertEqual(count, 1)
+    }
+}


### PR DESCRIPTION
Adds a RealityKit `SceneEvents.Update`-style per-frame callback to the SwiftUI scene API. Until now `UntoldView` only rendered — demos drove game logic with a SwiftUI `Timer`, which is choppy and not frame-rate independent.

## API

```swift
UntoldView(renderer: renderer) {
    MeshNode(resource: "redplayer.usdz", entityID: rootID)
}
.onUpdate { event in
    spin.yawDegrees += Float(event.deltaTime) * 45   // deg/sec, frame-rate independent
    rotateTo(entityId: rootID, pitch: 0, yaw: spin.yawDegrees, roll: 0)
}
```

Programmatic hosts (AppKit/XR/AR) can subscribe directly:

```swift
let token = renderer.onUpdate { event in ... }
token.cancel()
```

## Design

- **`UpdateEvent`** carries `deltaTime: TimeInterval` and the renderer; **`EventSubscription`** token with idempotent `cancel()` (RealityKit semantics: discarding the token does not auto-cancel).
- **`FrameEventDispatcher`**: thread-safe multicast (NSLock, snapshot-then-invoke), following the `SystemEventBus` pattern.
- Dispatch happens once per frame in `runFrame` after simulation and before rendering, **outside the `gameMode` gate** (matching RealityKit, where update events always fire). All three frame paths (MTKView, XR compositor, AR) inherit it since they funnel through `runFrame`.
- The existing single-slot `setupCallbacks(gameUpdate:handleInput:)` path is untouched, so view-level subscriptions and app-level game updates coexist.
- `SceneView` gains a `Coordinator` that owns the subscription across SwiftUI re-inits: subscribe on make, refresh the handler on update, cancel on dismantle. Events are delivered on the MainActor (`assumeIsolated` traps loudly if a future host drives the view off-main).

## Testing

- New `FrameEventsTests`: multicast dispatch, token cancellation (including double-cancel and reentrant cancel-during-dispatch) — 3/3 pass.
- `swift build` clean; `UntoldEngineTests` suite passes.
- Demo app sources typecheck against the modified engine.