### PR TITLE
Scene builder DSL: primitive, light, and camera nodes + TBDR emissive fix

### DIFF
--- a/Sources/UntoldEngine/Scenes/Builder/CameraNode.swift
+++ b/Sources/UntoldEngine/Scenes/Builder/CameraNode.swift
@@ -1,0 +1,27 @@
+//
+//  CameraNode.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import simd
+
+/// Declares the scene camera. By default it wraps the renderer's game camera,
+/// so declaring `CameraNode()` positions the existing active camera.
+@MainActor
+public final class CameraNode: Node {
+    public init(entityID: EntityID? = nil, name: String? = nil) {
+        super.init(entityID: entityID ?? findGameCamera(), name: name) {}
+    }
+
+    @discardableResult
+    public func lookAt(eye: simd_float3, target: simd_float3 = .zero, up: simd_float3 = simd_float3(0, 1, 0)) -> Self {
+        cameraLookAt(entityId: entityID, eye: eye, target: target, up: up)
+        return self
+    }
+}

--- a/Sources/UntoldEngine/Scenes/Builder/CameraNode.swift
+++ b/Sources/UntoldEngine/Scenes/Builder/CameraNode.swift
@@ -17,6 +17,13 @@ import simd
 public final class CameraNode: Node {
     public init(entityID: EntityID? = nil, name: String? = nil) {
         super.init(entityID: entityID ?? findGameCamera(), name: name) {}
+
+        // An explicitly passed entity may not be a camera yet. Promote it,
+        // matching the light nodes, which create their component when missing.
+        if !hasComponent(entityId: self.entityID, componentType: CameraComponent.self) {
+            createGameCamera(entityId: self.entityID)
+            if let n = name { setEntityName(entityId: self.entityID, name: n) }
+        }
     }
 
     @discardableResult

--- a/Sources/UntoldEngine/Scenes/Builder/LightNodes.swift
+++ b/Sources/UntoldEngine/Scenes/Builder/LightNodes.swift
@@ -1,0 +1,93 @@
+//
+//  LightNodes.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import simd
+
+@MainActor
+public protocol NodeLight: NodeProtocol {}
+
+@MainActor
+public extension NodeLight {
+    func color(_ red: Float, _ green: Float, _ blue: Float) -> Self {
+        setLight(entityId: entityID, .color(simd_float3(red, green, blue)))
+        return self
+    }
+
+    func intensity(_ value: Float) -> Self {
+        setLight(entityId: entityID, .intensity(value))
+        return self
+    }
+}
+
+/// Declares a directional (sun) light. Declaring one makes it the scene's
+/// active directional light, replacing the renderer's default.
+@MainActor
+public final class DirectionalLightNode: Node, NodeLight {
+    public init(entityID: EntityID? = nil, name: String? = nil) {
+        super.init(entityID: entityID, name: name) {}
+
+        if name == nil { setEntityName(entityId: self.entityID, name: "Directional Light") }
+        if !hasComponent(entityId: self.entityID, componentType: DirectionalLightComponent.self) {
+            createDirLight(entityId: self.entityID)
+        }
+        setLight(entityId: self.entityID, .directional(.active))
+    }
+}
+
+@MainActor
+public final class PointLightNode: Node, NodeLight {
+    public init(entityID: EntityID? = nil, name: String? = nil) {
+        super.init(entityID: entityID, name: name) {}
+
+        if name == nil { setEntityName(entityId: self.entityID, name: "Point Light") }
+        if !hasComponent(entityId: self.entityID, componentType: PointLightComponent.self) {
+            createPointLight(entityId: self.entityID)
+        }
+    }
+
+    public func radius(_ value: Float) -> Self {
+        setLight(entityId: entityID, .point(.radius(value)))
+        return self
+    }
+
+    public func falloff(_ value: Float) -> Self {
+        setLight(entityId: entityID, .point(.falloff(value)))
+        return self
+    }
+
+    /// Distance attenuation: 1 / (constant + linear·d + quadratic·d²)
+    public func attenuation(constant: Float = 1, linear: Float = 0, quadratic: Float = 0) -> Self {
+        setLight(entityId: entityID, .point(.attenuation(simd_float3(constant, linear, quadratic))))
+        return self
+    }
+}
+
+@MainActor
+public final class SpotLightNode: Node, NodeLight {
+    public init(entityID: EntityID? = nil, name: String? = nil) {
+        super.init(entityID: entityID, name: name) {}
+
+        if name == nil { setEntityName(entityId: self.entityID, name: "Spot Light") }
+        if !hasComponent(entityId: self.entityID, componentType: SpotLightComponent.self) {
+            createSpotLight(entityId: self.entityID)
+        }
+    }
+
+    public func coneAngle(_ value: Float) -> Self {
+        setLight(entityId: entityID, .spot(.coneAngle(value)))
+        return self
+    }
+
+    public func radius(_ value: Float) -> Self {
+        setLight(entityId: entityID, .spot(.radius(value)))
+        return self
+    }
+}

--- a/Sources/UntoldEngine/Scenes/Builder/MeshNode.swift
+++ b/Sources/UntoldEngine/Scenes/Builder/MeshNode.swift
@@ -13,7 +13,7 @@ import simd
 import SwiftUI
 
 @MainActor
-public class MeshNode: Node, NodeAnimations, NodeKinetics {
+public class MeshNode: Node, NodeAnimations, NodeKinetics, NodeMaterial {
     public convenience init(resource: String, entityID: EntityID? = nil, name: String? = nil) {
         self.init(resource: resource, entityID: entityID, name: name) {}
     }
@@ -24,34 +24,5 @@ public class MeshNode: Node, NodeAnimations, NodeKinetics {
         if name == nil { setEntityName(entityId: self.entityID, name: resource) }
 
         setEntityMeshAsync(entityId: self.entityID, filename: resource.filename, withExtension: resource.extensionName)
-    }
-
-    public func materialData(
-        roughness: Float = 0,
-        metallic: Float = 0,
-        emissive: (Float, Float, Float) = (0, 0, 0),
-        baseColor: (Float, Float, Float, Float) = (0, 0, 0, 0),
-        baseColorResource: String? = nil,
-        roughnessResource: String? = nil,
-        metallicResource: String? = nil,
-        normalResource: String? = nil
-    ) -> Self {
-        updateMaterialColor(entityId: entityID, color: colorFromSimd(simd_float4(baseColor.0, baseColor.1, baseColor.2, baseColor.3)))
-        updateMaterialRoughness(entityId: entityID, roughness: roughness)
-        updateMaterialMetallic(entityId: entityID, metallic: metallic)
-        updateMaterialEmmisive(entityId: entityID, emmissive: simd_float3(emissive.0, emissive.1, emissive.2))
-
-        func updateMaterialResource(_ resource: String?, _ type: TextureType) {
-            if let r = resource, let url = LoadingSystem.shared.resourceURL(forResource: r.filename, withExtension: r.extensionName) {
-                updateMaterialTexture(entityId: entityID, textureType: type, path: url)
-            }
-        }
-
-        updateMaterialResource(baseColorResource, .baseColor)
-        updateMaterialResource(roughnessResource, .roughness)
-        updateMaterialResource(metallicResource, .metallic)
-        updateMaterialResource(normalResource, .normal)
-
-        return self
     }
 }

--- a/Sources/UntoldEngine/Scenes/Builder/NodeCore/Node+Material.swift
+++ b/Sources/UntoldEngine/Scenes/Builder/NodeCore/Node+Material.swift
@@ -1,0 +1,68 @@
+//
+//  Node+Material.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import simd
+import SwiftUI
+
+@MainActor
+public protocol NodeMaterial: NodeProtocol {}
+
+@MainActor
+public extension NodeMaterial {
+    func materialData(
+        roughness: Float = 0,
+        metallic: Float = 0,
+        emissive: (Float, Float, Float) = (0, 0, 0),
+        baseColor: (Float, Float, Float, Float) = (0, 0, 0, 0),
+        baseColorResource: String? = nil,
+        roughnessResource: String? = nil,
+        metallicResource: String? = nil,
+        normalResource: String? = nil
+    ) -> Self {
+        updateMaterialColor(entityId: entityID, color: colorFromSimd(simd_float4(baseColor.0, baseColor.1, baseColor.2, baseColor.3)))
+        updateMaterialRoughness(entityId: entityID, roughness: roughness)
+        updateMaterialMetallic(entityId: entityID, metallic: metallic)
+        updateMaterialEmmisive(entityId: entityID, emmissive: simd_float3(emissive.0, emissive.1, emissive.2))
+
+        func updateMaterialResource(_ resource: String?, _ type: TextureType) {
+            if let r = resource, let url = LoadingSystem.shared.resourceURL(forResource: r.filename, withExtension: r.extensionName) {
+                updateMaterialTexture(entityId: entityID, textureType: type, path: url)
+            }
+        }
+
+        updateMaterialResource(baseColorResource, .baseColor)
+        updateMaterialResource(roughnessResource, .roughness)
+        updateMaterialResource(metallicResource, .metallic)
+        updateMaterialResource(normalResource, .normal)
+
+        return self
+    }
+
+    func baseColor(_ red: Float, _ green: Float, _ blue: Float, _ alpha: Float = 1.0) -> Self {
+        updateMaterialColor(entityId: entityID, color: colorFromSimd(simd_float4(red, green, blue, alpha)))
+        return self
+    }
+
+    func roughness(_ value: Float) -> Self {
+        updateMaterialRoughness(entityId: entityID, roughness: value)
+        return self
+    }
+
+    func metallic(_ value: Float) -> Self {
+        updateMaterialMetallic(entityId: entityID, metallic: value)
+        return self
+    }
+
+    func emissive(_ red: Float, _ green: Float, _ blue: Float) -> Self {
+        updateMaterialEmmisive(entityId: entityID, emmissive: simd_float3(red, green, blue))
+        return self
+    }
+}

--- a/Sources/UntoldEngine/Scenes/Builder/NodeCore/Node+Transform.swift
+++ b/Sources/UntoldEngine/Scenes/Builder/NodeCore/Node+Transform.swift
@@ -38,6 +38,11 @@ public extension NodeTransform {
         return self
     }
 
+    func translateTo(x: Float = 0, y: Float = 0, z: Float = 0) -> Self {
+        UntoldEngine.translateTo(entityId: entityID, position: simd_float3(x, y, z))
+        return self
+    }
+
     internal func axisToSimdFloat3(_ axis: [Axis]) -> simd_float3 {
         var x: Float = 0, y: Float = 0, z: Float = 0
         for a in axis {

--- a/Sources/UntoldEngine/Scenes/Builder/PrimitiveNodes.swift
+++ b/Sources/UntoldEngine/Scenes/Builder/PrimitiveNodes.swift
@@ -1,0 +1,80 @@
+//
+//  PrimitiveNodes.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import simd
+import SwiftUI
+
+/// Base class for procedurally generated primitive nodes (cube, sphere, plane...).
+/// The mesh is generated synchronously, so material modifiers apply immediately.
+@MainActor
+open class PrimitiveNode: Node, NodeMaterial, NodeKinetics {
+    public init(meshes: [Mesh], assetName: String, entityID: EntityID? = nil, name: String? = nil, @SceneBuilder content: @escaping @MainActor () -> [any NodeProtocol]) {
+        super.init(entityID: entityID, name: name, content: content)
+
+        if name == nil { setEntityName(entityId: self.entityID, name: assetName) }
+        setEntityMeshDirect(entityId: self.entityID, meshes: meshes, assetName: assetName)
+    }
+}
+
+@MainActor
+public final class CubeNode: PrimitiveNode {
+    public convenience init(size: Float = 1.0, segments: UInt32 = 1, entityID: EntityID? = nil, name: String? = nil) {
+        self.init(size: size, segments: segments, entityID: entityID, name: name) {}
+    }
+
+    public init(size: Float = 1.0, segments: UInt32 = 1, entityID: EntityID? = nil, name: String? = nil, @SceneBuilder content: @escaping @MainActor () -> [any NodeProtocol]) {
+        super.init(meshes: BasicPrimitives.createCube(extent: size, segments: segments), assetName: "Cube", entityID: entityID, name: name, content: content)
+    }
+}
+
+@MainActor
+public final class SphereNode: PrimitiveNode {
+    public convenience init(radius: Float = 0.5, segments: [UInt32] = [32, 16], entityID: EntityID? = nil, name: String? = nil) {
+        self.init(radius: radius, segments: segments, entityID: entityID, name: name) {}
+    }
+
+    public init(radius: Float = 0.5, segments: [UInt32] = [32, 16], entityID: EntityID? = nil, name: String? = nil, @SceneBuilder content: @escaping @MainActor () -> [any NodeProtocol]) {
+        super.init(meshes: BasicPrimitives.createSphere(extent: radius * 2.0, segments: segments), assetName: "Sphere", entityID: entityID, name: name, content: content)
+    }
+}
+
+@MainActor
+public final class PlaneNode: PrimitiveNode {
+    public convenience init(width: Float = 1.0, depth: Float = 1.0, segments: [UInt32] = [1, 1], entityID: EntityID? = nil, name: String? = nil) {
+        self.init(width: width, depth: depth, segments: segments, entityID: entityID, name: name) {}
+    }
+
+    public init(width: Float = 1.0, depth: Float = 1.0, segments: [UInt32] = [1, 1], entityID: EntityID? = nil, name: String? = nil, @SceneBuilder content: @escaping @MainActor () -> [any NodeProtocol]) {
+        super.init(meshes: BasicPrimitives.createPlane(width: width, depth: depth, segments: segments), assetName: "Plane", entityID: entityID, name: name, content: content)
+    }
+}
+
+@MainActor
+public final class CylinderNode: PrimitiveNode {
+    public convenience init(height: Float = 1.0, radius: Float = 0.5, segments: [UInt32] = [32, 1], entityID: EntityID? = nil, name: String? = nil) {
+        self.init(height: height, radius: radius, segments: segments, entityID: entityID, name: name) {}
+    }
+
+    public init(height: Float = 1.0, radius: Float = 0.5, segments: [UInt32] = [32, 1], entityID: EntityID? = nil, name: String? = nil, @SceneBuilder content: @escaping @MainActor () -> [any NodeProtocol]) {
+        super.init(meshes: BasicPrimitives.createCylinder(height: height, radius: radius, segments: segments), assetName: "Cylinder", entityID: entityID, name: name, content: content)
+    }
+}
+
+@MainActor
+public final class ConeNode: PrimitiveNode {
+    public convenience init(height: Float = 1.0, radius: Float = 0.5, segments: [UInt32] = [32, 1], entityID: EntityID? = nil, name: String? = nil) {
+        self.init(height: height, radius: radius, segments: segments, entityID: entityID, name: name) {}
+    }
+
+    public init(height: Float = 1.0, radius: Float = 0.5, segments: [UInt32] = [32, 1], entityID: EntityID? = nil, name: String? = nil, @SceneBuilder content: @escaping @MainActor () -> [any NodeProtocol]) {
+        super.init(meshes: BasicPrimitives.createCone(height: height, radius: radius, segments: segments), assetName: "Cone", entityID: entityID, name: name, content: content)
+    }
+}

--- a/Sources/UntoldEngine/Scenes/Builder/SceneBuilder.swift
+++ b/Sources/UntoldEngine/Scenes/Builder/SceneBuilder.swift
@@ -14,14 +14,18 @@ public struct SceneBuilder {
         []
     }
 
-    /// Single node
-    public static func buildBlock(_ component: any NodeProtocol) -> [any NodeProtocol] {
-        [component]
+    /// Lift each expression to a component so single nodes and for-loop
+    /// results (both `[any NodeProtocol]`) can be combined in the same block.
+    public static func buildExpression(_ node: any NodeProtocol) -> [any NodeProtocol] {
+        [node]
     }
 
-    /// Multiple nodes
-    public static func buildBlock(_ components: any NodeProtocol...) -> [any NodeProtocol] {
-        components
+    public static func buildExpression(_ nodes: [any NodeProtocol]) -> [any NodeProtocol] {
+        nodes
+    }
+
+    public static func buildBlock(_ components: [any NodeProtocol]...) -> [any NodeProtocol] {
+        components.flatMap { $0 }
     }
 
     /// Support conditionals (if/else)

--- a/Tests/UntoldEngineRenderTests/SceneBuilderNodesTest.swift
+++ b/Tests/UntoldEngineRenderTests/SceneBuilderNodesTest.swift
@@ -1,0 +1,185 @@
+//
+//  SceneBuilderNodesTest.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import simd
+@testable import UntoldEngine
+import XCTest
+
+/// Covers the scene builder DSL nodes that need the renderer: primitive nodes
+/// (procedural meshes + material modifiers) and light nodes.
+final class SceneBuilderNodesTest: BaseRenderSetup {
+    override func setUp() async throws {
+        try await super.setUp()
+    }
+
+    override func tearDown() async throws {
+        try await super.tearDown()
+        destroyAllEntities()
+    }
+
+    override func initializeAssets() {}
+
+    // MARK: - Primitive nodes
+
+    func testCubeNodeCreatesMeshSynchronously() throws {
+        let cube = CubeNode(size: 1.0)
+
+        let renderComponent = try XCTUnwrap(
+            scene.get(component: RenderComponent.self, for: cube.entityID),
+            "Primitive meshes are generated synchronously, so the render component must exist right after init"
+        )
+        XCTAssertFalse(renderComponent.mesh.isEmpty)
+        XCTAssertEqual(renderComponent.mesh.first?.assetName, "Cube")
+        XCTAssertEqual(getEntityName(entityId: cube.entityID), "Cube")
+    }
+
+    func testPrimitiveNodesCreateExpectedMeshes() {
+        let primitives: [(node: any NodeProtocol, expectedName: String)] = [
+            (CubeNode(), "Cube"),
+            (SphereNode(), "Sphere"),
+            (PlaneNode(), "Plane"),
+            (CylinderNode(), "Cylinder"),
+            (ConeNode(), "Cone"),
+        ]
+
+        for (node, expectedName) in primitives {
+            let renderComponent = scene.get(component: RenderComponent.self, for: node.entityID)
+            XCTAssertNotNil(renderComponent, "\(expectedName)Node should register a render component")
+            XCTAssertEqual(renderComponent?.mesh.isEmpty, false, "\(expectedName)Node should have a mesh")
+            XCTAssertEqual(getEntityName(entityId: node.entityID), expectedName)
+        }
+    }
+
+    func testPrimitiveNodeUsesProvidedName() {
+        let cube = CubeNode(name: "Crate")
+        XCTAssertEqual(getEntityName(entityId: cube.entityID), "Crate")
+    }
+
+    func testPrimitiveNodeWrapsExistingEntity() {
+        let entity = createEntity()
+        let cube = CubeNode(entityID: entity)
+        XCTAssertEqual(cube.entityID, entity)
+        XCTAssertNotNil(scene.get(component: RenderComponent.self, for: entity))
+    }
+
+    func testMaterialModifiersApplyImmediately() {
+        let cube = CubeNode()
+            .baseColor(1.0, 0.5, 0.0)
+            .roughness(0.3)
+            .metallic(0.8)
+            .emissive(0.25, 0.5, 1.0)
+
+        let baseColor = getMaterialBaseColor(entityId: cube.entityID)
+        XCTAssertEqual(baseColor.x, 1.0, accuracy: 0.02)
+        XCTAssertEqual(baseColor.y, 0.5, accuracy: 0.02)
+        XCTAssertEqual(baseColor.z, 0.0, accuracy: 0.02)
+        XCTAssertEqual(baseColor.w, 1.0, accuracy: 0.02)
+
+        XCTAssertEqual(getMaterialRoughness(entityId: cube.entityID), 0.3, accuracy: 0.001)
+        XCTAssertEqual(getMaterialMetallic(entityId: cube.entityID), 0.8, accuracy: 0.001)
+        XCTAssertEqual(getMaterialEmmissive(entityId: cube.entityID), simd_float3(0.25, 0.5, 1.0))
+    }
+
+    func testMaterialDataAppliesAllScalarValues() {
+        let sphere = SphereNode().materialData(
+            roughness: 0.4,
+            metallic: 0.6,
+            emissive: (0.1, 0.2, 0.3),
+            baseColor: (0.9, 0.1, 0.2, 1.0)
+        )
+
+        let baseColor = getMaterialBaseColor(entityId: sphere.entityID)
+        XCTAssertEqual(baseColor.x, 0.9, accuracy: 0.02)
+        XCTAssertEqual(baseColor.y, 0.1, accuracy: 0.02)
+        XCTAssertEqual(baseColor.z, 0.2, accuracy: 0.02)
+
+        XCTAssertEqual(getMaterialRoughness(entityId: sphere.entityID), 0.4, accuracy: 0.001)
+        XCTAssertEqual(getMaterialMetallic(entityId: sphere.entityID), 0.6, accuracy: 0.001)
+        XCTAssertEqual(getMaterialEmmissive(entityId: sphere.entityID), simd_float3(0.1, 0.2, 0.3))
+    }
+
+    func testPrimitiveNodeParentsChildContent() {
+        let child = SphereNode(name: "moon")
+        let parent = CubeNode { child }
+
+        XCTAssertEqual(parent.subNodes.count, 1)
+        XCTAssertEqual(getEntityParent(entityId: child.entityID), parent.entityID)
+    }
+
+    func testTranslateToPositionsPrimitiveAbsolutely() {
+        let cube = CubeNode()
+
+        _ = cube.translateTo(x: 2, y: 3, z: 4)
+        _ = cube.translateTo(x: 2, y: 3, z: 4)
+
+        XCTAssertEqual(getLocalPosition(entityId: cube.entityID), simd_float3(2, 3, 4))
+    }
+
+    // MARK: - Light nodes
+
+    func testPointLightNodeCreatesComponents() {
+        let light = PointLightNode()
+
+        XCTAssertTrue(hasComponent(entityId: light.entityID, componentType: LightComponent.self))
+        XCTAssertTrue(hasComponent(entityId: light.entityID, componentType: PointLightComponent.self))
+        XCTAssertEqual(getEntityName(entityId: light.entityID), "Point Light")
+    }
+
+    func testPointLightNodeModifiers() {
+        let light = PointLightNode()
+            .color(0.2, 0.9, 0.3)
+            .intensity(10)
+            .radius(0.5)
+            .falloff(0.8)
+            .attenuation(constant: 1, linear: 0.5, quadratic: 1.2)
+
+        XCTAssertEqual(getLightColor(entityId: light.entityID), simd_float3(0.2, 0.9, 0.3))
+        XCTAssertEqual(getLightIntensity(entityId: light.entityID), 10)
+        XCTAssertEqual(getLightRadius(entityId: light.entityID), 0.5)
+        XCTAssertEqual(getLightFalloff(entityId: light.entityID), 0.8)
+        XCTAssertEqual(getLightAttenuation(entityId: light.entityID), simd_float3(1, 0.5, 1.2))
+    }
+
+    func testDirectionalLightNodeBecomesActiveSun() {
+        let first = DirectionalLightNode()
+        XCTAssertEqual(LightingSystem.shared.activeDirectionalLight, first.entityID)
+
+        let second = DirectionalLightNode()
+        XCTAssertEqual(LightingSystem.shared.activeDirectionalLight, second.entityID,
+                       "Declaring a DirectionalLightNode makes it the scene's active sun")
+        XCTAssertEqual(getEntityName(entityId: second.entityID), "Directional Light")
+    }
+
+    func testSpotLightNodeModifiers() {
+        let light = SpotLightNode()
+            .coneAngle(30)
+            .radius(0.4)
+            .intensity(5)
+
+        XCTAssertTrue(hasComponent(entityId: light.entityID, componentType: SpotLightComponent.self))
+        XCTAssertEqual(getEntityName(entityId: light.entityID), "Spot Light")
+        XCTAssertEqual(getLightConeAngle(entityId: light.entityID), 30)
+        XCTAssertEqual(getLightRadius(entityId: light.entityID), 0.4)
+        XCTAssertEqual(getLightIntensity(entityId: light.entityID), 5)
+    }
+
+    func testLightNodeWrapsExistingLightEntity() {
+        let entity = createEntity()
+        createPointLight(entityId: entity)
+        updateLightIntensity(entityId: entity, intensity: 7)
+
+        let light = PointLightNode(entityID: entity)
+
+        XCTAssertEqual(light.entityID, entity)
+        XCTAssertEqual(getLightIntensity(entityId: entity), 7,
+                       "Wrapping an existing point light must not recreate the component")
+    }
+
+}

--- a/Tests/UntoldEngineTests/SceneBuilderNodeTests.swift
+++ b/Tests/UntoldEngineTests/SceneBuilderNodeTests.swift
@@ -1,0 +1,160 @@
+//
+//  SceneBuilderNodeTests.swift
+//  UntoldEngineTests
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import simd
+@testable import UntoldEngine
+import XCTest
+
+/// Covers the scene builder DSL pieces that don't need a Metal device:
+/// the result builder, Node identity/parenting, transform modifiers, and
+/// CameraNode.
+@MainActor
+final class SceneBuilderNodeTests: XCTestCase {
+    override func setUp() async throws {
+        resetEngineTestState()
+        Logger.logLevel = .none
+    }
+
+    // MARK: - Result builder
+
+    @SceneBuilder private func makeMixedBlock(includeExtra: Bool) -> [any NodeProtocol] {
+        Node(name: "first")
+        for index in 0 ..< 3 {
+            Node(name: "loop\(index)")
+        }
+        if includeExtra {
+            Node(name: "extra")
+        }
+    }
+
+    func testBuilderMixesSingleNodesAndLoops() {
+        let nodes = makeMixedBlock(includeExtra: false)
+
+        XCTAssertEqual(nodes.count, 4, "One single node plus a 3-iteration loop should yield 4 nodes")
+        XCTAssertEqual(getEntityName(entityId: nodes[0].entityID), "first")
+        XCTAssertEqual(getEntityName(entityId: nodes[1].entityID), "loop0")
+        XCTAssertEqual(getEntityName(entityId: nodes[3].entityID), "loop2")
+    }
+
+    func testBuilderSupportsConditionals() {
+        let withExtra = makeMixedBlock(includeExtra: true)
+        XCTAssertEqual(withExtra.count, 5)
+        XCTAssertEqual(getEntityName(entityId: withExtra[4].entityID), "extra")
+    }
+
+    func testEmptyBlockBuildsNoNodes() {
+        let node = Node(name: "parent") {}
+        XCTAssertTrue(node.subNodes.isEmpty)
+    }
+
+    // MARK: - Node
+
+    func testNodeCreatesEntity() {
+        let node = Node()
+        XCTAssertTrue(scene.exists(node.entityID))
+    }
+
+    func testNodeWrapsExistingEntity() {
+        let existing = createEntity()
+        let node = Node(entityID: existing)
+        XCTAssertEqual(node.entityID, existing)
+    }
+
+    func testNodeAssignsName() {
+        let node = Node(name: "Hero")
+        XCTAssertEqual(getEntityName(entityId: node.entityID), "Hero")
+    }
+
+    func testNodeParentsDeclaredChildren() {
+        let child = Node(name: "child")
+        let parent = Node(name: "parent") { child }
+
+        XCTAssertEqual(parent.subNodes.count, 1)
+        XCTAssertEqual(getEntityParent(entityId: child.entityID), parent.entityID)
+    }
+
+    // MARK: - Transform modifiers
+
+    func testTranslateToIsIdempotent() {
+        let node = Node().registerTransformComponent()
+
+        _ = node.translateTo(x: 1, y: 2, z: 3)
+        _ = node.translateTo(x: 1, y: 2, z: 3)
+
+        XCTAssertEqual(getLocalPosition(entityId: node.entityID), simd_float3(1, 2, 3),
+                       "translateTo must set an absolute position so re-evaluating a scene body doesn't drift")
+    }
+
+    func testTranslateByAccumulates() {
+        let node = Node().registerTransformComponent()
+
+        _ = node.translateBy(x: 1, y: 0, z: 0)
+        _ = node.translateBy(x: 1, y: 0, z: 0)
+
+        XCTAssertEqual(getLocalPosition(entityId: node.entityID), simd_float3(2, 0, 0))
+    }
+
+    // MARK: - CameraNode
+
+    func testCameraNodeDefaultsToGameCamera() {
+        let camera = CameraNode()
+
+        XCTAssertTrue(hasComponent(entityId: camera.entityID, componentType: CameraComponent.self))
+        XCTAssertEqual(CameraSystem.shared.activeCamera, camera.entityID)
+    }
+
+    func testCameraNodeReusesActiveGameCamera() {
+        let first = CameraNode()
+        let second = CameraNode()
+
+        XCTAssertEqual(first.entityID, second.entityID,
+                       "Declaring CameraNode() twice should wrap the same game camera, not create a second one")
+    }
+
+    func testCameraNodeCreatesCameraComponentForPlainEntity() {
+        let entity = createEntity()
+        XCTAssertFalse(hasComponent(entityId: entity, componentType: CameraComponent.self))
+
+        let camera = CameraNode(entityID: entity)
+
+        XCTAssertEqual(camera.entityID, entity)
+        XCTAssertTrue(hasComponent(entityId: entity, componentType: CameraComponent.self),
+                      "CameraNode(entityID:) must create the camera component when missing, like the light nodes do")
+        XCTAssertEqual(CameraSystem.shared.activeCamera, entity)
+    }
+
+    func testCameraNodePreservesCustomNameWhenPromotingEntity() {
+        let entity = createEntity()
+        _ = CameraNode(entityID: entity, name: "Chase Cam")
+
+        XCTAssertEqual(getEntityName(entityId: entity), "Chase Cam")
+    }
+
+    func testCameraNodeLookAtAppliesToPromotedEntity() throws {
+        let entity = createEntity()
+        let eye = simd_float3(0, 1, 2.7)
+        let target = simd_float3(0, 0.5, 0)
+
+        _ = CameraNode(entityID: entity).lookAt(eye: eye, target: target)
+
+        let cameraComponent = try XCTUnwrap(scene.get(component: CameraComponent.self, for: entity))
+        XCTAssertEqual(cameraComponent.eye, eye)
+        XCTAssertEqual(cameraComponent.target, target)
+        XCTAssertEqual(getCameraPosition(entityId: entity), eye)
+    }
+
+    func testCameraNodeLookAtOnDefaultCamera() throws {
+        let camera = CameraNode().lookAt(eye: simd_float3(0, 0, 5))
+
+        let cameraComponent = try XCTUnwrap(scene.get(component: CameraComponent.self, for: camera.entityID))
+        XCTAssertEqual(cameraComponent.eye, simd_float3(0, 0, 5))
+        XCTAssertEqual(cameraComponent.target, .zero)
+    }
+}


### PR DESCRIPTION
## Summary

Extends the SwiftUI-style scene builder DSL so complete scenes (geometry, lights, camera, materials) can be declared without imperative setup, and fixes material emissive being dropped in the deferred light pass.

### DSL additions (`Scenes/Builder/`)
- **Primitive nodes**: `CubeNode`, `SphereNode`, `PlaneNode`, `CylinderNode`, `ConeNode` — generated via `BasicPrimitives` + `setEntityMeshDirect`, so the mesh exists synchronously and material modifiers apply immediately (unlike `MeshNode`'s async load).
- **`NodeMaterial` protocol**: `materialData(...)` moved out of `MeshNode` unchanged, plus `.baseColor`, `.roughness`, `.metallic`, `.emissive` shorthands. `MeshNode` and all primitives conform.
- **Light nodes**: `DirectionalLightNode` (declares itself the active sun), `PointLightNode`, `SpotLightNode`, with `.color`/`.intensity`; point lights add `.radius`, `.falloff`, `.attenuation(constant:linear:quadratic:)`.
- **`CameraNode`**: wraps the renderer's game camera, `.lookAt(eye:target:up:)`.
- **Result builder**: `buildExpression` + array-based `buildBlock` so `for` loops can mix with single nodes in a scene block.
- **`translateTo`**: absolute positioning on `NodeTransform` (`translateBy` accumulates and is not idempotent when SwiftUI re-evaluates a scene body).

### Renderer fix
The TBDR light pass zeroed G-buffer emissive before compositing (`emissive = 0.0 // set to zero for now`), so material emissive never reached the screen. Removed; emissive defaults to zero for every material, so only entities that explicitly set it are affected. Kernels regenerated with `buildkernels.sh`.

## Example

```swift
UntoldView(renderer: renderer) {
    CameraNode().lookAt(eye: [0, 1, 2.7])
    PointLightNode()
        .color(0.2, 0.9, 0.3).intensity(10)
        .attenuation(constant: 1, quadratic: 1.2)
        .translateTo(y: 1.5)
    for row in 0..<7 {
        for col in 0..<7 {
            CubeNode(size: 0.85)
                .baseColor(1, 0.5, 0)
                .translateTo(x: Float(col), z: Float(row))
        }
    }
}
.onUpdate { event in /* per-frame animation */ }
```

## Testing
- Verified with two demo apps in UntoldArcade/SceneBuilder (rainbow cube-wave grid and a PBR cube with three orbiting colored point lights), built through the workspace against this branch and visually checked on macOS.
- Emissive fix confirmed by marker spheres that previously rendered black on their unlit side and now glow.

---
Cherry-picked onto current upstream develop (6d97efb9) from the miolabs fork; both commits apply cleanly and the package builds.