### PR TITLE
[Feature] Add physics backend plugin interface

### DIFF
--- a/Sources/UntoldEngine/Physics/PhysicsBackend.swift
+++ b/Sources/UntoldEngine/Physics/PhysicsBackend.swift
@@ -1,0 +1,318 @@
+//
+//  PhysicsBackend.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import simd
+
+/// Simulation features a physics backend provides beyond basic integration.
+public struct PhysicsCapabilities: OptionSet, Hashable, Sendable {
+    public let rawValue: UInt32
+
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+    public static let collisions = PhysicsCapabilities(rawValue: 1 << 0)
+    public static let triggers = PhysicsCapabilities(rawValue: 1 << 1)
+    public static let raycast = PhysicsCapabilities(rawValue: 1 << 2)
+    public static let shapecast = PhysicsCapabilities(rawValue: 1 << 3)
+    public static let overlap = PhysicsCapabilities(rawValue: 1 << 4)
+    public static let constraints = PhysicsCapabilities(rawValue: 1 << 5)
+    public static let characterController = PhysicsCapabilities(rawValue: 1 << 6)
+    public static let meshColliders = PhysicsCapabilities(rawValue: 1 << 7)
+}
+
+/// How a body participates in simulation.
+public enum PhysicsMotionType: Hashable, Sendable {
+    /// Never moves; collides with dynamic bodies.
+    case `static`
+    /// Moved by game code; pushes dynamic bodies but is not pushed back.
+    case kinematic
+    /// Fully simulated.
+    case dynamic
+}
+
+/// Collision shape in body-local space. Dimensions are in metres.
+public enum PhysicsColliderShape: Hashable, Sendable {
+    case sphere(radius: Float)
+    case box(halfExtents: simd_float3)
+    /// Capsule aligned to the local Y axis; `height` is the cylindrical section, excluding caps.
+    case capsule(radius: Float, height: Float)
+    /// Cylinder aligned to the local Y axis.
+    case cylinder(radius: Float, height: Float)
+    case convexHull(vertices: [simd_float3])
+}
+
+/// World-level simulation settings. Units are metres, kilograms and seconds; Y is up.
+public struct PhysicsWorldConfiguration: Sendable {
+    public var gravity: simd_float3 = simd_float3(0.0, -9.8, 0.0)
+    /// Layer pair filter: `collisionLayerMatrix[layer]` is the bit mask of layers that
+    /// layer collides with. Empty means every pair collides.
+    public var collisionLayerMatrix: [UInt32] = []
+
+    public init() {}
+}
+
+/// Collider description snapshot handed to a backend when a body is created.
+public struct PhysicsColliderDescriptor: Hashable, Sendable {
+    public var shape: PhysicsColliderShape
+    public var localOffset: simd_float3
+    public var friction: Float
+    public var restitution: Float
+    public var isTrigger: Bool
+
+    public init(
+        shape: PhysicsColliderShape,
+        localOffset: simd_float3 = .zero,
+        friction: Float = 0.5,
+        restitution: Float = 0.0,
+        isTrigger: Bool = false
+    ) {
+        self.shape = shape
+        self.localOffset = localOffset
+        self.friction = friction
+        self.restitution = restitution
+        self.isTrigger = isTrigger
+    }
+}
+
+/// Complete body description snapshot handed to a backend when a body is created.
+public struct PhysicsBodyDescriptor: Sendable {
+    public var motionType: PhysicsMotionType
+    public var collider: PhysicsColliderDescriptor
+    public var mass: Float
+    public var layer: UInt32
+    public var collisionMask: UInt32
+    public var gravityScale: Float
+    public var position: simd_float3
+    public var orientation: simd_quatf
+    public var linearVelocity: simd_float3
+    public var angularVelocity: simd_float3
+
+    public init(
+        motionType: PhysicsMotionType,
+        collider: PhysicsColliderDescriptor,
+        mass: Float = 1.0,
+        layer: UInt32 = 0,
+        collisionMask: UInt32 = .max,
+        gravityScale: Float = 1.0,
+        position: simd_float3 = .zero,
+        orientation: simd_quatf = simd_quatf(ix: 0, iy: 0, iz: 0, r: 1),
+        linearVelocity: simd_float3 = .zero,
+        angularVelocity: simd_float3 = .zero
+    ) {
+        self.motionType = motionType
+        self.collider = collider
+        self.mass = mass
+        self.layer = layer
+        self.collisionMask = collisionMask
+        self.gravityScale = gravityScale
+        self.position = position
+        self.orientation = orientation
+        self.linearVelocity = linearVelocity
+        self.angularVelocity = angularVelocity
+    }
+}
+
+/// A rigid transform exchanged between the engine and a backend.
+public struct PhysicsBodyTransform: Sendable {
+    public var position: simd_float3
+    public var orientation: simd_quatf
+
+    public init(position: simd_float3, orientation: simd_quatf) {
+        self.position = position
+        self.orientation = orientation
+    }
+}
+
+/// Kinematic targets for a set of bodies, written by the engine before a step.
+/// `entities` and `transforms` are parallel and equal in length. The buffers are
+/// only valid for the duration of the call that receives them.
+public struct PhysicsBodyWriteBatch {
+    public let entities: UnsafeBufferPointer<EntityID>
+    public let transforms: UnsafeBufferPointer<PhysicsBodyTransform>
+
+    public init(
+        entities: UnsafeBufferPointer<EntityID>,
+        transforms: UnsafeBufferPointer<PhysicsBodyTransform>
+    ) {
+        self.entities = entities
+        self.transforms = transforms
+    }
+}
+
+/// Caller-supplied storage a backend fills with the transforms of its active bodies.
+/// `entities` and `transforms` are parallel; the backend writes at most `capacity`
+/// entries and returns the count written. The buffers are only valid for the
+/// duration of the call that receives them.
+public struct PhysicsTransformReadBatch {
+    public let entities: UnsafeMutableBufferPointer<EntityID>
+    public let transforms: UnsafeMutableBufferPointer<PhysicsBodyTransform>
+
+    public var capacity: Int {
+        min(entities.count, transforms.count)
+    }
+
+    public init(
+        entities: UnsafeMutableBufferPointer<EntityID>,
+        transforms: UnsafeMutableBufferPointer<PhysicsBodyTransform>
+    ) {
+        self.entities = entities
+        self.transforms = transforms
+    }
+}
+
+public enum PhysicsContactPhase: Hashable, Sendable {
+    case began
+    case persisted
+    case ended
+}
+
+public struct PhysicsContactEvent: Sendable {
+    public let phase: PhysicsContactPhase
+    public let entityA: EntityID
+    public let entityB: EntityID
+    public let position: simd_float3
+    public let normal: simd_float3
+    public let impulse: Float
+
+    public init(
+        phase: PhysicsContactPhase,
+        entityA: EntityID,
+        entityB: EntityID,
+        position: simd_float3,
+        normal: simd_float3,
+        impulse: Float
+    ) {
+        self.phase = phase
+        self.entityA = entityA
+        self.entityB = entityB
+        self.position = position
+        self.normal = normal
+        self.impulse = impulse
+    }
+}
+
+public enum PhysicsTriggerPhase: Hashable, Sendable {
+    case entered
+    case exited
+}
+
+public struct PhysicsTriggerEvent: Sendable {
+    public let phase: PhysicsTriggerPhase
+    public let triggerEntity: EntityID
+    public let otherEntity: EntityID
+
+    public init(phase: PhysicsTriggerPhase, triggerEntity: EntityID, otherEntity: EntityID) {
+        self.phase = phase
+        self.triggerEntity = triggerEntity
+        self.otherEntity = otherEntity
+    }
+}
+
+public struct PhysicsBodyActivationEvent: Sendable {
+    public let entity: EntityID
+    public let isActive: Bool
+
+    public init(entity: EntityID, isActive: Bool) {
+        self.entity = entity
+        self.isActive = isActive
+    }
+}
+
+/// Receives simulation events during `PhysicsBackend.drainEvents(into:)`.
+public protocol PhysicsEventSink: AnyObject {
+    func receiveContact(_ event: PhysicsContactEvent)
+    func receiveTrigger(_ event: PhysicsTriggerEvent)
+    func receiveActivation(_ event: PhysicsBodyActivationEvent)
+    /// Reports events discarded because a backend's fixed-capacity buffers overflowed.
+    func reportDroppedEvents(count: Int)
+}
+
+public struct PhysicsRay: Sendable {
+    public var origin: simd_float3
+    public var direction: simd_float3
+    public var maxDistance: Float
+
+    public init(origin: simd_float3, direction: simd_float3, maxDistance: Float = .greatestFiniteMagnitude) {
+        self.origin = origin
+        self.direction = direction
+        self.maxDistance = maxDistance
+    }
+}
+
+public struct PhysicsQueryFilter: Sendable {
+    public var layerMask: UInt32
+    public var excludedEntities: Set<EntityID>
+
+    public init(layerMask: UInt32 = .max, excludedEntities: Set<EntityID> = []) {
+        self.layerMask = layerMask
+        self.excludedEntities = excludedEntities
+    }
+}
+
+public struct PhysicsRayHit: Sendable {
+    public let entity: EntityID
+    public let position: simd_float3
+    public let normal: simd_float3
+    public let distance: Float
+
+    public init(entity: EntityID, position: simd_float3, normal: simd_float3, distance: Float) {
+        self.entity = entity
+        self.position = position
+        self.normal = normal
+        self.distance = distance
+    }
+}
+
+/// A physics simulation provider.
+///
+/// Threading contract: every method is called on the engine's frame thread. A backend
+/// may parallelize internally, but callbacks from its worker threads must never reach
+/// the engine — events are buffered inside the backend and handed over only through
+/// `drainEvents(into:)`, which the engine calls after `step(deltaTime:)` returns.
+///
+/// Data-transfer contract: transform exchange is batch-only. Backends must never be
+/// asked for — nor perform — one call per body per frame.
+public protocol PhysicsBackend: AnyObject {
+    var id: String { get }
+    var capabilities: PhysicsCapabilities { get }
+
+    func configure(_ config: PhysicsWorldConfiguration)
+
+    /// Called when an entity gains the components that make it a physics body.
+    func didAddBody(entity: EntityID, descriptor: PhysicsBodyDescriptor)
+    /// Called when a body entity is destroyed or loses its physics components.
+    func didRemoveBody(entity: EntityID)
+
+    /// Advances the simulation by one fixed substep.
+    func step(deltaTime: Float)
+
+    /// Delivers events buffered during the preceding `step`. Called on the frame thread.
+    func drainEvents(into sink: any PhysicsEventSink)
+
+    func writeKinematicTargets(_ batch: PhysicsBodyWriteBatch)
+
+    /// Fills `batch` with the transforms of active bodies; returns the count written.
+    func readActiveTransforms(into batch: PhysicsTransformReadBatch) -> Int
+
+    /// Requires the `.raycast` capability; backends without it return nil.
+    func raycast(_ ray: PhysicsRay, filter: PhysicsQueryFilter) -> PhysicsRayHit?
+}
+
+/// Default no-op implementations so minimal backends only implement what they support.
+public extension PhysicsBackend {
+    func didAddBody(entity _: EntityID, descriptor _: PhysicsBodyDescriptor) {}
+    func didRemoveBody(entity _: EntityID) {}
+    func drainEvents(into _: any PhysicsEventSink) {}
+    func writeKinematicTargets(_: PhysicsBodyWriteBatch) {}
+    func readActiveTransforms(into _: PhysicsTransformReadBatch) -> Int { 0 }
+    func raycast(_: PhysicsRay, filter _: PhysicsQueryFilter) -> PhysicsRayHit? { nil }
+}

