### PR TITLE
[Feature] Inertialized animation transitions

### DIFF
--- a/Sources/UntoldEngine/Animation/Inertialization.swift
+++ b/Sources/UntoldEngine/Animation/Inertialization.swift
@@ -1,0 +1,206 @@
+//
+//  Inertialization.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import simd
+
+// Inertialized animation transitions.
+//
+// Instead of crossfading two clips (which samples both for the whole blend
+// and averages them), an inertialized transition captures the *offset*
+// between the pose being displayed and the incoming clip's pose at the
+// moment of the switch — plus the offset's velocity — and decays that
+// offset to zero with a critically damped spring. After the transition
+// frame only the incoming clip is sampled; the decaying offset rides on
+// top. The result is continuous in both pose and velocity at the switch.
+//
+// Formulation follows Daniel Holden's exact spring damper
+// (theorangeduck.com, "Spring-It-On" / "Inertialization"), parameterized
+// by halflife. See docs/Architecture/animationPoseLayer.md.
+
+// MARK: - Spring damper
+
+private let ln2: Float = 0.693_147_180_559_945_3
+
+/// Advances a critically damped spring that decays `x` (and its velocity
+/// `v`) toward zero with the given halflife. Exact closed form — stable for
+/// any `deltaTime`.
+@inline(__always)
+func decaySpringDamper(
+    _ x: inout simd_float3,
+    _ v: inout simd_float3,
+    halflife: Float,
+    deltaTime: Float
+) {
+    let y = (4.0 * ln2) / max(halflife, 1e-5) * 0.5
+    let j1 = v + x * y
+    let eydt = exp(-y * deltaTime)
+    x = eydt * (x + j1 * deltaTime)
+    v = eydt * (v - j1 * y * deltaTime)
+}
+
+// MARK: - Rotation vector helpers
+
+/// Rotation vector (scaled angle-axis, `2·log(q)`) of a unit quaternion.
+/// The quaternion is flipped to the shortest arc first so offsets never
+/// take the long way around.
+@inline(__always)
+func toScaledAngleAxis(_ q: simd_quatf) -> simd_float3 {
+    let shortest = q.real < 0 ? simd_quatf(vector: -q.vector) : q
+    let imagLength = simd_length(shortest.imag)
+    guard imagLength > 1e-8 else {
+        // Small-angle approximation of 2·log(q).
+        return shortest.imag * (2.0 / max(shortest.real, 1e-8))
+    }
+    let angle = 2.0 * atan2(imagLength, shortest.real)
+    return (shortest.imag / imagLength) * angle
+}
+
+/// Unit quaternion from a rotation vector (inverse of `toScaledAngleAxis`).
+@inline(__always)
+func fromScaledAngleAxis(_ v: simd_float3) -> simd_quatf {
+    let angle = simd_length(v)
+    guard angle > 1e-8 else {
+        // Small-angle approximation of exp(v/2).
+        return simd_normalize(simd_quatf(ix: v.x * 0.5, iy: v.y * 0.5, iz: v.z * 0.5, r: 1))
+    }
+    return simd_quatf(angle: angle, axis: v / angle)
+}
+
+// MARK: - Pose transition state
+
+/// Per-entity inertialized transition: per-joint offsets between the pose
+/// displayed at the switch and the incoming clip, decayed to zero each
+/// frame and added on top of the incoming clip's sampled pose.
+struct PoseTransition {
+    private(set) var isActive = false
+    private var halflife: Float = 0
+    private var translationOffsets: [simd_float3] = []
+    private var translationVelocities: [simd_float3] = []
+    private var rotationOffsets: [simd_float3] = []
+    private var rotationVelocities: [simd_float3] = []
+
+    /// Scratch poses reused across transitions to sample the incoming clip
+    /// at its start time and one velocity step later.
+    var scratchTarget = PoseBuffer()
+    var scratchTargetNext = PoseBuffer()
+
+    /// Offsets whose squared magnitude never exceeds this are invisible;
+    /// the transition deactivates once every joint is below it.
+    private static let doneThreshold: Float = 1e-10
+
+    /// Captures transition offsets at the moment of a clip switch.
+    ///
+    /// - `sourcePose`: the pose displayed on screen last frame.
+    /// - `sourcePrevious`/`sourceDeltaTime`: the displayed pose one frame
+    ///   earlier, for velocity estimation (`hasSourcePrevious` false on the
+    ///   very first frame — source velocity is treated as zero).
+    /// - `targetPose`/`targetNext`/`targetDeltaTime`: the incoming clip at
+    ///   its start time and one small step later.
+    mutating func begin(
+        halflife: Float,
+        sourcePose: PoseBuffer,
+        sourcePrevious: PoseBuffer,
+        hasSourcePrevious: Bool,
+        sourceDeltaTime: Float,
+        targetPose: PoseBuffer,
+        targetNext: PoseBuffer,
+        targetDeltaTime: Float
+    ) {
+        let jointCount = sourcePose.jointCount
+        guard jointCount > 0,
+              targetPose.jointCount == jointCount,
+              targetNext.jointCount == jointCount,
+              targetDeltaTime > 0
+        else {
+            isActive = false
+            return
+        }
+
+        self.halflife = halflife
+        resize(jointCount: jointCount)
+
+        let useSourceVelocity = hasSourcePrevious
+            && sourcePrevious.jointCount == jointCount
+            && sourceDeltaTime > 0
+
+        for index in 0 ..< jointCount {
+            translationOffsets[index] = sourcePose.translations[index] - targetPose.translations[index]
+            rotationOffsets[index] = toScaledAngleAxis(
+                sourcePose.rotations[index] * targetPose.rotations[index].inverse
+            )
+
+            let targetVelocity = (targetNext.translations[index] - targetPose.translations[index]) / targetDeltaTime
+            let targetAngular = toScaledAngleAxis(
+                targetNext.rotations[index] * targetPose.rotations[index].inverse
+            ) / targetDeltaTime
+
+            if useSourceVelocity {
+                let sourceVelocity = (sourcePose.translations[index] - sourcePrevious.translations[index]) / sourceDeltaTime
+                let sourceAngular = toScaledAngleAxis(
+                    sourcePose.rotations[index] * sourcePrevious.rotations[index].inverse
+                ) / sourceDeltaTime
+                translationVelocities[index] = sourceVelocity - targetVelocity
+                rotationVelocities[index] = sourceAngular - targetAngular
+            } else {
+                translationVelocities[index] = -targetVelocity
+                rotationVelocities[index] = -targetAngular
+            }
+        }
+
+        isActive = true
+    }
+
+    /// Decays the offsets by `deltaTime` and adds them on top of the
+    /// incoming clip's sampled pose. Deactivates itself once every offset
+    /// is visually zero.
+    mutating func apply(to pose: inout PoseBuffer, deltaTime: Float) {
+        guard isActive, pose.jointCount == translationOffsets.count else { return }
+
+        var maxSquaredMagnitude: Float = 0
+        for index in 0 ..< pose.jointCount {
+            decaySpringDamper(
+                &translationOffsets[index], &translationVelocities[index],
+                halflife: halflife, deltaTime: deltaTime
+            )
+            decaySpringDamper(
+                &rotationOffsets[index], &rotationVelocities[index],
+                halflife: halflife, deltaTime: deltaTime
+            )
+
+            pose.translations[index] += translationOffsets[index]
+            pose.rotations[index] = simd_normalize(
+                fromScaledAngleAxis(rotationOffsets[index]) * pose.rotations[index]
+            )
+
+            maxSquaredMagnitude = max(
+                maxSquaredMagnitude,
+                simd_length_squared(translationOffsets[index]),
+                simd_length_squared(rotationOffsets[index])
+            )
+        }
+
+        if maxSquaredMagnitude < Self.doneThreshold {
+            isActive = false
+        }
+    }
+
+    mutating func cancel() {
+        isActive = false
+    }
+
+    private mutating func resize(jointCount: Int) {
+        guard translationOffsets.count != jointCount else { return }
+        translationOffsets = [simd_float3](repeating: .zero, count: jointCount)
+        translationVelocities = [simd_float3](repeating: .zero, count: jointCount)
+        rotationOffsets = [simd_float3](repeating: .zero, count: jointCount)
+        rotationVelocities = [simd_float3](repeating: .zero, count: jointCount)
+    }
+}

