### PR TITLE
[Feature] Add simulator fallback for the TBDR deferred renderer

### DIFF
--- a/Sources/UntoldEngine/Renderer/ColorPipelineConfig.swift
+++ b/Sources/UntoldEngine/Renderer/ColorPipelineConfig.swift
@@ -36,6 +36,30 @@ public struct WorkingColorFormats: Sendable {
     public var gizmo: MTLPixelFormat
     public var ibl: MTLPixelFormat
 
+    #if targetEnvironment(simulator)
+    // The simulator caps combined render-target storage at 32 bytes/pixel/sample.
+    // The TBDR deferred pass keeps all 6 attachments (G-buffer 0-4 + sceneColor)
+    // live in tile memory, so the device set (44 bytes) exceeds the cap. This set
+    // totals exactly 32: albedo 4 + normal 4 (snorm keeps sign, shaders read
+    // half4 unchanged) + position 8 + material 4 + emissive 4 (unorm clamps HDR
+    // emissive — simulator-only quality loss; rg11b10Float is charged 8 bytes by
+    // the simulator's validator) + sceneColor 8.
+    public static let standard = WorkingColorFormats(
+        gBufferAlbedo: .rgba8Unorm,
+        gBufferNormal: .rgba8Snorm,
+        gBufferPosition: .rgba16Float,
+        gBufferMaterial: .rgba8Unorm,
+        gBufferEmissive: .rgba8Unorm,
+        sceneColor: .rgba16Float,
+        postProcess: .rgba16Float,
+        sceneComposite: .rgba16Float,
+        lookOutput: .rgba16Float,
+        environment: .rgba16Float,
+        gaussian: .rgba16Float,
+        gizmo: .rgba16Float,
+        ibl: .rgba16Float
+    )
+    #else
     public static let standard = WorkingColorFormats(
         gBufferAlbedo: .rgba16Float,
         gBufferNormal: .rgba16Float,
@@ -51,6 +75,7 @@ public struct WorkingColorFormats: Sendable {
         gizmo: .rgba16Float,
         ibl: .rgba16Float
     )
+    #endif
 }
 
 public struct PresentOutputConfig: Sendable {

--- a/Sources/UntoldEngine/Renderer/Pipelines/RenderPipeLines.swift
+++ b/Sources/UntoldEngine/Renderer/Pipelines/RenderPipeLines.swift
@@ -170,6 +170,12 @@ public func CreateTilePipeline(
     colorFormats: [MTLPixelFormat],
     name: String
 ) -> RenderPipeline? {
+    #if targetEnvironment(simulator)
+    // Tile shaders are unsupported in the simulator; creating the pipeline state
+    // raises a hard assertion (not a catchable error), so bail out before that.
+    Logger.log(message: "Skipping tile pipeline '\(name)': tile shaders are not supported in the simulator")
+    return nil
+    #else
     let pipelineDescriptor = MTLTileRenderPipelineDescriptor()
 
     guard let tileLibrary = resolveRenderShaderLibrary(
@@ -210,6 +216,7 @@ public func CreateTilePipeline(
         handleError(.pipelineStateCreationFailed, name)
         return nil
     }
+    #endif
 }
 
 public typealias RenderPipelineInitBlock = () -> RenderPipeline?
@@ -320,7 +327,25 @@ public func InitModelPipeline() -> RenderPipeline? {
 /// (framebuffer fetch) and writes the lit result to attachment 5 (deferredColorMap).
 /// Attachments 0-4 carry G-buffer data; their writeMask is disabled so the light
 /// quad does not overwrite geometry output that is still live in tile memory.
+///
+/// Simulator: framebuffer fetch is unsupported ("reading from a rendertarget is
+/// not supported"), so the light pass instead samples the stored G-buffer
+/// textures with the texture-based fragmentLightShader in its own encoder
+/// (deferredRenderPassDescriptor). See combinedModelLightExecution.
 public func InitLightPipeline() -> RenderPipeline? {
+    #if targetEnvironment(simulator)
+    return CreatePipeline(
+        vertexShader: "vertexLightShader",
+        fragmentShader: "fragmentLightShader",
+        vertexDescriptor: createLightVertexDescriptor(),
+        colorFormats: [wf.sceneColor],
+        depthFormat: renderInfo.depthPixelFormat,
+        depthCompareFunction: .always,
+        depthEnabled: false,
+        reverseZCompatible: false,
+        name: "Light Pipeline (Simulator)"
+    )
+    #else
     guard let library = renderInfo.library else {
         handleError(.metalLibraryNotFound)
         return nil
@@ -370,9 +395,10 @@ public func InitLightPipeline() -> RenderPipeline? {
             rasterSampleCount: desc.rasterSampleCount
         )
     } catch {
-        handleError(.pipelineStateCreationFailed, "Light Pipeline (TBDR)")
+        handleError(.pipelineStateCreationFailed, "Light Pipeline (TBDR): \(error.localizedDescription)")
         return nil
     }
+    #endif
 }
 
 // MARK: Geometry pipeline

--- a/Sources/UntoldEngine/Renderer/RenderInitializer.swift
+++ b/Sources/UntoldEngine/Renderer/RenderInitializer.swift
@@ -112,6 +112,11 @@ func createTexture(
 
 @inline(__always)
 func requestedOpaqueSampleCount() -> Int {
+    #if targetEnvironment(simulator)
+    // The simulator's two-pass deferred fallback samples the G-buffer as
+    // texture2d, which is incompatible with multisampled (memoryless) targets.
+    return 1
+    #else
     switch antiAliasingMode {
     case .msaa:
         let preferredSampleCount = 4
@@ -120,6 +125,7 @@ func requestedOpaqueSampleCount() -> Int {
     case .none, .fxaa, .smaa:
         return 1
     }
+    #endif
 }
 
 @inline(__always)
@@ -446,8 +452,13 @@ func initRenderPassDescriptors() {
     // Combined G-buffer + lighting render pass (TBDR).
     // Attachments 0-4 are normally memoryless G-buffer slots and are discarded at
     // the end. G-buffer debug views switch them to stored textures so the later
-    // debug pass can sample them.
+    // debug pass can sample them; the simulator always stores them for its
+    // texture-based light pass.
+    #if targetEnvironment(simulator)
+    let gBufferStoreAction: MTLStoreAction = .store
+    #else
     let gBufferStoreAction: MTLStoreAction = renderInfo.gBufferDebugStorageEnabled ? .store : .dontCare
+    #endif
     renderInfo.offscreenRenderPassDescriptor = createRenderPassDescriptor(
         width: Int(renderInfo.viewPort.x),
         height: Int(renderInfo.viewPort.y),
@@ -571,12 +582,19 @@ func initGBufferTextureResources() {
     let viewportHeight = max(1, Int(renderInfo.viewPort.y))
     let opaqueSampleCount = max(1, renderInfo.opaqueSampleCount)
 
-    // G-buffer textures: memoryless in normal rendering; persistent only when
-    // a debug view needs to sample the G-buffer after the TBDR pass.
-    let gBufferUsage: MTLTextureUsage = renderInfo.gBufferDebugStorageEnabled
+    // G-buffer textures: memoryless in normal rendering; persistent when a debug
+    // view needs to sample the G-buffer after the TBDR pass, and always in the
+    // simulator, where the light pass samples the G-buffer as textures because
+    // framebuffer fetch is unsupported there.
+    #if targetEnvironment(simulator)
+    let gBufferNeedsStorage = true
+    #else
+    let gBufferNeedsStorage = renderInfo.gBufferDebugStorageEnabled
+    #endif
+    let gBufferUsage: MTLTextureUsage = gBufferNeedsStorage
         ? [.renderTarget, .shaderRead]
         : [.renderTarget]
-    let gBufferStorageMode: MTLStorageMode = renderInfo.gBufferDebugStorageEnabled
+    let gBufferStorageMode: MTLStorageMode = gBufferNeedsStorage
         ? .private
         : .memoryless
 

--- a/Sources/UntoldEngine/Renderer/RenderPasses.swift
+++ b/Sources/UntoldEngine/Renderer/RenderPasses.swift
@@ -2159,7 +2159,13 @@ public enum RenderPasses {
 
         // G-buffer slots (0-4): cleared at start, normally discarded at end.
         // Lit output (5): cleared at start, stored for downstream passes.
+        // The simulator always stores the G-buffer: its light pass samples it as
+        // textures because framebuffer fetch is unsupported there.
+        #if targetEnvironment(simulator)
+        let gBufferStoreAction: MTLStoreAction = .store
+        #else
         let gBufferStoreAction: MTLStoreAction = renderInfo.gBufferDebugStorageEnabled ? .store : .dontCare
+        #endif
         for i in 0 ..< 5 {
             encoderDescriptor.colorAttachments[i].loadAction = .clear
             encoderDescriptor.colorAttachments[i].storeAction = gBufferStoreAction
@@ -2175,11 +2181,8 @@ public enum RenderPasses {
             return
         }
 
-        defer {
-            renderEncoder.popDebugGroup()
-            renderEncoder.endEncoding()
-        }
-
+        // No defer here: the simulator path ends this encoder mid-function and
+        // continues in a second one, so both paths end their encoders explicitly.
         renderEncoder.label = "G-Buffer + Light Pass (TBDR)"
         renderEncoder.pushDebugGroup("G-Buffer + Light Pass (TBDR)")
 
@@ -2393,42 +2396,87 @@ public enum RenderPasses {
         }
 
         // ── Sub-pass 2: Lighting quad ────────────────────────────────────────────
-        // Reads G-buffer from tile memory via [[color(N)]] framebuffer fetch.
-        // No G-buffer textures are bound — they come from attachments 0-4 in tile memory.
-        renderEncoder.setRenderPipelineState(lightPipeline.pipelineState!)
+        // Device: reads G-buffer from tile memory via [[color(N)]] framebuffer fetch
+        // in the same encoder — no G-buffer textures are bound.
+        // Simulator: framebuffer fetch is unsupported, so end the G-buffer encoder
+        // (attachments were stored) and light in a second encoder that samples the
+        // G-buffer textures with the texture-based fragmentLightShader.
+        #if targetEnvironment(simulator)
+        renderEncoder.updateFence(renderInfo.fence, after: .fragment)
+        renderEncoder.popDebugGroup()
+        renderEncoder.endEncoding()
+
+        guard let lightPassDescriptor = renderInfo.deferredRenderPassDescriptor else {
+            handleError(.renderPassCreationFailed, "Deferred render pass descriptor not initialized")
+            return
+        }
+        // deferredColorMap was cleared by the G-buffer pass (attachment 5); the
+        // fullscreen quad overwrites every pixel. Preserve opaque depth for
+        // transparency and post-process consumers.
+        lightPassDescriptor.colorAttachments[0].loadAction = .load
+        lightPassDescriptor.colorAttachments[0].storeAction = .store
+        lightPassDescriptor.depthAttachment.loadAction = .load
+        lightPassDescriptor.depthAttachment.storeAction = .store
+
+        guard let lightEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: lightPassDescriptor) else {
+            handleError(.renderPassCreationFailed, "Light Pass (Simulator)")
+            return
+        }
+        lightEncoder.label = "Light Pass (Simulator)"
+        lightEncoder.pushDebugGroup("Light Pass (Simulator)")
+        lightEncoder.waitForFence(renderInfo.fence, before: .fragment)
+
+        // G-buffer textures (stored by the previous encoder).
+        lightEncoder.setFragmentTexture(textureResources.colorMap, index: Int(lightPassAlbedoTextureIndex.rawValue))
+        lightEncoder.setFragmentTexture(textureResources.normalMap, index: Int(lightPassNormalTextureIndex.rawValue))
+        lightEncoder.setFragmentTexture(textureResources.positionMap, index: Int(lightPassPositionTextureIndex.rawValue))
+        lightEncoder.setFragmentTexture(textureResources.materialMap, index: Int(lightPassMaterialTextureIndex.rawValue))
+
+        // SSAO runs after this pass in the graph (same as the TBDR path, where
+        // ambient occlusion is fixed at 1.0), so disable it here too.
+        lightEncoder.setFragmentTexture(textureResources.ssaoBlurTexture, index: Int(lightPassSSAOTextureIndex.rawValue))
+        var ssaoEnabledForLightPass = false
+        lightEncoder.setFragmentBytes(&ssaoEnabledForLightPass, length: MemoryLayout<Bool>.size, index: Int(lightPassSSAOEnabledIndex.rawValue))
+
+        let lightQuadEncoder: MTLRenderCommandEncoder = lightEncoder
+        #else
+        let lightQuadEncoder: MTLRenderCommandEncoder = renderEncoder
+        #endif
+
+        lightQuadEncoder.setRenderPipelineState(lightPipeline.pipelineState!)
         if let depthState = lightPipeline.depthState {
-            renderEncoder.setDepthStencilState(depthState)
+            lightQuadEncoder.setDepthStencilState(depthState)
         }
 
-        renderEncoder.setVertexBuffer(bufferResources.quadVerticesBuffer, offset: 0, index: 0)
-        renderEncoder.setVertexBuffer(bufferResources.quadTexCoordsBuffer, offset: 0, index: 1)
+        lightQuadEncoder.setVertexBuffer(bufferResources.quadVerticesBuffer, offset: 0, index: 0)
+        lightQuadEncoder.setVertexBuffer(bufferResources.quadTexCoordsBuffer, offset: 0, index: 1)
 
         var effectiveCamPos = SceneRootTransform.shared.effectiveCameraPosition(cameraComponent.localPosition)
-        renderEncoder.setFragmentBytes(&effectiveCamPos, length: MemoryLayout<simd_float3>.stride, index: Int(lightPassCameraPositionIndex.rawValue))
+        lightQuadEncoder.setFragmentBytes(&effectiveCamPos, length: MemoryLayout<simd_float3>.stride, index: Int(lightPassCameraPositionIndex.rawValue))
 
         var csmUniforms = shadowSystem.makeUniforms()
         csmUniforms.cameraViewMatrix = viewMatrix
         csmUniforms.lightSpaceMatrices.0 = SceneRootTransform.shared.effectiveLightMatrix(csmUniforms.lightSpaceMatrices.0)
         csmUniforms.lightSpaceMatrices.1 = SceneRootTransform.shared.effectiveLightMatrix(csmUniforms.lightSpaceMatrices.1)
         csmUniforms.lightSpaceMatrices.2 = SceneRootTransform.shared.effectiveLightMatrix(csmUniforms.lightSpaceMatrices.2)
-        renderEncoder.setFragmentBytes(&csmUniforms, length: MemoryLayout<CSMUniforms>.stride, index: Int(lightPassLightOrthoViewMatrixIndex.rawValue))
+        lightQuadEncoder.setFragmentBytes(&csmUniforms, length: MemoryLayout<CSMUniforms>.stride, index: Int(lightPassLightOrthoViewMatrixIndex.rawValue))
 
-        renderEncoder.setFragmentTexture(textureResources.csmShadowMap, index: Int(lightPassShadowTextureIndex.rawValue))
-        renderEncoder.setFragmentTexture(textureResources.pointShadowCubeMap, index: Int(lightPassPointShadowTextureIndex.rawValue))
+        lightQuadEncoder.setFragmentTexture(textureResources.csmShadowMap, index: Int(lightPassShadowTextureIndex.rawValue))
+        lightQuadEncoder.setFragmentTexture(textureResources.pointShadowCubeMap, index: Int(lightPassPointShadowTextureIndex.rawValue))
         var pointShadowUniforms = pointShadowState.makeUniforms()
-        renderEncoder.setFragmentBytes(&pointShadowUniforms, length: MemoryLayout<PointShadowUniforms>.stride, index: Int(lightPassPointShadowUniformIndex.rawValue))
-        renderEncoder.setFragmentTexture(textureResources.spotShadowMap, index: Int(lightPassSpotShadowTextureIndex.rawValue))
+        lightQuadEncoder.setFragmentBytes(&pointShadowUniforms, length: MemoryLayout<PointShadowUniforms>.stride, index: Int(lightPassPointShadowUniformIndex.rawValue))
+        lightQuadEncoder.setFragmentTexture(textureResources.spotShadowMap, index: Int(lightPassSpotShadowTextureIndex.rawValue))
         var spotShadowUniforms = spotShadowState.makeUniforms()
-        renderEncoder.setFragmentBytes(&spotShadowUniforms, length: MemoryLayout<SpotShadowUniforms>.stride, index: Int(lightPassSpotShadowUniformIndex.rawValue))
+        lightQuadEncoder.setFragmentBytes(&spotShadowUniforms, length: MemoryLayout<SpotShadowUniforms>.stride, index: Int(lightPassSpotShadowUniformIndex.rawValue))
         let environmentLighting = resolveCurrentEnvironmentLighting()
-        renderEncoder.setFragmentTexture(environmentLighting.irradianceMap, index: Int(lightPassIBLIrradianceTextureIndex.rawValue))
-        renderEncoder.setFragmentTexture(environmentLighting.specularMap, index: Int(lightPassIBLSpecularTextureIndex.rawValue))
-        renderEncoder.setFragmentTexture(environmentLighting.brdfMap, index: Int(lightPassIBLBRDFMapTextureIndex.rawValue))
-        renderEncoder.setFragmentTexture(textureResources.areaTextureLTCMag, index: Int(lightPassAreaLTCMagTextureIndex.rawValue))
-        renderEncoder.setFragmentTexture(textureResources.areaTextureLTCMat, index: Int(lightPassAreaLTCMatTextureIndex.rawValue))
+        lightQuadEncoder.setFragmentTexture(environmentLighting.irradianceMap, index: Int(lightPassIBLIrradianceTextureIndex.rawValue))
+        lightQuadEncoder.setFragmentTexture(environmentLighting.specularMap, index: Int(lightPassIBLSpecularTextureIndex.rawValue))
+        lightQuadEncoder.setFragmentTexture(environmentLighting.brdfMap, index: Int(lightPassIBLBRDFMapTextureIndex.rawValue))
+        lightQuadEncoder.setFragmentTexture(textureResources.areaTextureLTCMag, index: Int(lightPassAreaLTCMagTextureIndex.rawValue))
+        lightQuadEncoder.setFragmentTexture(textureResources.areaTextureLTCMat, index: Int(lightPassAreaLTCMatTextureIndex.rawValue))
 
         var lightParams = getDirectionalLightParameters()
-        renderEncoder.setFragmentBytes(&lightParams, length: MemoryLayout<LightParameters>.stride, index: Int(lightPassLightParamsIndex.rawValue))
+        lightQuadEncoder.setFragmentBytes(&lightParams, length: MemoryLayout<LightParameters>.stride, index: Int(lightPassLightParamsIndex.rawValue))
 
         let headerSize = 16
         _ = uploadAndBindLights(
@@ -2436,7 +2484,7 @@ public enum RenderPasses {
             lights: getPointLights(),
             maxCount: 1024,
             headerSize: headerSize,
-            encoder: renderEncoder,
+            encoder: lightQuadEncoder,
             bufferIndex: Int(lightPassPointLightsIndex.rawValue),
             labelForErrors: "Point Lights"
         )
@@ -2445,7 +2493,7 @@ public enum RenderPasses {
             lights: getSpotLights(),
             maxCount: 1024,
             headerSize: headerSize,
-            encoder: renderEncoder,
+            encoder: lightQuadEncoder,
             bufferIndex: Int(lightPassSpotLightsIndex.rawValue),
             labelForErrors: "Spot Lights"
         )
@@ -2454,7 +2502,7 @@ public enum RenderPasses {
             lights: getAreaLights(),
             maxCount: 1024,
             headerSize: headerSize,
-            encoder: renderEncoder,
+            encoder: lightQuadEncoder,
             bufferIndex: Int(lightPassAreaLightsIndex.rawValue),
             labelForErrors: "Area Lights"
         )
@@ -2462,15 +2510,15 @@ public enum RenderPasses {
         var brdfParameters = IBLParamsUniform()
         brdfParameters.applyIBL = environmentLighting.applyIBL
         brdfParameters.ambientIntensity = environmentLighting.ambientIntensity
-        renderEncoder.setFragmentBytes(&brdfParameters, length: MemoryLayout<IBLParamsUniform>.stride, index: Int(lightPassIBLParamIndex.rawValue))
+        lightQuadEncoder.setFragmentBytes(&brdfParameters, length: MemoryLayout<IBLParamsUniform>.stride, index: Int(lightPassIBLParamIndex.rawValue))
 
         var lightPassRotationAngle = envRotationAngle
-        renderEncoder.setFragmentBytes(&lightPassRotationAngle, length: MemoryLayout<Float>.stride, index: Int(lightPassIBLRotationAngleIndex.rawValue))
+        lightQuadEncoder.setFragmentBytes(&lightPassRotationAngle, length: MemoryLayout<Float>.stride, index: Int(lightPassIBLRotationAngleIndex.rawValue))
 
         var isGameMode = gameMode
-        renderEncoder.setFragmentBytes(&isGameMode, length: MemoryLayout<Bool>.size, index: Int(lightPassGameModeIndex.rawValue))
+        lightQuadEncoder.setFragmentBytes(&isGameMode, length: MemoryLayout<Bool>.size, index: Int(lightPassGameModeIndex.rawValue))
 
-        renderEncoder.drawIndexedPrimitivesTracked(
+        lightQuadEncoder.drawIndexedPrimitivesTracked(
             type: .triangle,
             indexCount: 6,
             indexType: .uint16,
@@ -2478,7 +2526,11 @@ public enum RenderPasses {
             indexBufferOffset: 0
         )
 
-        renderEncoder.updateFence(renderInfo.fence, after: .fragment)
+        lightQuadEncoder.updateFence(renderInfo.fence, after: .fragment)
+        // Ends the shared TBDR encoder on device, the standalone light encoder
+        // in the simulator (its G-buffer encoder was ended above).
+        lightQuadEncoder.popDebugGroup()
+        lightQuadEncoder.endEncoding()
     }
 
     static let ssaoExecution: RenderPassExecution = { commandBuffer in
@@ -4470,6 +4522,12 @@ public enum RenderPasses {
     }
 
     public static let gaussianExecution: RenderPassExecution = { commandBuffer in
+        #if targetEnvironment(simulator)
+        // Gaussian splatting needs tile shaders, which the simulator doesn't
+        // support — the pipelines were never created, so skip quietly.
+        _ = commandBuffer
+        return
+        #else
         let profileStart = gaussianProfilingStartTime()
         var profileTotals = GaussianProfileTotals()
         var activeSplatTotal = 0
@@ -4675,6 +4733,7 @@ public enum RenderPasses {
             totals: profileTotals,
             extra: String(format: "activeSplats=%d viewport=%.0fx%.0f tile=32x32", activeSplatTotal, renderInfo.viewPort.x, renderInfo.viewPort.y)
         )
+        #endif
     }
 
     static func executePostProcess(

--- a/Sources/UntoldEngine/Renderer/RenderPasses.swift
+++ b/Sources/UntoldEngine/Renderer/RenderPasses.swift
@@ -2181,8 +2181,19 @@ public enum RenderPasses {
             return
         }
 
-        // No defer here: the simulator path ends this encoder mid-function and
-        // continues in a second one, so both paths end their encoders explicitly.
+        // Both paths end this encoder explicitly (the simulator path ends it
+        // mid-function and continues in a second one), so the defer is a
+        // safety net only: it fires solely if a future early return leaves
+        // the encoder open. Note the device path's final close is this same
+        // encoder via lightQuadEncoder, so the flag must be set there too.
+        var combinedEncoderClosed = false
+        defer {
+            if !combinedEncoderClosed {
+                renderEncoder.popDebugGroup()
+                renderEncoder.endEncoding()
+            }
+        }
+
         renderEncoder.label = "G-Buffer + Light Pass (TBDR)"
         renderEncoder.pushDebugGroup("G-Buffer + Light Pass (TBDR)")
 
@@ -2405,6 +2416,7 @@ public enum RenderPasses {
         renderEncoder.updateFence(renderInfo.fence, after: .fragment)
         renderEncoder.popDebugGroup()
         renderEncoder.endEncoding()
+        combinedEncoderClosed = true
 
         guard let lightPassDescriptor = renderInfo.deferredRenderPassDescriptor else {
             handleError(.renderPassCreationFailed, "Deferred render pass descriptor not initialized")
@@ -2531,6 +2543,9 @@ public enum RenderPasses {
         // in the simulator (its G-buffer encoder was ended above).
         lightQuadEncoder.popDebugGroup()
         lightQuadEncoder.endEncoding()
+        // On device lightQuadEncoder is renderEncoder itself — this close is
+        // the one the safety-net defer is watching.
+        combinedEncoderClosed = true
     }
 
     static let ssaoExecution: RenderPassExecution = { commandBuffer in


### PR DESCRIPTION
## Summary

Any app using the engine crashed at renderer init in the visionOS/iOS simulator with a Metal validation assertion ("This set of render targets requires 44 bytes of pixel storage. This device supports 32 bytes."). The simulator cannot run the single-pass TBDR deferred renderer at all:

- Render targets are capped at 32 bytes/pixel/sample (the 6-attachment G-buffer set needs 44; `rg11b10Float` is charged 8 bytes by its validator).
- Framebuffer fetch (`[[color(N)]]` reads) is rejected at pipeline creation ("reading from a rendertarget is not supported").
- Tile shaders raise an uncatchable assertion when the pipeline state is created.

## Changes (all behind `#if targetEnvironment(simulator)`, device rendering unchanged)

- **ColorPipelineConfig**: simulator G-buffer formats fit exactly 32 bytes — albedo/material/emissive `rgba8Unorm`, normal `rgba8Snorm`, position and sceneColor stay `rgba16Float`. Emissive clamps to [0,1] on simulator only.
- **RenderPipeLines**: the light pipeline falls back to the texture-based `fragmentLightShader`; `CreateTilePipeline` skips with a log instead of asserting; the TBDR light pipeline failure now logs the underlying Metal error.
- **RenderInitializer**: G-buffer textures are stored (`.private` + shaderRead) instead of memoryless; opaque sample count is forced to 1 (the fallback samples the G-buffer as `texture2d`, incompatible with multisampled memoryless targets).
- **RenderPasses**: `combinedModelLightExecution` splits into two encoders on simulator — G-buffer pass stores its attachments, then a separate light pass via `deferredRenderPassDescriptor` (SSAO disabled, matching the TBDR path). `gaussianExecution` no-ops quietly.

## Testing

- Verified on the visionOS 26.5 simulator with Metal API validation enabled: renderer init succeeds, immersive XR session renders continuously with no assertions or per-frame errors.
- `swift build` (macOS) passes, confirming the device code path still compiles.