--- a/Sources/UntoldEngine/Physics/PhysicsBackendRegistry.swift
+++ b/Sources/UntoldEngine/Physics/PhysicsBackendRegistry.swift
@@ -1,0 +1,318 @@
+//
+//  PhysicsBackendRegistry.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// Identifies the physics-backend contract understood by the engine and a plugin.
+public struct PhysicsBackendAPIVersion: RawRepresentable, Hashable, Codable, Comparable, Sendable {
+    /// The backend API implemented by this engine build.
+    public static let current = PhysicsBackendAPIVersion(1)
+
+    public let rawValue: UInt32
+
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+    public static func < (lhs: PhysicsBackendAPIVersion, rhs: PhysicsBackendAPIVersion) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+/// A backend plugin's release version.
+public struct PhysicsBackendVersion: Hashable, Codable, Comparable, Sendable, CustomStringConvertible {
+    public let major: UInt32
+    public let minor: UInt32
+    public let patch: UInt32
+
+    public init(major: UInt32, minor: UInt32, patch: UInt32) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+    }
+
+    public static func < (lhs: PhysicsBackendVersion, rhs: PhysicsBackendVersion) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        return lhs.patch < rhs.patch
+    }
+
+    public var description: String {
+        "\(major).\(minor).\(patch)"
+    }
+}
+
+/// Declares a physics backend plugin's stable identity, release version, and required engine contract.
+public struct PhysicsBackendPluginManifest: Hashable, Codable, Sendable {
+    public let id: String
+    public let displayName: String
+    public let version: PhysicsBackendVersion
+    public let requiredAPIVersion: PhysicsBackendAPIVersion
+
+    public init(
+        id: String,
+        displayName: String,
+        version: PhysicsBackendVersion,
+        requiredAPIVersion: PhysicsBackendAPIVersion = .current
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.version = version
+        self.requiredAPIVersion = requiredAPIVersion
+    }
+}
+
+/// A statically linked package or framework that provides a physics backend.
+public protocol PhysicsBackendPlugin: Sendable {
+    var manifest: PhysicsBackendPluginManifest { get }
+
+    /// Creates the backend supplied by this plugin for contract validation or installation.
+    func makeBackend() -> any PhysicsBackend
+}
+
+/// Describes a violation of the physics-backend plugin contract.
+public enum PhysicsBackendPluginValidationError: Error, Equatable, Sendable, CustomStringConvertible {
+    case emptyPluginID
+    case pluginIDMustBeNamespaced(String)
+    case emptyDisplayName(pluginID: String)
+    case unsupportedAPIVersion(
+        pluginID: String,
+        required: PhysicsBackendAPIVersion,
+        supported: PhysicsBackendAPIVersion
+    )
+    case emptyBackendID(pluginID: String)
+    case backendIDOutsidePluginNamespace(pluginID: String, backendID: String)
+
+    public var description: String {
+        switch self {
+        case .emptyPluginID:
+            return "Physics backend plugin IDs cannot be empty"
+        case let .pluginIDMustBeNamespaced(id):
+            return "Physics backend plugin ID '\(id)' must be a dot-separated package namespace"
+        case let .emptyDisplayName(pluginID):
+            return "Physics backend plugin '\(pluginID)' must provide a display name"
+        case let .unsupportedAPIVersion(pluginID, required, supported):
+            return "Physics backend plugin '\(pluginID)' requires API version \(required.rawValue), but the engine supports version \(supported.rawValue)"
+        case let .emptyBackendID(pluginID):
+            return "Physics backend plugin '\(pluginID)' provides a backend with an empty ID"
+        case let .backendIDOutsidePluginNamespace(pluginID, backendID):
+            return "Physics backend ID '\(backendID)' must equal or begin with plugin namespace '\(pluginID)'"
+        }
+    }
+}
+
+/// Validates plugin metadata and backend identity without installing anything.
+public enum PhysicsBackendPluginValidator {
+    public static func validate(
+        _ plugin: any PhysicsBackendPlugin,
+        supportedAPIVersion: PhysicsBackendAPIVersion = .current
+    ) -> [PhysicsBackendPluginValidationError] {
+        validate(
+            manifest: plugin.manifest,
+            backendID: plugin.makeBackend().id,
+            supportedAPIVersion: supportedAPIVersion
+        )
+    }
+
+    static func validate(
+        manifest: PhysicsBackendPluginManifest,
+        backendID: String,
+        supportedAPIVersion: PhysicsBackendAPIVersion = .current
+    ) -> [PhysicsBackendPluginValidationError] {
+        let pluginID = manifest.id
+        let trimmedPluginID = pluginID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasValidPluginID = isValidNamespace(pluginID)
+        var errors: [PhysicsBackendPluginValidationError] = []
+
+        if trimmedPluginID.isEmpty {
+            errors.append(.emptyPluginID)
+        } else if !hasValidPluginID {
+            errors.append(.pluginIDMustBeNamespaced(pluginID))
+        }
+        if manifest.displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            errors.append(.emptyDisplayName(pluginID: pluginID))
+        }
+        if manifest.requiredAPIVersion != supportedAPIVersion {
+            errors.append(
+                .unsupportedAPIVersion(
+                    pluginID: pluginID,
+                    required: manifest.requiredAPIVersion,
+                    supported: supportedAPIVersion
+                )
+            )
+        }
+        if backendID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            errors.append(.emptyBackendID(pluginID: pluginID))
+        } else if hasValidPluginID,
+                  backendID != pluginID,
+                  !backendID.hasPrefix("\(pluginID).")
+        {
+            errors.append(
+                .backendIDOutsidePluginNamespace(pluginID: pluginID, backendID: backendID)
+            )
+        }
+        return errors
+    }
+
+    private static func isValidNamespace(_ id: String) -> Bool {
+        guard id == id.trimmingCharacters(in: .whitespacesAndNewlines) else { return false }
+        let components = id.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count >= 2 else { return false }
+        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        return components.allSatisfy { component in
+            !component.isEmpty && component.unicodeScalars.allSatisfy(allowedCharacters.contains)
+        }
+    }
+}
+
+/// Collects the reasons a plugin installation was rejected.
+public struct PhysicsBackendPluginFailure: Equatable, Sendable {
+    public let validationErrors: [PhysicsBackendPluginValidationError]
+    /// Set when a different backend plugin is already installed.
+    public let conflictingPluginID: String?
+    /// Set when the registry was locked for runtime before the call.
+    public let registryLocked: Bool
+
+    public init(
+        validationErrors: [PhysicsBackendPluginValidationError] = [],
+        conflictingPluginID: String? = nil,
+        registryLocked: Bool = false
+    ) {
+        self.validationErrors = validationErrors
+        self.conflictingPluginID = conflictingPluginID
+        self.registryLocked = registryLocked
+    }
+}
+
+/// Reports whether a backend plugin was installed, replaced, or rejected atomically.
+public enum PhysicsBackendInstallationResult: Equatable, Sendable {
+    case installed
+    case replaced
+    case rejected(PhysicsBackendPluginFailure)
+}
+
+private struct InstalledPhysicsBackendPlugin {
+    let manifest: PhysicsBackendPluginManifest
+    let backend: any PhysicsBackend
+}
+
+/// Installs and removes the optional physics backend as serialized transactions.
+///
+/// At most one external backend is active at a time. Installing a plugin whose ID
+/// matches the active one replaces it; installing a different plugin while one is
+/// active is rejected — uninstall first. When no plugin is installed the engine
+/// uses its built-in integrator, exactly as before this registry existed.
+///
+/// Install before `UntoldRenderer.create(...)`. Once the engine locks the registry
+/// for runtime, install and uninstall are rejected.
+public final class PhysicsBackendRegistry: @unchecked Sendable {
+    public static let shared = PhysicsBackendRegistry()
+
+    private let lock = NSLock()
+    private var installedPlugin: InstalledPhysicsBackendPlugin?
+    private var failuresByPluginID: [String: PhysicsBackendPluginFailure] = [:]
+    private var lockedForRuntime = false
+
+    private init() {}
+
+    /// Validates and atomically installs or replaces the backend plugin.
+    @discardableResult
+    public func install(_ plugin: any PhysicsBackendPlugin) -> PhysicsBackendInstallationResult {
+        let manifest = plugin.manifest
+        let backend = plugin.makeBackend()
+        let validationErrors = PhysicsBackendPluginValidator.validate(
+            manifest: manifest,
+            backendID: backend.id
+        )
+        guard validationErrors.isEmpty else {
+            let failure = PhysicsBackendPluginFailure(validationErrors: validationErrors)
+            lock.lock()
+            failuresByPluginID[manifest.id] = failure
+            lock.unlock()
+            return .rejected(failure)
+        }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !lockedForRuntime else {
+            let failure = PhysicsBackendPluginFailure(registryLocked: true)
+            failuresByPluginID[manifest.id] = failure
+            return .rejected(failure)
+        }
+        if let active = installedPlugin, active.manifest.id != manifest.id {
+            let failure = PhysicsBackendPluginFailure(conflictingPluginID: active.manifest.id)
+            failuresByPluginID[manifest.id] = failure
+            return .rejected(failure)
+        }
+
+        let replacing = installedPlugin != nil
+        installedPlugin = InstalledPhysicsBackendPlugin(manifest: manifest, backend: backend)
+        failuresByPluginID.removeValue(forKey: manifest.id)
+        return replacing ? .replaced : .installed
+    }
+
+    /// Removes the backend plugin. Returns false if it is not installed or the registry is locked.
+    @discardableResult
+    public func uninstall(id: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !lockedForRuntime, installedPlugin?.manifest.id == id else {
+            return false
+        }
+        installedPlugin = nil
+        failuresByPluginID.removeValue(forKey: id)
+        return true
+    }
+
+    public func activeManifest() -> PhysicsBackendPluginManifest? {
+        lock.lock()
+        defer { lock.unlock() }
+        return installedPlugin?.manifest
+    }
+
+    public func activeBackend() -> (any PhysicsBackend)? {
+        lock.lock()
+        defer { lock.unlock() }
+        return installedPlugin?.backend
+    }
+
+    public func failure(forPluginID id: String) -> PhysicsBackendPluginFailure? {
+        lock.lock()
+        defer { lock.unlock() }
+        return failuresByPluginID[id]
+    }
+
+    /// Freezes the installed backend for the lifetime of the engine. Called during engine creation.
+    func lockForRuntime() {
+        lock.lock()
+        lockedForRuntime = true
+        lock.unlock()
+    }
+
+    var isLockedForRuntime: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return lockedForRuntime
+    }
+
+    /// Clears all state including the runtime lock. Test support only.
+    func resetForTesting() {
+        lock.lock()
+        installedPlugin = nil
+        failuresByPluginID.removeAll()
+        lockedForRuntime = false
+        lock.unlock()
+    }
+}

