### PR TITLE
[Feature] Per-entity animation policy (inherit / forceOn / forceOff)

### DIFF
--- a/Sources/UntoldEngine/ECS/Components.swift
+++ b/Sources/UntoldEngine/ECS/Components.swift
@@ -160,6 +160,24 @@ public class SkeletonComponent: Component {
     }
 }
 
+/// Per-entity animation control policy.
+///
+/// Layered animation control (see upstream discussion #801): the global
+/// `AnimationSystem.isEnabled` toggle has highest precedence — when it is
+/// off, nothing animates regardless of policy. When it is on, each entity
+/// resolves its own policy: `.inherit` follows the effective value from the
+/// levels above (global today; per-view control when the editor adds it),
+/// `.forceOn` always animates, and `.forceOff` never animates.
+///
+/// `.forceOff` freezes the entity's playback clock without touching its
+/// `pause` state, so toggling the policy back restores whatever play/pause
+/// state the entity had.
+public enum AnimationPolicy: String, CaseIterable, Sendable {
+    case inherit
+    case forceOn
+    case forceOff
+}
+
 public class AnimationComponent: Component {
     var animationClips: [String: AnimationClip] = [:]
     var currentAnimation: AnimationClip?
@@ -167,6 +185,7 @@ public class AnimationComponent: Component {
     var pause: Bool = false
     var playbackSpeed: Float = 1.0
     var currentTime: Float = 0.0
+    var policy: AnimationPolicy = .inherit
 
     // Compiled sampling state (see docs/Architecture/animationPoseLayer.md):
     // clips resolved against this entity's skeleton, plus the per-entity

--- a/Sources/UntoldEngine/Systems/AnimationSystem.swift
+++ b/Sources/UntoldEngine/Systems/AnimationSystem.swift
@@ -157,6 +157,10 @@ private func updateAnimationSystem(deltaTime: Float) {
             continue
         }
 
+        if animationPolicyAllowsPlayback(animationComponent) == false {
+            continue
+        }
+
         if isAnimationComponentPaused(entityId: entity) {
             continue
         }
@@ -188,6 +192,46 @@ private func updateAnimationSystem(deltaTime: Float) {
             }
         }
     }
+}
+
+/// Resolves whether an animation component may advance this frame given its
+/// per-entity policy. The global `AnimationSystem.isEnabled` toggle has
+/// already been applied by the time the update loop runs (disabled swaps in
+/// a dummy update), so `.inherit` and `.forceOn` both animate here; they
+/// diverge once per-view control exists, where `.forceOn` overrides a
+/// view-level pause and `.inherit` honors it.
+func animationPolicyAllowsPlayback(_ animationComponent: AnimationComponent) -> Bool {
+    switch animationComponent.policy {
+    case .inherit, .forceOn:
+        return true
+    case .forceOff:
+        return false
+    }
+}
+
+/// Sets the animation policy for the entity (or its descendants that carry
+/// an `AnimationComponent`, matching how the other animation APIs resolve
+/// hierarchical assets).
+public func setAnimationPolicy(entityId: EntityID, policy: AnimationPolicy) {
+    let animationComponents = animationComponentsForEntityOrDescendants(entityId: entityId)
+    guard animationComponents.isEmpty == false else {
+        handleError(.noAnimationComponent, entityId)
+        return
+    }
+
+    for (_, animationComponent) in animationComponents {
+        animationComponent.policy = policy
+    }
+}
+
+public func getAnimationPolicy(entityId: EntityID) -> AnimationPolicy {
+    let targetEntityId = resolveEntityWithAnimationComponent(entityId: entityId) ?? entityId
+    guard let animationComponent = scene.get(component: AnimationComponent.self, for: targetEntityId) else {
+        handleError(.noAnimationComponent, entityId)
+        return .inherit
+    }
+
+    return animationComponent.policy
 }
 
 public func pauseAnimationComponent(entityId: EntityID, isPaused: Bool) {

--- a/Sources/UntoldEngine/Systems/AnimationSystem.swift
+++ b/Sources/UntoldEngine/Systems/AnimationSystem.swift
@@ -224,14 +224,23 @@ public func setAnimationPolicy(entityId: EntityID, policy: AnimationPolicy) {
     }
 }
 