--- a/Sources/UntoldEngine/ECS/Components.swift
+++ b/Sources/UntoldEngine/ECS/Components.swift
@@ -194,6 +194,16 @@ public class AnimationComponent: Component {
     var sampler = ClipSampler()
     var localPose = PoseBuffer()
 
+    // Displayed-pose history for inertialized transitions: `localPose` holds
+    // the pose shown last frame (post-transition offsets), `previousPose`
+    // the frame before. The update loop ping-pongs the two buffers so
+    // steady-state playback never allocates.
+    var previousPose = PoseBuffer()
+    var hasSampledPose = false
+    var hasPreviousPose = false
+    var lastSampleDeltaTime: Float = 0
+    var transition = PoseTransition()
+
     public required init() {}
 
     func cleanUp() {
@@ -203,6 +213,11 @@ public class AnimationComponent: Component {
         compiledClips.removeAll()
         sampler = ClipSampler()
         localPose = PoseBuffer()
+        previousPose = PoseBuffer()
+        hasSampledPose = false
+        hasPreviousPose = false
+        lastSampleDeltaTime = 0
+        transition = PoseTransition()
     }
 
     func getAllAnimationClips() -> [String] {

--- a/Sources/UntoldEngine/Scenes/Builder/NodeCore/Node+Animations.swift
+++ b/Sources/UntoldEngine/Scenes/Builder/NodeCore/Node+Animations.swift
@@ -11,7 +11,7 @@
 @MainActor
 public protocol NodeAnimations: NodeProtocol {
     func setAnimations(resource: String, name: String) -> Self
-    func changeAnimation(name: String, withPause pause: Bool) -> Self
+    func changeAnimation(name: String, transitionHalflife: Float, withPause pause: Bool) -> Self
     func setAnimationPlaybackSpeed(speed: Float) -> Self
 }
 
@@ -22,8 +22,8 @@ public extension NodeAnimations {
         return self
     }
 
-    func changeAnimation(name: String, withPause pause: Bool = false) -> Self {
-        UntoldEngine.changeAnimation(entityId: entityID, name: name, withPause: pause)
+    func changeAnimation(name: String, transitionHalflife: Float = defaultAnimationTransitionHalflife, withPause pause: Bool = false) -> Self {
+        UntoldEngine.changeAnimation(entityId: entityID, name: name, transitionHalflife: transitionHalflife, withPause: pause)
         return self
     }
 

--- a/Sources/UntoldEngine/Scripting/USCBuilder.swift
+++ b/Sources/UntoldEngine/Scripting/USCBuilder.swift
@@ -539,8 +539,8 @@ public final class USCBuilder {
     // MARK: - Animation
 
     @discardableResult
-    public func playAnimation(_ name: String, loop: Bool = true) -> USCBuilder {
-        instructions.append(.playAnimation(entity: "self", name: name, loop: loop))
+    public func playAnimation(_ name: String, loop: Bool = true, transitionHalflife: Float? = nil) -> USCBuilder {
+        instructions.append(.playAnimation(entity: "self", name: name, loop: loop, transitionHalflife: transitionHalflife))
         return self
     }
 

--- a/Sources/UntoldEngine/Scripting/USCInstruction.swift
+++ b/Sources/UntoldEngine/Scripting/USCInstruction.swift
@@ -93,7 +93,9 @@ public enum USCInstruction: Codable {
     case lookAt(entity: String, target: String) // Orient towards target
 
     // Animation
-    case playAnimation(entity: String, name: String, loop: Bool)
+    // `transitionHalflife` is optional so scripts serialized before it
+    // existed still decode; nil means the engine default.
+    case playAnimation(entity: String, name: String, loop: Bool, transitionHalflife: Float?)
     case stopAnimation(entity: String)
 
     // Camera

--- a/Sources/UntoldEngine/Scripting/USCInterpreter.swift
+++ b/Sources/UntoldEngine/Scripting/USCInterpreter.swift
@@ -309,9 +309,12 @@ public class USCInterpreter: @unchecked Sendable {
                               offsetY: offsetYVal)
             return pc + 1
 
-        case let .playAnimation(entityRef, name, loop):
+        case let .playAnimation(entityRef, name, loop, transitionHalflife):
             let targetEntity = resolveEntity(entityRef, context: context)
-            changeAnimation(entityId: targetEntity, name: name, withPause: !loop)
+            changeAnimation(entityId: targetEntity,
+                            name: name,
+                            transitionHalflife: transitionHalflife ?? defaultAnimationTransitionHalflife,
+                            withPause: !loop)
             return pc + 1
 
         case let .stopAnimation(entityRef):

--- a/Sources/UntoldEngine/Systems/AnimationSystem.swift
+++ b/Sources/UntoldEngine/Systems/AnimationSystem.swift
@@ -173,6 +173,14 @@ private func updateAnimationSystem(deltaTime: Float) {
             for: animationClip,
             skeleton: skeletonComponent.skeleton
         )
+
+        // Preserve the pose displayed last frame (post-transition offsets)
+        // for velocity estimation when the next transition begins. Swapping
+        // the buffers avoids any copy; the sampler fully overwrites
+        // localPose below.
+        swap(&animationComponent.previousPose, &animationComponent.localPose)
+        animationComponent.hasPreviousPose = animationComponent.hasSampledPose
+
         animationComponent.sampler.sample(
             compiledClip,
             time: animationComponent.currentTime,
@@ -180,6 +188,15 @@ private func updateAnimationSystem(deltaTime: Float) {
             speed: animationClip.speed,
             into: &animationComponent.localPose
         )
+
+        // Transitions decay in real time, independent of playback speed.
+        animationComponent.transition.apply(
+            to: &animationComponent.localPose,
+            deltaTime: deltaTime
+        )
+        animationComponent.hasSampledPose = true
+        animationComponent.lastSampleDeltaTime = deltaTime
+
         skeletonComponent.skeleton.updateWorldPose(
             from: animationComponent.localPose,
             localScales: compiledClip.restScales
@@ -267,7 +284,14 @@ public func isAnimationComponentPaused(entityId: EntityID) -> Bool {
     }
 }
 
-public func changeAnimation(entityId: EntityID, name: String, withPause: Bool = false) {
+/// Switches the entity to the named clip.
+///
+/// With a positive `transitionHalflife`, the switch is inertialized: the
+/// offset between the pose on screen and the incoming clip is captured and
+/// decayed to zero with a critically damped spring, so the character eases
+/// into the new clip instead of popping. `transitionHalflife: 0` reproduces
+/// a hard cut. Playback restarts at the beginning of the new clip.
+public func changeAnimation(entityId: EntityID, name: String, transitionHalflife: Float = 0.1, withPause: Bool = false) {
     guard hasAnyAnimationComponent(entityId: entityId) else {
         handleError(.noAnimationComponent, entityId)
         return
@@ -279,10 +303,77 @@ public func changeAnimation(entityId: EntityID, name: String, withPause: Bool = 
         return
     }
 
-    for (_, animationComponent, animationClip) in matchingComponents {
+    for (targetEntityId, animationComponent, animationClip) in matchingComponents {
+        beginAnimationTransition(
+            entityId: targetEntityId,
+            animationComponent: animationComponent,
+            to: animationClip,
+            halflife: transitionHalflife
+        )
         animationComponent.currentAnimation = animationClip
+        animationComponent.currentTime = 0
         animationComponent.pause = withPause
     }
+}
+
+/// Captures inertialization offsets for a clip switch. Falls back to a hard
+/// cut (no transition) when there is nothing to blend from: no clip playing,
+/// no pose displayed yet, no skeleton, or a zero halflife.
+private func beginAnimationTransition(
+    entityId: EntityID,
+    animationComponent: AnimationComponent,
+    to clip: AnimationClip,
+    halflife: Float
+) {
+    guard halflife > 0,
+          animationComponent.currentAnimation != nil,
+          animationComponent.hasSampledPose,
+          let skeleton = scene.get(component: SkeletonComponent.self, for: entityId)?.skeleton
+    else {
+        animationComponent.transition.cancel()
+        return
+    }
+
+    let compiledClip = animationComponent.compiledClip(for: clip, skeleton: skeleton)
+    guard compiledClip.jointCount == animationComponent.localPose.jointCount else {
+        animationComponent.transition.cancel()
+        return
+    }
+
+    // Sample the incoming clip at its start and one small step later to
+    // estimate its initial velocity. The component sampler rebinds to the
+    // new clip here, which it would do on the next frame anyway.
+    let velocityStep: Float = 1.0 / 60.0
+    animationComponent.sampler.sample(
+        compiledClip,
+        time: 0,
+        duration: clip.duration,
+        speed: clip.speed,
+        into: &animationComponent.transition.scratchTarget
+    )
+    animationComponent.sampler.sample(
+        compiledClip,
+        time: velocityStep,
+        duration: clip.duration,
+        speed: clip.speed,
+        into: &animationComponent.transition.scratchTargetNext
+    )
+
+    // Copy the scratch poses out (COW, no allocation) so the mutating
+    // begin() call does not overlap a read of the same property.
+    let targetPose = animationComponent.transition.scratchTarget
+    let targetNext = animationComponent.transition.scratchTargetNext
+
+    animationComponent.transition.begin(
+        halflife: halflife,
+        sourcePose: animationComponent.localPose,
+        sourcePrevious: animationComponent.previousPose,
+        hasSourcePrevious: animationComponent.hasPreviousPose,
+        sourceDeltaTime: animationComponent.lastSampleDeltaTime,
+        targetPose: targetPose,
+        targetNext: targetNext,
+        targetDeltaTime: velocityStep
+    )
 }
 
 public func setAnimationPlaybackSpeed(entityId: EntityID, speed: Float) {

--- a/Sources/UntoldEngine/Systems/AnimationSystem.swift
+++ b/Sources/UntoldEngine/Systems/AnimationSystem.swift
@@ -284,6 +284,10 @@ public func isAnimationComponentPaused(entityId: EntityID) -> Bool {
     }
 }
 
+/// Default halflife for inertialized clip switches, shared by every public
+/// entry point (`changeAnimation`, the node builder, USC `.playAnimation`).
+public let defaultAnimationTransitionHalflife: Float = 0.1
+
 /// Switches the entity to the named clip.
 ///
 /// With a positive `transitionHalflife`, the switch is inertialized: the
@@ -291,7 +295,12 @@ public func isAnimationComponentPaused(entityId: EntityID) -> Bool {
 /// decayed to zero with a critically damped spring, so the character eases
 /// into the new clip instead of popping. `transitionHalflife: 0` reproduces
 /// a hard cut. Playback restarts at the beginning of the new clip.
-public func changeAnimation(entityId: EntityID, name: String, transitionHalflife: Float = 0.1, withPause: Bool = false) {
+///
+/// Calling this with the clip that is already playing is a no-op apart from
+/// the `withPause` flag: playback keeps its phase and any in-flight
+/// transition keeps decaying, so callers may reassert the current clip
+/// every frame without restarting it.
+public func changeAnimation(entityId: EntityID, name: String, transitionHalflife: Float = defaultAnimationTransitionHalflife, withPause: Bool = false) {
     guard hasAnyAnimationComponent(entityId: entityId) else {
         handleError(.noAnimationComponent, entityId)
         return
@@ -304,6 +313,10 @@ public func changeAnimation(entityId: EntityID, name: String, transitionHalflife
     }
 
     for (targetEntityId, animationComponent, animationClip) in matchingComponents {
+        guard animationComponent.currentAnimation !== animationClip else {
+            animationComponent.pause = withPause
+            continue
+        }
         beginAnimationTransition(
             entityId: targetEntityId,
             animationComponent: animationComponent,
@@ -364,11 +377,18 @@ private func beginAnimationTransition(
     let targetPose = animationComponent.transition.scratchTarget
     let targetNext = animationComponent.transition.scratchTargetNext
 
+    // While playback is frozen (pause or .forceOff) the update loop stops
+    // swapping pose history, so `previousPose`/`lastSampleDeltaTime` describe
+    // motion from before the freeze. The pose actually on screen is static —
+    // treat its velocity as zero instead of the stale history.
+    let isFrozen = animationComponent.pause
+        || animationPolicyAllowsPlayback(animationComponent) == false
+
     animationComponent.transition.begin(
         halflife: halflife,
         sourcePose: animationComponent.localPose,
         sourcePrevious: animationComponent.previousPose,
-        hasSourcePrevious: animationComponent.hasPreviousPose,
+        hasSourcePrevious: animationComponent.hasPreviousPose && !isFrozen,
         sourceDeltaTime: animationComponent.lastSampleDeltaTime,
         targetPose: targetPose,
         targetNext: targetNext,

--- a/Tests/UntoldEngineTests/AnimationInertializationTests.swift
+++ b/Tests/UntoldEngineTests/AnimationInertializationTests.swift
@@ -63,6 +63,23 @@ final class AnimationInertializationTests: XCTestCase {
         return AnimationClip(runtimeClip: RuntimeAnimationClip(name: name, duration: 2.0, channels: [rootChannel]))
     }
 
+    /// Clip whose root rises linearly from 0 to 2 over 2 s — a constant
+    /// upward velocity of 1 unit/s, for velocity-capture assertions.
+    private func makeRampClip(name: String) -> AnimationClip {
+        let rootChannel = RuntimeAnimationChannel(
+            jointPath: "root",
+            translations: [
+                .init(time: 0.0, value: simd_float3(0, 0, 0)),
+                .init(time: 2.0, value: simd_float3(0, 2, 0)),
+            ],
+            rotations: [
+                .init(time: 0.0, value: SIMD4<Float>(0, 0, 0, 1)),
+                .init(time: 2.0, value: SIMD4<Float>(0, 0, 0, 1)),
+            ]
+        )
+        return AnimationClip(runtimeClip: RuntimeAnimationClip(name: name, duration: 2.0, channels: [rootChannel]))
+    }
+
     private var animationComponent: AnimationComponent {
         scene.get(component: AnimationComponent.self, for: entityId)!
     }
@@ -216,6 +233,87 @@ final class AnimationInertializationTests: XCTestCase {
         let lateGap = abs(displayedRootHeight - 2.0)
 
         XCTAssertLessThan(lateGap, earlyGap * 0.1, "Offset must have decayed by an order of magnitude after 5 halflives")
+    }
+
+    // MARK: - Redundant calls
+
+    func testRedundantChangeAnimationDoesNotRestartPlayback() {
+        playAndSettle("low", frames: 30)
+        let timeBeforeCall = animationComponent.currentTime
+        XCTAssertGreaterThan(timeBeforeCall, 0)
+
+        changeAnimation(entityId: entityId, name: "low")
+
+        XCTAssertEqual(animationComponent.currentTime, timeBeforeCall,
+                       "Reasserting the playing clip must not reset its phase")
+        XCTAssertFalse(animationComponent.transition.isActive,
+                       "Reasserting the playing clip must not start a transition")
+    }
+
+    func testRedundantChangeAnimationKeepsInFlightTransition() {
+        playAndSettle("low")
+        changeAnimation(entityId: entityId, name: "high", transitionHalflife: 0.1)
+        for _ in 0 ..< 4 {
+            AnimationSystem.shared.update(deltaTime)
+        }
+        let timeMidTransition = animationComponent.currentTime
+        XCTAssertTrue(animationComponent.transition.isActive)
+
+        // A state machine reasserting "high" every frame must not restart it.
+        changeAnimation(entityId: entityId, name: "high", transitionHalflife: 0.1)
+
+        XCTAssertEqual(animationComponent.currentTime, timeMidTransition,
+                       "Redundant call mid-transition must not reset the clock")
+        XCTAssertTrue(animationComponent.transition.isActive,
+                      "The in-flight transition must keep decaying, not restart")
+    }
+
+    func testRedundantChangeAnimationStillAppliesPause() {
+        playAndSettle("low", frames: 30)
+        let timeBeforeCall = animationComponent.currentTime
+
+        changeAnimation(entityId: entityId, name: "low", withPause: true)
+        XCTAssertTrue(isAnimationComponentPaused(entityId: entityId))
+        XCTAssertEqual(animationComponent.currentTime, timeBeforeCall)
+
+        changeAnimation(entityId: entityId, name: "low", withPause: false)
+        XCTAssertFalse(isAnimationComponentPaused(entityId: entityId))
+        XCTAssertEqual(animationComponent.currentTime, timeBeforeCall)
+    }
+
+    // MARK: - Transitions from a frozen entity
+
+    func testTransitionFromPausedEntityIgnoresStaleVelocity() {
+        animationComponent.animationClips["ramp"] = makeRampClip(name: "ramp")
+
+        // Build up real upward velocity (1 unit/s), then freeze. The pose
+        // history now describes motion from before the pause.
+        changeAnimation(entityId: entityId, name: "ramp", transitionHalflife: 0)
+        for _ in 0 ..< 18 {
+            AnimationSystem.shared.update(deltaTime)
+        }
+        pauseAnimationComponent(entityId: entityId, isPaused: true)
+        for _ in 0 ..< 30 {
+            AnimationSystem.shared.update(deltaTime)
+        }
+        let heightAtSwitch = displayedRootHeight
+        XCTAssertGreaterThan(heightAtSwitch, 0.1)
+
+        // Switch to the static clip at height 0. The displayed pose has been
+        // static for the whole pause, so the captured source velocity must be
+        // zero — the offset decays straight down, never riding the stale
+        // upward velocity above the pose at the switch.
+        changeAnimation(entityId: entityId, name: "low", transitionHalflife: 0.1)
+        var maxHeight: Float = 0
+        for _ in 0 ..< 90 {
+            AnimationSystem.shared.update(deltaTime)
+            maxHeight = max(maxHeight, displayedRootHeight)
+        }
+
+        XCTAssertLessThanOrEqual(maxHeight, heightAtSwitch + 1e-4,
+                                 "Stale pre-pause velocity must not push the pose past where it froze")
+        XCTAssertEqual(displayedRootHeight, 0.0, accuracy: 0.02,
+                       "Pose must converge to the incoming clip")
     }
 
     func testRapidRetargetingStaysContinuous() {

--- a/Tests/UntoldEngineTests/AnimationInertializationTests.swift
+++ b/Tests/UntoldEngineTests/AnimationInertializationTests.swift
@@ -1,0 +1,237 @@
+//
+//  AnimationInertializationTests.swift
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import simd
+@testable import UntoldEngine
+import XCTest
+
+@MainActor
+final class AnimationInertializationTests: XCTestCase {
+    var entityId: EntityID!
+
+    private let deltaTime: Float = 1.0 / 90.0
+
+    override func setUp() async throws {
+        resetEngineTestState()
+
+        entityId = createEntity()
+        registerComponent(entityId: entityId, componentType: SkeletonComponent.self)
+        registerComponent(entityId: entityId, componentType: AnimationComponent.self)
+        registerComponent(entityId: entityId, componentType: RenderComponent.self)
+        registerComponent(entityId: entityId, componentType: ScenegraphComponent.self)
+
+        let runtimeSkeleton = RuntimeSkeleton(
+            jointPaths: ["root", "root/arm"],
+            parentIndices: [nil, 0],
+            bindTransforms: [.identity, simd_float4x4(translation: simd_float3(0, 1, 0))],
+            restTransforms: [.identity, simd_float4x4(translation: simd_float3(0, 1, 0))]
+        )
+        scene.get(component: SkeletonComponent.self, for: entityId)?.skeleton =
+            Skeleton(runtimeSkeleton: runtimeSkeleton)
+
+        let animationComponent = scene.get(component: AnimationComponent.self, for: entityId)!
+        animationComponent.animationClips["low"] = makeClip(name: "low", rootHeight: 0)
+        animationComponent.animationClips["high"] = makeClip(name: "high", rootHeight: 2)
+    }
+
+    override func tearDown() async throws {
+        destroyEntity(entityId: entityId)
+    }
+
+    /// Constant-pose clip whose root sits at `rootHeight` — the pose gap
+    /// between two of these clips is exactly the height difference, which
+    /// makes offset decay easy to assert against.
+    private func makeClip(name: String, rootHeight: Float) -> AnimationClip {
+        let rootChannel = RuntimeAnimationChannel(
+            jointPath: "root",
+            translations: [
+                .init(time: 0.0, value: simd_float3(0, rootHeight, 0)),
+                .init(time: 2.0, value: simd_float3(0, rootHeight, 0)),
+            ],
+            rotations: [
+                .init(time: 0.0, value: SIMD4<Float>(0, 0, 0, 1)),
+                .init(time: 2.0, value: SIMD4<Float>(0, 0, 0, 1)),
+            ]
+        )
+        return AnimationClip(runtimeClip: RuntimeAnimationClip(name: name, duration: 2.0, channels: [rootChannel]))
+    }
+
+    private var animationComponent: AnimationComponent {
+        scene.get(component: AnimationComponent.self, for: entityId)!
+    }
+
+    private func playAndSettle(_ name: String, frames: Int = 5) {
+        changeAnimation(entityId: entityId, name: name, transitionHalflife: 0)
+        for _ in 0 ..< frames {
+            AnimationSystem.shared.update(deltaTime)
+        }
+    }
+
+    private var displayedRootHeight: Float {
+        animationComponent.localPose.translations[0].y
+    }
+
+    // MARK: - Spring damper math
+
+    func testSpringDamperDecaysTowardZero() {
+        var x = simd_float3(1, 0, 0)
+        var v = simd_float3.zero
+        let halflife: Float = 0.1
+
+        let initial = simd_length(x)
+        var elapsed: Float = 0
+        while elapsed < halflife * 8 {
+            decaySpringDamper(&x, &v, halflife: halflife, deltaTime: 1.0 / 90.0)
+            elapsed += 1.0 / 90.0
+        }
+
+        XCTAssertLessThan(simd_length(x), initial * 0.01, "Offset must be under 1% after 8 halflives")
+        XCTAssertLessThan(simd_length(v), 0.1, "Velocity must settle with the offset")
+    }
+
+    func testSpringDamperIsStableForLargeTimeSteps() {
+        var x = simd_float3(1, 2, 3)
+        var v = simd_float3(-5, 4, 0)
+
+        decaySpringDamper(&x, &v, halflife: 0.1, deltaTime: 1.0)
+
+        XCTAssertLessThan(simd_length(x), 1e-2, "Exact form must not explode on a huge dt")
+    }
+
+    func testScaledAngleAxisRoundTrip() {
+        let rotations: [simd_quatf] = [
+            simd_quatf(angle: 0.7, axis: simd_normalize(simd_float3(1, 2, 3))),
+            simd_quatf(angle: -1.3, axis: simd_normalize(simd_float3(0, 1, 0))),
+            simd_quatf(angle: 0.0001, axis: simd_float3(1, 0, 0)),
+            simd_quatf(angle: 3.0, axis: simd_normalize(simd_float3(-1, 0, 1))),
+        ]
+
+        for rotation in rotations {
+            let roundTripped = fromScaledAngleAxis(toScaledAngleAxis(rotation))
+            // Compare as rotations (q and -q are the same rotation).
+            let dot = abs(simd_dot(rotation.vector, roundTripped.vector))
+            XCTAssertEqual(dot, 1.0, accuracy: 1e-5, "Round trip must preserve the rotation")
+        }
+    }
+
+    func testScaledAngleAxisTakesShortestArc() {
+        let rotation = simd_quatf(angle: 0.5, axis: simd_float3(0, 1, 0))
+        let negated = simd_quatf(vector: -rotation.vector)
+
+        let a = toScaledAngleAxis(rotation)
+        let b = toScaledAngleAxis(negated)
+        XCTAssertEqual(simd_length(a - b), 0, accuracy: 1e-5, "q and -q must produce the same rotation vector")
+        XCTAssertEqual(simd_length(a), 0.5, accuracy: 1e-5)
+    }
+
+    // MARK: - Hard cut
+
+    func testZeroHalflifeIsAHardCut() {
+        playAndSettle("low")
+
+        changeAnimation(entityId: entityId, name: "high", transitionHalflife: 0)
+        AnimationSystem.shared.update(deltaTime)
+
+        XCTAssertEqual(displayedRootHeight, 2.0, accuracy: 1e-5, "Zero halflife must pop straight to the new clip")
+        XCTAssertFalse(animationComponent.transition.isActive)
+    }
+
+    func testChangeAnimationResetsPlaybackClock() {
+        playAndSettle("low", frames: 30)
+        XCTAssertGreaterThan(animationComponent.currentTime, 0)
+
+        changeAnimation(entityId: entityId, name: "high", transitionHalflife: 0.1)
+        XCTAssertEqual(animationComponent.currentTime, 0, "New clip must start from its beginning")
+    }
+
+    func testFirstEverChangeAnimationFallsBackToHardCut() {
+        // No pose has been displayed yet — nothing to blend from.
+        changeAnimation(entityId: entityId, name: "high", transitionHalflife: 0.2)
+        XCTAssertFalse(animationComponent.transition.isActive)
+
+        AnimationSystem.shared.update(deltaTime)
+        XCTAssertEqual(displayedRootHeight, 2.0, accuracy: 1e-5)
+    }
+
+    // MARK: - Inertialized transition behavior
+
+    func testTransitionIsContinuousAtTheSwitch() {
+        playAndSettle("low")
+        let heightBeforeSwitch = displayedRootHeight
+
+        changeAnimation(entityId: entityId, name: "high", transitionHalflife: 0.15)
+        XCTAssertTrue(animationComponent.transition.isActive)
+        AnimationSystem.shared.update(deltaTime)
+
+        // One 90 Hz frame into a 0.15 s halflife transition, the pose must
+        // still be near the outgoing pose, not the incoming one.
+        let jump = abs(displayedRootHeight - heightBeforeSwitch)
+        XCTAssertLessThan(jump, 0.25, "Pose must not snap at the switch (moved \(jump) of a 2.0 gap)")
+    }
+
+    func testTransitionConvergesToIncomingClip() {
+        playAndSettle("low")
+
+        let halflife: Float = 0.1
+        changeAnimation(entityId: entityId, name: "high", transitionHalflife: halflife)
+
+        var elapsed: Float = 0
+        while elapsed < halflife * 10 {
+            AnimationSystem.shared.update(deltaTime)
+            elapsed += deltaTime
+        }
+
+        XCTAssertEqual(displayedRootHeight, 2.0, accuracy: 0.02, "Pose must converge to the incoming clip")
+    }
+
+    func testTransitionDeactivatesAfterSettling() {
+        playAndSettle("low")
+        changeAnimation(entityId: entityId, name: "high", transitionHalflife: 0.05)
+        XCTAssertTrue(animationComponent.transition.isActive)
+
+        for _ in 0 ..< 300 {
+            AnimationSystem.shared.update(deltaTime)
+        }
+
+        XCTAssertFalse(animationComponent.transition.isActive, "Settled transition must switch itself off")
+    }
+
+    func testTransitionGapShrinksOverTime() {
+        playAndSettle("low")
+        changeAnimation(entityId: entityId, name: "high", transitionHalflife: 0.1)
+
+        AnimationSystem.shared.update(deltaTime)
+        let earlyGap = abs(displayedRootHeight - 2.0)
+
+        for _ in 0 ..< 45 { // 0.5 s = 5 halflives
+            AnimationSystem.shared.update(deltaTime)
+        }
+        let lateGap = abs(displayedRootHeight - 2.0)
+
+        XCTAssertLessThan(lateGap, earlyGap * 0.1, "Offset must have decayed by an order of magnitude after 5 halflives")
+    }
+
+    func testRapidRetargetingStaysContinuous() {
+        playAndSettle("low")
+
+        changeAnimation(entityId: entityId, name: "high", transitionHalflife: 0.1)
+        for _ in 0 ..< 4 {
+            AnimationSystem.shared.update(deltaTime)
+        }
+        let heightMidTransition = displayedRootHeight
+
+        // Interrupt the half-finished transition and go back.
+        changeAnimation(entityId: entityId, name: "low", transitionHalflife: 0.1)
+        AnimationSystem.shared.update(deltaTime)
+
+        let jump = abs(displayedRootHeight - heightMidTransition)
+        XCTAssertLessThan(jump, 0.25, "Interrupting a transition must capture the displayed pose, not the clip pose")
+    }
+}

--- a/docs/API/UsingAnimationTransitions.md
+++ b/docs/API/UsingAnimationTransitions.md
@@ -1,0 +1,87 @@
+# Animation Transitions
+
+## Introduction
+
+When a character switches clips — idle to walk, walk to run — the engine
+eases it into the new clip instead of popping. The technique is
+**inertialization**: at the moment of the switch, the engine captures the
+difference between the pose on screen and the incoming clip's first pose
+(plus how fast that difference is changing), then decays that difference to
+zero with a critically damped spring while only the new clip plays.
+
+## Why Use It
+
+- **No pops.** The character's pose *and* its velocity are continuous at
+  the switch — a mid-stride walk-to-run doesn't snap legs to a new phase.
+- **Cheaper than crossfades.** A crossfade samples both clips for the whole
+  blend. An inertialized transition samples only the incoming clip after
+  the switch frame; the decaying offset is a handful of math operations per
+  joint.
+- **No blend-tree authoring.** Transitions work between any two clips with
+  no setup.
+
+## Step-by-Step Implementation
+
+Transitions are built into `changeAnimation`. If you already switch clips,
+you already have them:
+
+```swift
+// Eases into "running" with the default halflife (0.1 s).
+changeAnimation(entityId: player, name: "running")
+```
+
+Control the feel with `transitionHalflife` — the time it takes the offset
+to decay by roughly half:
+
+```swift
+// Snappier switch for a dodge.
+changeAnimation(entityId: player, name: "dodge", transitionHalflife: 0.05)
+
+// Lazier settle for an idle.
+changeAnimation(entityId: player, name: "idle", transitionHalflife: 0.25)
+
+// Exact hard cut (the old behavior).
+changeAnimation(entityId: player, name: "teleport", transitionHalflife: 0)
+```
+
+Playback of the new clip starts at its beginning, and `withPause` behaves
+as before.
+
+## What Happens Behind the Scenes
+
+1. On `changeAnimation`, the engine samples the incoming clip at its start
+   (and one small step later, to know its initial velocity).
+2. For every joint it stores an offset — translation as a vector, rotation
+   as a rotation vector (scaled angle-axis) — between the pose displayed
+   last frame and the incoming pose, plus the velocity difference.
+3. Every frame, each offset is advanced by an exact critically damped
+   spring toward zero and added on top of the incoming clip's sampled pose.
+4. When every offset is visually zero, the transition switches itself off.
+   There is no fixed blend duration; the spring runs until it settles
+   (visually, a few times the halflife).
+
+Transitions decay in real time, independent of the clip's playback speed.
+A transition that begins before the entity has ever displayed a pose (for
+example, right after scene load) falls back to a hard cut — there is
+nothing on screen to blend from.
+
+## Tips and Best Practices
+
+- Halflife, not duration: the pose covers half the remaining gap every
+  `transitionHalflife` seconds. As a rule of thumb the transition looks
+  settled after 4–6 halflives, so `0.1` reads as roughly a quarter-second
+  ease.
+- Very long halflives (> 0.5 s) make characters feel like they're moving
+  through syrup; prefer shorter values and let the spring's velocity
+  matching do the work.
+- Rapid-fire `changeAnimation` calls are safe: each new transition captures
+  the currently displayed pose, including any offset still decaying, so
+  chains of switches stay continuous.
+
+## Running the Feature
+
+1. Load two clips on an entity (see *Enabling Animation*).
+2. Enter game mode and call `changeAnimation` between them — from a key
+   press, a script, or AI.
+3. Compare with `transitionHalflife: 0` to see the hard cut the spring is
+   removing.

--- a/docs/API/UsingAnimationTransitions.md
+++ b/docs/API/UsingAnimationTransitions.md
@@ -47,6 +47,26 @@ changeAnimation(entityId: player, name: "teleport", transitionHalflife: 0)
 Playback of the new clip starts at its beginning, and `withPause` behaves
 as before.
 
+Calling `changeAnimation` with the clip that is **already playing** is a
+no-op apart from the `withPause` flag: playback keeps its phase and any
+in-flight transition keeps decaying. A state machine that defensively
+reasserts "make sure this entity is playing idle" every frame is safe — it
+won't restart the clip. To deliberately replay a clip from its beginning
+(a repeated hit reaction, for example), switch to another clip first or
+reset the component's time yourself.
+
+The same control is available from the other entry points:
+
+```swift
+// Scene-builder node API.
+MeshNode(name: "player", resource: "player.usdz")
+    .changeAnimation(name: "running", transitionHalflife: 0.05)
+
+// USC scripts — omit transitionHalflife to use the engine default.
+USCBuilder()
+    .playAnimation("running", transitionHalflife: 0.05)
+```
+
 ## What Happens Behind the Scenes
 
 1. On `changeAnimation`, the engine samples the incoming clip at its start
@@ -64,6 +84,10 @@ Transitions decay in real time, independent of the clip's playback speed.
 A transition that begins before the entity has ever displayed a pose (for
 example, right after scene load) falls back to a hard cut — there is
 nothing on screen to blend from.
+
+Switching clips on a **paused** (or `.forceOff`) entity captures the static
+pose on screen with zero velocity — the motion recorded before the freeze
+is not carried into the transition.
 
 ## Tips and Best Practices
 


### PR DESCRIPTION
## Summary

Next link in the animation chain after the pose layer and per-entity policy: `changeAnimation` previously swapped clips with an instant pop. It now performs an **inertialized transition** (Daniel Holden's formulation): at the switch it captures the per-joint offset — translation as a vector, rotation as a scaled angle-axis rotation vector — between the pose displayed on screen and the incoming clip's start pose, **plus the offset's velocity**, then decays that offset to zero with an exact critically damped spring while only the incoming clip is sampled. Continuous in pose *and* velocity at the switch; after the transition frame the cost is a handful of math ops per joint — no second clip is sampled, unlike a crossfade.

### API

```swift
changeAnimation(entityId: player, name: "running")                          // eases in, default 0.1 s halflife
changeAnimation(entityId: player, name: "dodge", transitionHalflife: 0.05)  // snappier
changeAnimation(entityId: player, name: "teleport", transitionHalflife: 0)  // exact old hard cut
```

- `changeAnimation` now also **resets `currentTime`** so the new clip starts at its beginning instead of an arbitrary phase (fixes a latent bug — previously the incoming clip resumed at whatever time the outgoing clip had reached).
- Falls back to a hard cut when there is nothing to blend from: no clip playing, no pose displayed yet (e.g. right after scene load), or no skeleton.
- Interrupting a live transition captures the *displayed* pose including the decaying offset, so rapid clip switches chain continuously.
- Transitions decay in real time, independent of clip playback speed; pause and `.forceOff` freeze them along with playback.
- Displayed-pose history is kept by ping-ponging two `PoseBuffer`s — steady-state playback still never allocates.

New `Animation/Inertialization.swift`: exact spring damper, quaternion log/exp (shortest-arc), and the `PoseTransition` per-entity state.

How-to guide: `docs/API/UsingAnimationTransitions.md`. Single commit cherry-picked onto current develop (bee8546a). Next in the chain: root motion, foot IK, motion matching.

## Testing

`AnimationInertializationTests` (12 tests, all passing):
- Spring damper: decays below 1% in 8 halflives, stable for a 1-second dt (exact closed form)
- Quaternion log/exp round-trips; q and −q map to the same (shortest-arc) rotation vector
- Zero halflife = exact hard cut; first-ever switch (no displayed pose) hard-cuts
- `currentTime` resets on switch
- C0 continuity at the switch (one frame in, pose is near the outgoing pose, not the incoming one)
- Convergence to the incoming clip; gap shrinks by >10× over 5 halflives; settled transitions deactivate themselves
- Interrupting a mid-flight transition stays continuous

Compiled-sampler and policy suites still pass on this base.