--- a/Sources/UntoldEngine/Physics/PhysicsComponents.swift
+++ b/Sources/UntoldEngine/Physics/PhysicsComponents.swift
@@ -1,0 +1,60 @@
+//
+//  PhysicsComponents.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import simd
+
+// ECS-facing components for the pluggable physics backend. Like
+// CameraComponent/LightComponent for render extensions, these are the shared,
+// engine-owned vocabulary every PhysicsBackend consumes; backends never define
+// their own component types.
+
+public class ColliderComponent: Component {
+    public var shape: PhysicsColliderShape = .sphere(radius: 0.5)
+    public var localOffset: simd_float3 = .zero
+    public var friction: Float = 0.5
+    public var restitution: Float = 0.0
+    public var isTrigger: Bool = false
+
+    public required init() {}
+}
+
+public class RigidBodyComponent: Component {
+    public var motionType: PhysicsMotionType = .dynamic
+    public var mass: Float = 1.0
+    public var layer: UInt32 = 0
+    public var collisionMask: UInt32 = .max
+    public var gravityScale: Float = 1.0
+    public var initialLinearVelocity: simd_float3 = .zero
+    public var initialAngularVelocity: simd_float3 = .zero
+
+    public required init() {}
+}
+
+/// Called from registerComponentCleanupHandlers() so physics component
+/// wiring stays in Physics/ instead of the shared registration list.
+func registerPhysicsComponentCleanupHandlers() {
+    ComponentRegistry.register(componentType: ColliderComponent.self, handlerId: "physicsBody", priority: 30) { entityId in
+        removeEntityPhysicsBody(entityId: entityId)
+    }
+    ComponentRegistry.register(componentType: RigidBodyComponent.self, handlerId: "physicsBody", priority: 30) { entityId in
+        removeEntityPhysicsBody(entityId: entityId)
+    }
+}
+
+func removeEntityPhysicsBody(entityId: EntityID) {
+    if scene.get(component: ColliderComponent.self, for: entityId) != nil {
+        scene.remove(component: ColliderComponent.self, from: entityId)
+    }
+
+    if scene.get(component: RigidBodyComponent.self, for: entityId) != nil {
+        scene.remove(component: RigidBodyComponent.self, from: entityId)
+    }
+}