-public func getAnimationPolicy(entityId: EntityID) -> AnimationPolicy {
-    let targetEntityId = resolveEntityWithAnimationComponent(entityId: entityId) ?? entityId
-    guard let animationComponent = scene.get(component: AnimationComponent.self, for: targetEntityId) else {
+/// Returns the policy shared by the entity's (or its descendants')
+/// animation components, or nil when they disagree — mirroring how
+/// `setAnimationPolicy` applies to every descendant. A nil result means a
+/// policy was set on an individual child rather than the asset root;
+/// callers building UI or LOD logic on top should treat it as "mixed"
+/// rather than assuming any single value.
+public func getAnimationPolicy(entityId: EntityID) -> AnimationPolicy? {
+    let animationComponents = animationComponentsForEntityOrDescendants(entityId: entityId)
+    guard let firstPolicy = animationComponents.first?.1.policy else {
         handleError(.noAnimationComponent, entityId)
-        return .inherit
+        return nil
     }
 
-    return animationComponent.policy
+    let allAgree = animationComponents.allSatisfy { _, animationComponent in
+        animationComponent.policy == firstPolicy
+    }
+    return allAgree ? firstPolicy : nil
 }
 
 public func pauseAnimationComponent(entityId: EntityID, isPaused: Bool) {

--- a/Tests/UntoldEngineTests/AnimationPolicyTests.swift
+++ b/Tests/UntoldEngineTests/AnimationPolicyTests.swift
@@ -60,11 +60,42 @@ final class AnimationPolicyTests: XCTestCase {
         XCTAssertEqual(getAnimationPolicy(entityId: entityId), .inherit)
     }
 
-    func testGetPolicyWithoutAnimationComponentReturnsInherit() {
+    func testGetPolicyWithoutAnimationComponentReturnsNil() {
         let bareEntity = createEntity()
         defer { destroyEntity(entityId: bareEntity) }
 
-        XCTAssertEqual(getAnimationPolicy(entityId: bareEntity), .inherit)
+        XCTAssertNil(getAnimationPolicy(entityId: bareEntity))
+    }
+
+    func testDivergentDescendantPoliciesReadBackAsNil() {
+        // A second animated child under a common root, with a policy set on
+        // one child directly instead of the root.
+        let rootId = createEntity()
+        registerComponent(entityId: rootId, componentType: LocalTransformComponent.self)
+        registerComponent(entityId: rootId, componentType: WorldTransformComponent.self)
+        registerComponent(entityId: rootId, componentType: ScenegraphComponent.self)
+        let siblingId = createEntity()
+        registerComponent(entityId: siblingId, componentType: AnimationComponent.self)
+        registerComponent(entityId: siblingId, componentType: LocalTransformComponent.self)
+        registerComponent(entityId: siblingId, componentType: WorldTransformComponent.self)
+        registerComponent(entityId: siblingId, componentType: ScenegraphComponent.self)
+        registerComponent(entityId: entityId, componentType: LocalTransformComponent.self)
+        registerComponent(entityId: entityId, componentType: WorldTransformComponent.self)
+        defer {
+            destroyEntity(entityId: siblingId)
+            destroyEntity(entityId: rootId)
+        }
+
+        setParent(childId: entityId, parentId: rootId)
+        setParent(childId: siblingId, parentId: rootId)
+
+        // Diverge: one child forced off, the other left at inherit.
+        setAnimationPolicy(entityId: entityId, policy: .forceOff)
+        XCTAssertNil(getAnimationPolicy(entityId: rootId), "Divergent descendant policies must not be masked")
+
+        // Setting on the root restores agreement.
+        setAnimationPolicy(entityId: rootId, policy: .forceOn)
+        XCTAssertEqual(getAnimationPolicy(entityId: rootId), .forceOn)
     }
 
     // MARK: - Hierarchical resolution

--- a/Tests/UntoldEngineTests/AnimationPolicyTests.swift
+++ b/Tests/UntoldEngineTests/AnimationPolicyTests.swift
@@ -1,0 +1,137 @@
+//
+//  AnimationPolicyTests.swift
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import simd
+@testable import UntoldEngine
+import XCTest
+
+@MainActor
+final class AnimationPolicyTests: XCTestCase {
+    var entityId: EntityID!
+
+    override func setUp() async throws {
+        resetEngineTestState()
+
+        entityId = createEntity()
+        registerComponent(entityId: entityId, componentType: SkeletonComponent.self)
+        registerComponent(entityId: entityId, componentType: AnimationComponent.self)
+        registerComponent(entityId: entityId, componentType: RenderComponent.self)
+        registerComponent(entityId: entityId, componentType: ScenegraphComponent.self)
+
+        let runtimeSkeleton = RuntimeSkeleton(
+            jointPaths: ["root"],
+            parentIndices: [nil],
+            bindTransforms: [.identity],
+            restTransforms: [.identity]
+        )
+        scene.get(component: SkeletonComponent.self, for: entityId)?.skeleton =
+            Skeleton(runtimeSkeleton: runtimeSkeleton)
+    }
+
+    override func tearDown() async throws {
+        destroyEntity(entityId: entityId)
+    }
+
+    private var animationComponent: AnimationComponent {
+        scene.get(component: AnimationComponent.self, for: entityId)!
+    }
+
+    // MARK: - Defaults and accessors
+
+    func testDefaultPolicyIsInherit() {
+        XCTAssertEqual(getAnimationPolicy(entityId: entityId), .inherit)
+    }
+
+    func testSetAndGetPolicyRoundTrip() {
+        setAnimationPolicy(entityId: entityId, policy: .forceOff)
+        XCTAssertEqual(getAnimationPolicy(entityId: entityId), .forceOff)
+
+        setAnimationPolicy(entityId: entityId, policy: .forceOn)
+        XCTAssertEqual(getAnimationPolicy(entityId: entityId), .forceOn)
+
+        setAnimationPolicy(entityId: entityId, policy: .inherit)
+        XCTAssertEqual(getAnimationPolicy(entityId: entityId), .inherit)
+    }
+
+    func testGetPolicyWithoutAnimationComponentReturnsInherit() {
+        let bareEntity = createEntity()
+        defer { destroyEntity(entityId: bareEntity) }
+
+        XCTAssertEqual(getAnimationPolicy(entityId: bareEntity), .inherit)
+    }
+
+    // MARK: - Hierarchical resolution
+
+    func testSetPolicyOnParentAppliesToDescendantComponents() {
+        let parentId = createEntity()
+        registerComponent(entityId: parentId, componentType: LocalTransformComponent.self)
+        registerComponent(entityId: parentId, componentType: WorldTransformComponent.self)
+        registerComponent(entityId: parentId, componentType: ScenegraphComponent.self)
+        registerComponent(entityId: entityId, componentType: LocalTransformComponent.self)
+        registerComponent(entityId: entityId, componentType: WorldTransformComponent.self)
+        defer { destroyEntity(entityId: parentId) }
+
+        setParent(childId: entityId, parentId: parentId)
+
+        // The parent itself has no AnimationComponent; the call must resolve
+        // to the child, matching the other animation APIs.
+        setAnimationPolicy(entityId: parentId, policy: .forceOff)
+
+        XCTAssertEqual(getAnimationPolicy(entityId: entityId), .forceOff)
+        XCTAssertEqual(getAnimationPolicy(entityId: parentId), .forceOff)
+    }
+
+    // MARK: - Playback gating
+
+    func testPolicyGate() {
+        animationComponent.policy = .inherit
+        XCTAssertTrue(animationPolicyAllowsPlayback(animationComponent))
+
+        animationComponent.policy = .forceOn
+        XCTAssertTrue(animationPolicyAllowsPlayback(animationComponent))
+
+        animationComponent.policy = .forceOff
+        XCTAssertFalse(animationPolicyAllowsPlayback(animationComponent))
+    }
+
+    func testForceOffFreezesPlaybackClock() {
+        animationComponent.currentTime = 1.25
+
+        setAnimationPolicy(entityId: entityId, policy: .forceOff)
+        AnimationSystem.shared.update(0.1)
+        XCTAssertEqual(animationComponent.currentTime, 1.25, "forceOff must freeze the playback clock")
+
+        setAnimationPolicy(entityId: entityId, policy: .inherit)
+        AnimationSystem.shared.update(0.1)
+        XCTAssertEqual(animationComponent.currentTime, 1.35, accuracy: 1e-5, "restoring the policy must resume the clock")
+    }
+
+    func testForceOffDoesNotTouchPauseState() {
+        pauseAnimationComponent(entityId: entityId, isPaused: true)
+        setAnimationPolicy(entityId: entityId, policy: .forceOff)
+        setAnimationPolicy(entityId: entityId, policy: .inherit)
+
+        XCTAssertTrue(
+            isAnimationComponentPaused(entityId: entityId),
+            "Policy round-trip must preserve the entity's own pause state"
+        )
+    }
+
+    func testGlobalDisableStillOverridesForceOn() {
+        animationComponent.currentTime = 0
+        setAnimationPolicy(entityId: entityId, policy: .forceOn)
+
+        AnimationSystem.shared.isEnabled = false
+        defer { AnimationSystem.shared.isEnabled = true }
+        AnimationSystem.shared.update(0.1)
+
+        XCTAssertEqual(animationComponent.currentTime, 0, "Global off has precedence over forceOn")
+    }
+}

--- a/docs/API/UsingAnimationSystem.md
+++ b/docs/API/UsingAnimationSystem.md
@@ -87,6 +87,8 @@ setAnimationPolicy(entityId: zombie, policy: .forceOff)
 // Restore the default layered behavior.
 setAnimationPolicy(entityId: zombie, policy: .inherit)
 
+// nil means descendants disagree (a policy was set on an individual
+// child instead of the asset root) — treat as "mixed".
 let policy = getAnimationPolicy(entityId: zombie)
 ```
 

--- a/docs/API/UsingAnimationSystem.md
+++ b/docs/API/UsingAnimationSystem.md
@@ -68,6 +68,40 @@ Once the animation is set up:
 
 ---
 
+## Controlling Which Entities Animate
+
+Animation can be controlled at two levels, with a clear precedence:
+
+1. **Global** — `AnimationSystem.shared.isEnabled`. When `false`, nothing
+   animates, regardless of any per-entity setting. Useful for packaged
+   builds, performance testing, or editing a static world.
+2. **Per entity** — each `AnimationComponent` carries an `AnimationPolicy`:
+   - `.inherit` (default): follow the effective value from the levels above.
+   - `.forceOn`: always animate (when the global toggle is on).
+   - `.forceOff`: never animate.
+
+```swift
+// Freeze one character while the rest of the scene keeps animating.
+setAnimationPolicy(entityId: zombie, policy: .forceOff)
+
+// Restore the default layered behavior.
+setAnimationPolicy(entityId: zombie, policy: .inherit)
+
+let policy = getAnimationPolicy(entityId: zombie)
+```
+
+Like the other animation APIs, `setAnimationPolicy` called on an asset root
+applies to every descendant that carries an `AnimationComponent`, so split
+or multi-mesh rigged assets behave as one actor.
+
+`.forceOff` freezes the entity's playback clock without touching its
+play/pause state — switching the policy back resumes exactly where the
+entity left off, with whatever pause state it had. This also makes
+`.forceOff` a cheap animation LOD lever: distant characters can be frozen
+and unfrozen without disturbing their playback state.
+
+---
+
 ## Tips and Best Practices
 
 - Name Animations Clearly: Use descriptive names like "running" or "jumping" to make it easier to manage multiple animations.


### PR DESCRIPTION
## Summary

Implements the **entity tier** of the layered animation control proposed in [discussion #801](https://github.com/untoldengine/UntoldEngine/discussions/801), following the precedence model endorsed there:

1. **Global** — `AnimationSystem.shared.isEnabled` off ⇒ nothing animates, regardless of policy (unchanged behavior, highest precedence).
2. **Per entity** — each `AnimationComponent` carries an `AnimationPolicy`: `.inherit` (default, follows the effective value from the levels above), `.forceOn` (always animates), `.forceOff` (never animates). `.inherit` and `.forceOn` diverge once per-view control exists — `.forceOn` will override a view-level pause.

Design points:
- `.forceOff` **freezes the playback clock without touching the entity's `pause` state** — restoring the policy resumes exactly where playback left off, with whatever play/pause state the entity had. This also makes it a cheap animation-LOD lever for freezing distant characters.
- `setAnimationPolicy` / `getAnimationPolicy` resolve hierarchical assets to descendant `AnimationComponent`s, matching the existing animation APIs, so split/multi-mesh rigs behave as one actor.
- Policy is runtime-only for now; scene persistence and the inspector dropdown belong with the per-view tier (editor work).
- How-to section added to `docs/API/UsingAnimationSystem.md`.

The per-view tier from #801 is deliberately out of scope: it needs editor view context that does not exist in the engine update loop.

Single commit cherry-picked onto current develop (ad9f35d2); first of the animation-stack follow-ups to the pose layer (next up, in order: inertialized transitions, root motion, foot IK, motion matching).

## Testing

`AnimationPolicyTests` (8 tests, all passing):
- Default policy is `.inherit`; set/get round-trip; entities without an `AnimationComponent` report `.inherit`
- Setting policy on a parent applies to descendant components (hierarchical resolution)
- Playback gate: `.forceOff` blocks, `.inherit`/`.forceOn` allow
- `.forceOff` freezes `currentTime` through a real `AnimationSystem.update`, and restoring the policy resumes the clock
- Policy round-trip preserves the entity's own pause state
- Global disable overrides `.forceOn`

Compiled-sampler suite still passes on this base.