### PR TITLE
[Bugfix] Recreate one-shot ARKit data providers on every session run

### DIFF
--- a/Sources/UntoldEngine/Systems/InputSystem+PSVR2.swift
+++ b/Sources/UntoldEngine/Systems/InputSystem+PSVR2.swift
@@ -94,6 +94,7 @@ extension InputSystem {
             psvr2AccessoryLoadTask = nil
             psvr2AnchorMonitorTask = nil
             if psvr2SpatialControllers.isEmpty {
+                psvr2AccessoriesStorage = []
                 psvr2AccessoryTrackingProviderStorage = nil
                 psvr2SenseControllerState = PSVR2SenseControllerState()
                 NotificationCenter.default.post(name: .psvr2AccessoryTrackingConfigurationDidChange, object: self)
@@ -153,9 +154,7 @@ extension InputSystem {
                         try await accessories.append(Accessory(device: controller))
                     }
                     guard !Task.isCancelled, psvr2AccessoryGeneration == generation else { return }
-                    let provider = AccessoryTrackingProvider(accessories: accessories)
-                    psvr2AccessoryTrackingProviderStorage = provider
-                    monitorPSVR2Anchors(from: provider)
+                    psvr2AccessoriesStorage = accessories
                     NotificationCenter.default.post(
                         name: .psvr2AccessoryTrackingConfigurationDidChange,
                         object: self
@@ -165,6 +164,20 @@ extension InputSystem {
                     Logger.log(message: "PSVR2 accessory loading failed: \(error)")
                 }
             }
+        }
+
+        /// Builds a fresh AccessoryTrackingProvider from the cached accessories and
+        /// re-wires the anchor monitor to it. ARKit data providers are one-shot — an
+        /// instance that has been passed to ARKitSession.run can never be run again —
+        /// so the session owner must call this before every run. Returns nil when no
+        /// PSVR2 accessories have finished loading.
+        public func makePSVR2AccessoryTrackingProviderForSessionRun() -> AccessoryTrackingProvider? {
+            let accessories = psvr2AccessoriesStorage.compactMap { $0 as? Accessory }
+            guard !accessories.isEmpty else { return nil }
+            let provider = AccessoryTrackingProvider(accessories: accessories)
+            psvr2AccessoryTrackingProviderStorage = provider
+            monitorPSVR2Anchors(from: provider)
+            return provider
         }
 
         private func monitorPSVR2Anchors(from provider: AccessoryTrackingProvider) {

--- a/Sources/UntoldEngine/Systems/InputSystem.swift
+++ b/Sources/UntoldEngine/Systems/InputSystem.swift
@@ -73,11 +73,19 @@ public final class InputSystem: @unchecked Sendable {
     public var psvr2SenseControllerState = PSVR2SenseControllerState()
     #if os(visionOS)
         var psvr2SpatialControllers: [GCController] = []
+        // Loaded Accessory objects ([Any] to avoid @available on a stored property).
+        // Kept instead of a long-lived provider: ARKit data providers are one-shot,
+        // so a fresh AccessoryTrackingProvider is built from these for every
+        // ARKitSession run (see makePSVR2AccessoryTrackingProviderForSessionRun).
+        var psvr2AccessoriesStorage: [Any] = []
         var psvr2AccessoryTrackingProviderStorage: AnyObject?
         var psvr2AccessoryLoadTask: Task<Void, Never>?
         var psvr2AnchorMonitorTask: Task<Void, Never>?
         var psvr2AccessoryGeneration = 0
 
+        /// The provider most recently created for a session run. May already have
+        /// been run — never pass this to ARKitSession.run again; use
+        /// makePSVR2AccessoryTrackingProviderForSessionRun for that.
         @available(visionOS 26.0, *)
         public var psvr2AccessoryTrackingProvider: AccessoryTrackingProvider? {
             psvr2AccessoryTrackingProviderStorage as? AccessoryTrackingProvider

--- a/Sources/UntoldEngineXR/UntoldEngineXR.swift
+++ b/Sources/UntoldEngineXR/UntoldEngineXR.swift
@@ -59,10 +59,17 @@
         /// Task handle for the plane-update monitor so we can cancel it on shutdown.
         private var planeMonitorTask: Task<Void, Never>?
 
+        /// Task handle for the ARKitSession event monitor (provider state changes,
+        /// authorization changes) so we can cancel it on shutdown.
+        private var sessionEventMonitorTask: Task<Void, Never>?
+
         #if canImport(ARKit)
             private let arSession = ARKitSession()
-            private let worldTracking = WorldTrackingProvider()
-            private let planeDetection = PlaneDetectionProvider(alignments: [.horizontal, .vertical])
+            // ARKit data providers are one-shot: an instance that has been passed to
+            // arSession.run can never be run again, so runARKitProvidersOnce swaps in
+            // freshly created instances (guarded by arKitProviderRunLock) on every run.
+            private var worldTracking = WorldTrackingProvider()
+            private var planeDetection = PlaneDetectionProvider(alignments: [.horizontal, .vertical])
         #else
             private let arSession: Any? = nil
             private let worldTracking: WorldTrackingProvider? = nil
@@ -92,13 +99,11 @@
             configurePSVR2TrackingObserver()
             registerRuntimeLightingModeObserverIfNeeded()
             applyXRLightingMode(RuntimeEnvironmentLightingStore.shared.mode)
+            startSessionEventMonitor()
 
+            // The plane monitor is wired up inside runARKitProvidersOnce, since it
+            // must follow the fresh PlaneDetectionProvider created for each run.
             startARKitProviders(reason: "startup")
-
-            // Start monitoring plane anchor updates in the background.
-            if PlaneDetectionProvider.isSupported {
-                startPlaneMonitor()
-            }
 
             let configuration = layerRenderer.configuration
             _ = configuration.layout
@@ -255,6 +260,8 @@
             lock.unlock()
             planeMonitorTask?.cancel()
             planeMonitorTask = nil
+            sessionEventMonitorTask?.cancel()
+            sessionEventMonitorTask = nil
             xrEnvironmentLightingSystem.setEnabled(false)
             RealSurfacePlaneStore.shared.clear()
         }
@@ -263,6 +270,44 @@
             #if canImport(ARKit)
                 scheduleARKitProviderRun(reason: reason)
             #endif
+        }
+
+        /// Watches ARKitSession.events and logs every provider state change with the
+        /// error ARKit attaches — the only place the system says WHY tracking paused
+        /// or stopped. Also feeds the recovery path so a pause of the current world
+        /// tracking provider is handled event-driven instead of waiting for an anchor
+        /// query to miss.
+        private func startSessionEventMonitor() {
+            #if canImport(ARKit)
+                guard sessionEventMonitorTask == nil else { return }
+                let arSession = arSession
+                sessionEventMonitorTask = Task { [weak self] in
+                    for await event in arSession.events {
+                        guard let self else { break }
+                        if Task.isCancelled { break }
+                        switch event {
+                        case let .dataProviderStateChanged(providers, newState, error):
+                            let names = providers.map { String(describing: type(of: $0)) }.joined(separator: ",")
+                            let errorText = error.map { ", error=\($0)" } ?? ""
+                            print("XR ARKit session event: t=\(xrLogTimestamp()), providers=\(names), newState=\(newState)\(errorText)")
+                            if newState == .paused || newState == .stopped {
+                                let current = currentWorldTracking()
+                                if providers.contains(where: { ($0 as AnyObject) === current }) {
+                                    scheduleWorldTrackingRecoveryIfNeeded()
+                                }
+                            }
+                        case let .authorizationChanged(type, status):
+                            print("XR ARKit session event: t=\(xrLogTimestamp()), authorizationChanged type=\(type), status=\(status)")
+                        default:
+                            print("XR ARKit session event: t=\(xrLogTimestamp()), \(event)")
+                        }
+                    }
+                }
+            #endif
+        }
+
+        private func xrLogTimestamp() -> String {
+            String(format: "%.3f", CACurrentMediaTime())
         }
 
         private func scheduleARKitProviderRun(reason: String) {
@@ -339,10 +384,15 @@
 
         #if canImport(ARKit)
             private func runARKitProvidersOnce(reason: String) async -> Bool {
-                let worldTracking = worldTracking
                 let arSession = arSession
-                let planeDetection = planeDetection
                 let xrEnvironmentLightingSystem = xrEnvironmentLightingSystem
+
+                // ARKit data providers are one-shot: an instance that has already been
+                // passed to arSession.run can never be run again (re-running it leaves
+                // world tracking paused forever). Create fresh instances for every run.
+                let worldTracking = WorldTrackingProvider()
+                let planeDetection = PlaneDetectionProvider(alignments: [.horizontal, .vertical])
+                installFreshARKitProviders(worldTracking: worldTracking, planeDetection: planeDetection)
 
                 let attempt = nextARKitProviderRunAttempt()
                 let startTime = CACurrentMediaTime()
@@ -351,6 +401,7 @@
                     // Check world sensing authorization before attempting plane detection.
                     let authStatus = await arSession.queryAuthorization(for: [.worldSensing])
                     let worldSensingAllowed = authStatus[.worldSensing] != .denied
+                    let authMs = (CACurrentMediaTime() - startTime) * 1000.0
 
                     var providers: [any DataProvider] = [worldTracking]
                     var providerNames = ["WorldTrackingProvider"]
@@ -359,6 +410,7 @@
                         if PlaneDetectionProvider.isSupported {
                             providers.append(planeDetection)
                             providerNames.append("PlaneDetectionProvider")
+                            restartPlaneMonitor(with: planeDetection)
                         } else {
                             print("⚠️ PlaneDetectionProvider is not supported on this device")
                         }
@@ -366,31 +418,32 @@
                         print("⚠️ World sensing authorization denied — plane detection disabled. Grant permission in Settings > Privacy > World Sensing.")
                     }
 
-                    if let lightingProvider = xrEnvironmentLightingSystem.providerForSession {
+                    let lightingProvider = xrEnvironmentLightingSystem.makeProviderForSessionRun()
+                    if let lightingProvider {
                         providers.append(lightingProvider)
                         providerNames.append("EnvironmentLightingProvider")
                     }
 
                     if #available(visionOS 26.0, *),
-                       let accessoryProvider = InputSystem.shared.psvr2AccessoryTrackingProvider
+                       let accessoryProvider = InputSystem.shared.makePSVR2AccessoryTrackingProviderForSessionRun()
                     {
                         providers.append(accessoryProvider)
                         providerNames.append("PSVR2 AccessoryTrackingProvider")
                     }
 
                     let providerList = providerNames.joined(separator: ",")
-                    print("XR ARKit providers run starting: attempt=\(attempt), reason=\(reason), providers=\(providerList), worldSensingAllowed=\(worldSensingAllowed)")
+                    print("XR ARKit providers run starting: t=\(xrLogTimestamp()), attempt=\(attempt), reason=\(reason), providers=\(providerList), worldSensingAllowed=\(worldSensingAllowed), authMs=\(String(format: "%.2f", authMs))")
                     try await arSession.run(providers)
-                    xrEnvironmentLightingSystem.markProviderRunning(xrEnvironmentLightingSystem.providerForSession != nil)
+                    xrEnvironmentLightingSystem.markProviderRunning(lightingProvider != nil)
                     let durationMs = (CACurrentMediaTime() - startTime) * 1000.0
                     let durationText = String(format: "%.2f", durationMs)
-                    print("XR ARKit providers run completed: attempt=\(attempt), durationMs=\(durationText), worldTrackingState=\(String(describing: worldTracking.state))")
+                    print("XR ARKit providers run completed: t=\(xrLogTimestamp()), attempt=\(attempt), durationMs=\(durationText), worldTrackingState=\(String(describing: worldTracking.state))")
                     return true
                 } catch {
                     xrEnvironmentLightingSystem.markProviderRunning(false)
                     let durationMs = (CACurrentMediaTime() - startTime) * 1000.0
                     let durationText = String(format: "%.2f", durationMs)
-                    print("XR ARKit providers run failed: attempt=\(attempt), durationMs=\(durationText), worldTrackingState=\(String(describing: worldTracking.state)), error=\(error)")
+                    print("XR ARKit providers run failed: t=\(xrLogTimestamp()), attempt=\(attempt), durationMs=\(durationText), worldTrackingState=\(String(describing: worldTracking.state)), error=\(error)")
                     print("⚠️ Failed to start ARKit providers: \(error)")
                     return false
                 }
@@ -404,6 +457,29 @@
             arKitProviderRunLock.unlock()
             return attempt
         }
+
+        #if canImport(ARKit)
+            private func installFreshARKitProviders(worldTracking: WorldTrackingProvider, planeDetection: PlaneDetectionProvider) {
+                arKitProviderRunLock.lock()
+                self.worldTracking = worldTracking
+                self.planeDetection = planeDetection
+                arKitProviderRunLock.unlock()
+            }
+
+            private func currentWorldTracking() -> WorldTrackingProvider {
+                arKitProviderRunLock.lock()
+                let provider = worldTracking
+                arKitProviderRunLock.unlock()
+                return provider
+            }
+
+            private func isARKitProviderRunInProgress() -> Bool {
+                arKitProviderRunLock.lock()
+                let inProgress = arKitProviderRunInProgress
+                arKitProviderRunLock.unlock()
+                return inProgress
+            }
+        #endif
 
         private func isRunning() -> Bool {
             lock.lock()
@@ -593,8 +669,11 @@
 
         // MARK: - Plane Detection
 
-        private func startPlaneMonitor() {
-            let planeDetection = planeDetection
+        /// Restarts the plane-update monitor on the given provider. Called from
+        /// runARKitProvidersOnce, since anchorUpdates streams are tied to a specific
+        /// provider instance and end when that instance stops.
+        private func restartPlaneMonitor(with planeDetection: PlaneDetectionProvider) {
+            planeMonitorTask?.cancel()
             planeMonitorTask = Task(priority: .utility) {
                 var trackedPlanes: [UUID: TrackedPlane] = [:]
                 for await update in planeDetection.anchorUpdates {
@@ -856,7 +935,7 @@
                 let layerState = layerRenderer.map { String(describing: $0.state) } ?? "nil"
                 print(
                     "⚠️ \(message): missingFrameCount=\(missingAnchorFrameCount), " +
-                        "worldTrackingState=\(String(describing: worldTracking.state)), " +
+                        "worldTrackingState=\(String(describing: currentWorldTracking().state)), " +
                         "layerState=\(layerState), " +
                         "lastValidAnchorAvailable=\(lastValidDeviceAnchor != nil), " +
                         "xrLightingValid=\(lightingDiagnostics.latestProbeTextureValid), " +
@@ -879,7 +958,7 @@
                 print(
                     "⚠️ XR command buffer semaphore stall: phase=\(phase), waitMs=\(waitText), " +
                         "missingAnchorFrameCount=\(missingAnchorFrameCount), " +
-                        "worldTrackingState=\(String(describing: worldTracking.state)), " +
+                        "worldTrackingState=\(String(describing: currentWorldTracking().state)), " +
                         "layerState=\(layerState), " +
                         "xrLightingValid=\(lightingDiagnostics.latestProbeTextureValid), " +
                         "xrIntensityScale=\(String(describing: lightingDiagnostics.latestIntensityScale)), " +
@@ -895,6 +974,7 @@
 
         private func queryDeviceAnchorIfTrackingRunning(atTimestamp timestamp: TimeInterval) -> DeviceAnchor? {
             #if canImport(ARKit)
+                let worldTracking = currentWorldTracking()
                 guard worldTracking.state == .running else {
                     scheduleWorldTrackingRecoveryIfNeeded()
                     return nil
@@ -908,6 +988,11 @@
 
         private func scheduleWorldTrackingRecoveryIfNeeded() {
             #if canImport(ARKit)
+                // A run in progress means a fresh provider is already starting up;
+                // its state stays .initialized until arSession.run returns, and
+                // scheduling recovery here would just queue a pointless extra run.
+                guard !isARKitProviderRunInProgress() else { return }
+
                 let now = CACurrentMediaTime()
                 guard now - lastWorldTrackingRecoveryAttemptTime >= worldTrackingRecoveryCooldownSeconds else {
                     if shouldLogAnchorDiagnostics() {
@@ -918,9 +1003,10 @@
 
                 lastWorldTrackingRecoveryAttemptTime = now
 
+                let worldTracking = currentWorldTracking()
                 guard worldTracking.state != .running else { return }
                 startARKitProviders(reason: "worldTrackingState=\(String(describing: worldTracking.state))")
-                print("✓ XR ARKit providers recovery scheduled: worldTrackingState=\(String(describing: worldTracking.state)), missingAnchorFrameCount=\(missingAnchorFrameCount)")
+                print("✓ XR ARKit providers recovery scheduled: t=\(xrLogTimestamp()), worldTrackingState=\(String(describing: worldTracking.state)), missingAnchorFrameCount=\(missingAnchorFrameCount)")
             #endif
         }
 

--- a/Sources/UntoldEngineXR/XREnvironmentLightingSystem.swift
+++ b/Sources/UntoldEngineXR/XREnvironmentLightingSystem.swift
@@ -59,7 +59,10 @@
         private var lastSmoothedLightingTimestamp: CFTimeInterval?
 
         #if canImport(ARKit)
-            private let environmentLightEstimationProvider: EnvironmentLightEstimationProvider?
+            // ARKit data providers are one-shot: an instance that has been passed to
+            // ARKitSession.run can never be run again, so makeProviderForSessionRun
+            // swaps in a fresh instance (guarded by lock) for every session run.
+            private var environmentLightEstimationProvider: EnvironmentLightEstimationProvider?
         #endif
 
         public var minimumProbeUpdateInterval: CFTimeInterval = 0.5
@@ -95,7 +98,7 @@
 
         public var providerSupported: Bool {
             #if canImport(ARKit)
-                environmentLightEstimationProvider != nil
+                EnvironmentLightEstimationProvider.isSupported
             #else
                 false
             #endif
@@ -103,9 +106,28 @@
 
         #if canImport(ARKit)
             public var providerForSession: (any DataProvider)? {
-                guard enabled, let environmentLightEstimationProvider else { return nil }
-                return environmentLightEstimationProvider
+                guard enabled else { return nil }
+                lock.lock()
+                let provider = environmentLightEstimationProvider
+                lock.unlock()
+                return provider
             }
+
+            /// Creates a fresh provider for an ARKitSession run and re-wires the probe
+            /// monitor to it. ARKit data providers are one-shot — an instance that has
+            /// been passed to ARKitSession.run can never be run again — so the session
+            /// owner must call this before every run instead of reusing providerForSession.
+            public func makeProviderForSessionRun() -> (any DataProvider)? {
+                guard enabled, EnvironmentLightEstimationProvider.isSupported else { return nil }
+                let provider = EnvironmentLightEstimationProvider()
+                lock.lock()
+                environmentLightEstimationProvider = provider
+                lock.unlock()
+                restartProbeMonitor(with: provider)
+                return provider
+            }
+        #else
+            public func makeProviderForSessionRun() -> Any? { nil }
         #endif
 
         public func setEnabled(_ enabled: Bool) {
@@ -176,11 +198,21 @@
         #if canImport(ARKit)
             private func startProbeMonitor() {
                 guard probeMonitorTask == nil else { return }
-                guard let provider = environmentLightEstimationProvider else {
+                lock.lock()
+                let provider = environmentLightEstimationProvider
+                lock.unlock()
+                guard let provider else {
                     publishUnavailableProbe(reason: "Environment light estimation unsupported")
                     return
                 }
 
+                restartProbeMonitor(with: provider)
+            }
+
+            /// anchorUpdates streams are tied to a specific provider instance and end
+            /// when that instance stops, so each fresh provider needs a fresh monitor.
+            private func restartProbeMonitor(with provider: EnvironmentLightEstimationProvider) {
+                probeMonitorTask?.cancel()
                 probeMonitorTask = Task(priority: .utility) { [weak self, provider] in
                     for await update in provider.anchorUpdates {
                         if Task.isCancelled { break }


### PR DESCRIPTION
## Problem

ARKit data providers are one-shot: an instance that has been passed to `ARKitSession.run` can never be run again. The XR layer created its `WorldTrackingProvider` / `PlaneDetectionProvider` once (`let` properties) and re-passed the same instances on every provider re-run. The `EnvironmentLightEstimationProvider` (single instance created in `XREnvironmentLightingSystem.init`) and the PSVR2 `AccessoryTrackingProvider` (rebuilt only when controllers change) had the same problem.

Any re-run therefore left world tracking **paused permanently** — device anchors and accessory anchors stopped until app relaunch. Re-runs happen in normal use:

- the PSVR2 accessory provider finishes loading after the first run (`Accessory(device:)` is slow), which posts `.psvr2AccessoryTrackingConfigurationDidChange`
- the runtime lighting mode changes
- the recovery path fires after a transient pause (headset removed for a moment, crown press)

Observed on a Vision Pro (visionOS 26) with PSVR2 Sense controllers: the first run completes and tracks, the accessory-triggered re-run completes in ~2 ms with `worldTrackingState=paused`, and tracking never recovers, so the wands never track.

## Fix

- `runARKitProvidersOnce` creates **fresh** `WorldTrackingProvider`/`PlaneDetectionProvider` instances for every run (the swap is guarded by `arKitProviderRunLock`) and re-wires the plane monitor, since an `anchorUpdates` stream is tied to its provider instance and ends when that instance stops.
- `XREnvironmentLightingSystem.makeProviderForSessionRun()` returns a fresh `EnvironmentLightEstimationProvider` and re-wires the probe monitor. `providerForSession` remains as a read-only accessor.
- `InputSystem` now caches the loaded PSVR2 `Accessory` objects (the slow part) and `makePSVR2AccessoryTrackingProviderForSessionRun()` builds a cheap fresh `AccessoryTrackingProvider` per run, re-wiring the anchor monitor.
- Recovery scheduling is suppressed while a provider run is in flight: a freshly swapped-in provider reports `.initialized` until `run` returns, which previously queued a spurious extra re-run.
- New `ARKitSession.events` monitor logs every provider state change **with the error ARKit attaches** (the only place the system says why tracking paused) and triggers recovery event-driven. Run logs now carry timestamps and report the `queryAuthorization` time separately.

## Verification

- `UntoldEngineXR` builds for visionOS (`generic/platform=visionOS`); macOS SPM build green; PSVR2/lighting unit tests pass.
- On device (Vision Pro, visionOS 26, PSVR2 Sense wands): world tracking now survives transient pauses — the recovery re-run completes in ~12 ms with fresh providers and returns to `running` — and the wands track even when the accessory provider loads after the first run. Previously either scenario permanently killed tracking.