--- a/Sources/UntoldEngine/Systems/RegistrationSystem.swift
+++ b/Sources/UntoldEngine/Systems/RegistrationSystem.swift
@@ -148,6 +148,8 @@ private func registerComponentCleanupHandlers() {
         removeEntityKinetics(entityId: entityId)
     }
 
+    registerPhysicsComponentCleanupHandlers()
+
     ComponentRegistry.register(componentType: LightComponent.self, handlerId: "light", priority: 30) { entityId in
         removeEntityLight(entityId: entityId)
     }

--- a/Tests/UntoldEngineTests/PhysicsBackendRegistryTests.swift
+++ b/Tests/UntoldEngineTests/PhysicsBackendRegistryTests.swift
@@ -1,0 +1,244 @@
+//
+//  PhysicsBackendRegistryTests.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import simd
+@testable import UntoldEngine
+import XCTest
+
+private final class MockPhysicsBackend: PhysicsBackend {
+    let id: String
+    let capabilities: PhysicsCapabilities
+    private(set) var configuration: PhysicsWorldConfiguration?
+    private(set) var stepCount = 0
+
+    init(id: String, capabilities: PhysicsCapabilities = []) {
+        self.id = id
+        self.capabilities = capabilities
+    }
+
+    func configure(_ config: PhysicsWorldConfiguration) {
+        configuration = config
+    }
+
+    func step(deltaTime _: Float) {
+        stepCount += 1
+    }
+}
+
+private struct MockBackendPlugin: PhysicsBackendPlugin {
+    let manifest: PhysicsBackendPluginManifest
+    let backendID: String
+
+    init(
+        pluginID: String = "com.example.mockphysics",
+        displayName: String = "Mock Physics",
+        requiredAPIVersion: PhysicsBackendAPIVersion = .current,
+        backendID: String? = nil
+    ) {
+        manifest = PhysicsBackendPluginManifest(
+            id: pluginID,
+            displayName: displayName,
+            version: PhysicsBackendVersion(major: 1, minor: 0, patch: 0),
+            requiredAPIVersion: requiredAPIVersion
+        )
+        self.backendID = backendID ?? pluginID
+    }
+
+    func makeBackend() -> any PhysicsBackend {
+        MockPhysicsBackend(id: backendID)
+    }
+}
+
+final class PhysicsBackendRegistryTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        PhysicsBackendRegistry.shared.resetForTesting()
+    }
+
+    override func tearDown() {
+        PhysicsBackendRegistry.shared.resetForTesting()
+        super.tearDown()
+    }
+
+    func testInstallValidPlugin() {
+        let result = PhysicsBackendRegistry.shared.install(MockBackendPlugin())
+
+        XCTAssertEqual(result, .installed)
+        XCTAssertEqual(PhysicsBackendRegistry.shared.activeManifest()?.id, "com.example.mockphysics")
+        XCTAssertEqual(PhysicsBackendRegistry.shared.activeBackend()?.id, "com.example.mockphysics")
+        XCTAssertNil(PhysicsBackendRegistry.shared.failure(forPluginID: "com.example.mockphysics"))
+    }
+
+    func testEmptyPluginIDIsRejected() {
+        let result = PhysicsBackendRegistry.shared.install(MockBackendPlugin(pluginID: "", backendID: "some.backend"))
+
+        guard case let .rejected(failure) = result else {
+            return XCTFail("Expected rejection, got \(result)")
+        }
+        XCTAssertTrue(failure.validationErrors.contains(.emptyPluginID))
+        XCTAssertNil(PhysicsBackendRegistry.shared.activeBackend())
+    }
+
+    func testNonNamespacedPluginIDIsRejected() {
+        let result = PhysicsBackendRegistry.shared.install(MockBackendPlugin(pluginID: "mockphysics"))
+
+        guard case let .rejected(failure) = result else {
+            return XCTFail("Expected rejection, got \(result)")
+        }
+        XCTAssertTrue(failure.validationErrors.contains(.pluginIDMustBeNamespaced("mockphysics")))
+    }
+
+    func testEmptyDisplayNameIsRejected() {
+        let result = PhysicsBackendRegistry.shared.install(MockBackendPlugin(displayName: "  "))
+
+        guard case let .rejected(failure) = result else {
+            return XCTFail("Expected rejection, got \(result)")
+        }
+        XCTAssertTrue(failure.validationErrors.contains(.emptyDisplayName(pluginID: "com.example.mockphysics")))
+    }
+
+    func testAPIVersionMismatchIsRejected() {
+        let result = PhysicsBackendRegistry.shared.install(
+            MockBackendPlugin(requiredAPIVersion: PhysicsBackendAPIVersion(99))
+        )
+
+        guard case let .rejected(failure) = result else {
+            return XCTFail("Expected rejection, got \(result)")
+        }
+        XCTAssertEqual(
+            failure.validationErrors,
+            [.unsupportedAPIVersion(
+                pluginID: "com.example.mockphysics",
+                required: PhysicsBackendAPIVersion(99),
+                supported: .current
+            )]
+        )
+    }
+
+    func testBackendIDOutsidePluginNamespaceIsRejected() {
+        let result = PhysicsBackendRegistry.shared.install(MockBackendPlugin(backendID: "org.other.backend"))
+
+        guard case let .rejected(failure) = result else {
+            return XCTFail("Expected rejection, got \(result)")
+        }
+        XCTAssertTrue(failure.validationErrors.contains(
+            .backendIDOutsidePluginNamespace(
+                pluginID: "com.example.mockphysics",
+                backendID: "org.other.backend"
+            )
+        ))
+    }
+
+    func testNamespacedBackendIDInsidePluginNamespaceIsAccepted() {
+        let result = PhysicsBackendRegistry.shared.install(
+            MockBackendPlugin(backendID: "com.example.mockphysics.world")
+        )
+
+        XCTAssertEqual(result, .installed)
+        XCTAssertEqual(PhysicsBackendRegistry.shared.activeBackend()?.id, "com.example.mockphysics.world")
+    }
+
+    func testSecondPluginWithDifferentIDIsRejected() {
+        PhysicsBackendRegistry.shared.install(MockBackendPlugin())
+        let result = PhysicsBackendRegistry.shared.install(MockBackendPlugin(pluginID: "com.example.otherphysics"))
+
+        guard case let .rejected(failure) = result else {
+            return XCTFail("Expected rejection, got \(result)")
+        }
+        XCTAssertEqual(failure.conflictingPluginID, "com.example.mockphysics")
+        XCTAssertEqual(
+            PhysicsBackendRegistry.shared.failure(forPluginID: "com.example.otherphysics"),
+            failure
+        )
+        XCTAssertEqual(PhysicsBackendRegistry.shared.activeManifest()?.id, "com.example.mockphysics")
+    }
+
+    func testReinstallingSamePluginIDReplaces() {
+        PhysicsBackendRegistry.shared.install(MockBackendPlugin())
+        let previousBackend = PhysicsBackendRegistry.shared.activeBackend()
+
+        let result = PhysicsBackendRegistry.shared.install(MockBackendPlugin())
+
+        XCTAssertEqual(result, .replaced)
+        XCTAssertNotNil(PhysicsBackendRegistry.shared.activeBackend())
+        XCTAssertTrue(PhysicsBackendRegistry.shared.activeBackend() !== previousBackend)
+    }
+
+    func testUninstall() {
+        PhysicsBackendRegistry.shared.install(MockBackendPlugin())
+
+        XCTAssertTrue(PhysicsBackendRegistry.shared.uninstall(id: "com.example.mockphysics"))
+        XCTAssertNil(PhysicsBackendRegistry.shared.activeBackend())
+        XCTAssertNil(PhysicsBackendRegistry.shared.activeManifest())
+    }
+
+    func testUninstallUnknownIDReturnsFalse() {
+        XCTAssertFalse(PhysicsBackendRegistry.shared.uninstall(id: "com.example.unknown"))
+
+        PhysicsBackendRegistry.shared.install(MockBackendPlugin())
+        XCTAssertFalse(PhysicsBackendRegistry.shared.uninstall(id: "com.example.unknown"))
+        XCTAssertNotNil(PhysicsBackendRegistry.shared.activeBackend())
+    }
+
+    func testLockedRegistryRejectsInstall() {
+        PhysicsBackendRegistry.shared.lockForRuntime()
+
+        let result = PhysicsBackendRegistry.shared.install(MockBackendPlugin())
+
+        guard case let .rejected(failure) = result else {
+            return XCTFail("Expected rejection, got \(result)")
+        }
+        XCTAssertTrue(failure.registryLocked)
+        XCTAssertNil(PhysicsBackendRegistry.shared.activeBackend())
+    }
+
+    func testLockedRegistryRejectsUninstall() {
+        PhysicsBackendRegistry.shared.install(MockBackendPlugin())
+        PhysicsBackendRegistry.shared.lockForRuntime()
+
+        XCTAssertFalse(PhysicsBackendRegistry.shared.uninstall(id: "com.example.mockphysics"))
+        XCTAssertNotNil(PhysicsBackendRegistry.shared.activeBackend())
+    }
+
+    func testValidationRejectionDoesNotDisturbActivePlugin() {
+        PhysicsBackendRegistry.shared.install(MockBackendPlugin())
+
+        let result = PhysicsBackendRegistry.shared.install(MockBackendPlugin(pluginID: "notnamespaced"))
+
+        guard case .rejected = result else {
+            return XCTFail("Expected rejection, got \(result)")
+        }
+        XCTAssertEqual(PhysicsBackendRegistry.shared.activeManifest()?.id, "com.example.mockphysics")
+    }
+
+    func testBackendDefaultImplementationsAreInert() {
+        let backend = MockPhysicsBackend(id: "com.example.mockphysics")
+
+        XCTAssertNil(backend.raycast(
+            PhysicsRay(origin: .zero, direction: simd_float3(0, -1, 0)),
+            filter: PhysicsQueryFilter()
+        ))
+
+        var entities = [EntityID](repeating: .invalid, count: 4)
+        var transforms = [PhysicsBodyTransform](
+            repeating: PhysicsBodyTransform(position: .zero, orientation: simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)),
+            count: 4
+        )
+        let written = entities.withUnsafeMutableBufferPointer { entityBuffer in
+            transforms.withUnsafeMutableBufferPointer { transformBuffer in
+                backend.readActiveTransforms(
+                    into: PhysicsTransformReadBatch(entities: entityBuffer, transforms: transformBuffer)
+                )
+            }
+        }
+        XCTAssertEqual(written, 0)
+    }
+}

--- a/Tests/UntoldEngineTests/TestEngineReset.swift
+++ b/Tests/UntoldEngineTests/TestEngineReset.swift
@@ -31,6 +31,7 @@
     EntityLifecycleEvents.shared.reset()
     PluginSpatialRegistry.shared.removeAll()
     RenderExtensionRegistry.shared.removeAll()
+    PhysicsBackendRegistry.shared.resetForTesting()
     for frame in 0 ..< 3 {
         tripleVisibleEntities.setWrite(frame: frame, with: [])
     }


### PR DESCRIPTION
## Summary

First PR of the narrowed phase-1 plan from discussion #1116 (PR A of four): the plugin-facing seam for optional physics backends. Per the agreed scope, **nothing invokes the new API yet — runtime behavior is unchanged by construction**, the current physics system remains untouched and the default, and no render-graph or ECS internals are modified. Rebased on current `develop` (includes the #1127 plugin-hosting infrastructure).

- `Sources/UntoldEngine/Physics/PhysicsBackend.swift` — `PhysicsBackend` protocol with the threading contract (step/drain on the frame thread, backends buffer worker-thread events internally) and batch-only transform transfer, plus all value types: `PhysicsCapabilities`, `PhysicsMotionType`, `PhysicsColliderShape`, `PhysicsWorldConfiguration` (gravity default `(0, -9.8, 0)`, collision layer matrix, m/kg/s units), body/collider descriptors, write/read transform batches, contact/trigger/activation events, `PhysicsEventSink`, ray query types. Default no-op implementations so minimal backends only implement what they support.
- `Sources/UntoldEngine/Physics/PhysicsBackendRegistry.swift` — `PhysicsBackendPlugin` + manifest + validator following the render-extension plugin conventions (namespaced IDs, exact API-version match, backend ID inside plugin namespace); single-slot registry with install/replace/reject semantics, uninstall, failure introspection, and a `lockForRuntime()` seam for engine creation (wired in PR B).
- `Sources/UntoldEngine/Physics/PhysicsComponents.swift` — `ColliderComponent` and `RigidBodyComponent`, the engine-owned ECS-facing vocabulary shared by all backends (same relationship as `CameraComponent`/`LightComponent` to render extensions). Kept out of the `Components.swift` grab bag per review; their cleanup handlers (handler ID `physicsBody`) are registered by a physics-scoped `registerPhysicsComponentCleanupHandlers()` in the same file, so the only touch outside `Physics/` is a one-line call in `registerComponentCleanupHandlers()`.
- 15 unit tests covering validation rejections, install/replace/uninstall, second-backend conflict, runtime lock, and inert default implementations. `PhysicsBackendRegistry` is also wired into the shared `resetEngineTestState()` alongside the other global registries (`EngineExtensionRegistry`, `RenderExtensionRegistry`, `PluginSpatialRegistry`), so cross-suite test isolation matches the #1127 conventions.

Follow-ups per the phase-1 plan, updated for the #1127 infrastructure: PR B (default backend wrap + `PhysicsCoordinator` conforming to `EngineExtension`, registered via `EngineExtensionRegistry.shared.register(_:)` with `fixedUpdate` driving `PhysicsBackendRegistry.shared.activeBackend()?.step` — no `runFrame` edits or engine-core changes), PR C (event sink + USC `OnCollision` wiring), PR D (raycast facade). The engine package keeps zero external dependencies and zero C++ — Jolt itself lives in a separate `UntoldJoltPhysics` package consuming only the public API.

## Test plan

- [x] `swift test --filter PhysicsBackendRegistryTests` — 15/15 pass
- [x] `ComponentRegistryTest` (enforces cleanup handlers for every component) and `ECSTests` pass — 41/41 across the three suites
- [x] Engine target builds clean against current `develop` (post-#1127); full-suite failures are limited to pre-existing GPU golden-image render tests that fail identically on clean `develop` on the same machine
