### PR TITLE
[Feature] Drive external physics backends via an EngineExtension coordinator

### DIFF
--- a/Sources/UntoldEngine/Physics/PhysicsBackendRegistry.swift
+++ b/Sources/UntoldEngine/Physics/PhysicsBackendRegistry.swift
@@ -214,8 +214,9 @@ private struct InstalledPhysicsBackendPlugin {
 /// active is rejected — uninstall first. When no plugin is installed the engine
 /// uses its built-in integrator, exactly as before this registry existed.
 ///
-/// Install before `UntoldRenderer.create(...)`. Once the engine locks the registry
-/// for runtime, install and uninstall are rejected.
+/// Install before `UntoldRenderer.create(...)`. The registry locks for runtime on
+/// the first fixed substep the coordinator simulates with the installed backend;
+/// from then on install and uninstall are rejected.
 public final class PhysicsBackendRegistry: @unchecked Sendable {
     public static let shared = PhysicsBackendRegistry()
 
@@ -244,22 +245,28 @@ public final class PhysicsBackendRegistry: @unchecked Sendable {
         }
 
         lock.lock()
-        defer { lock.unlock() }
 
         guard !lockedForRuntime else {
             let failure = PhysicsBackendPluginFailure(registryLocked: true)
             failuresByPluginID[manifest.id] = failure
+            lock.unlock()
             return .rejected(failure)
         }
         if let active = installedPlugin, active.manifest.id != manifest.id {
             let failure = PhysicsBackendPluginFailure(conflictingPluginID: active.manifest.id)
             failuresByPluginID[manifest.id] = failure
+            lock.unlock()
             return .rejected(failure)
         }
 
         let replacing = installedPlugin != nil
         installedPlugin = InstalledPhysicsBackendPlugin(manifest: manifest, backend: backend)
         failuresByPluginID.removeValue(forKey: manifest.id)
+        lock.unlock()
+
+        // Outside the lock: configures the backend and schedules the coordinator
+        // in EngineExtensionRegistry (idempotent for a replace of the same ID).
+        PhysicsCoordinator.shared.backendDidInstall(backend)
         return replacing ? .replaced : .installed
     }
 
@@ -267,12 +274,15 @@ public final class PhysicsBackendRegistry: @unchecked Sendable {
     @discardableResult
     public func uninstall(id: String) -> Bool {
         lock.lock()
-        defer { lock.unlock() }
         guard !lockedForRuntime, installedPlugin?.manifest.id == id else {
+            lock.unlock()
             return false
         }
         installedPlugin = nil
         failuresByPluginID.removeValue(forKey: id)
+        lock.unlock()
+
+        PhysicsCoordinator.shared.backendDidUninstall()
         return true
     }
 
@@ -314,5 +324,8 @@ public final class PhysicsBackendRegistry: @unchecked Sendable {
         failuresByPluginID.removeAll()
         lockedForRuntime = false
         lock.unlock()
+
+        PhysicsCoordinator.shared.backendDidUninstall()
+        PhysicsCoordinator.shared.resetForTesting()
     }
 }

--- a/Sources/UntoldEngine/Physics/PhysicsCoordinator.swift
+++ b/Sources/UntoldEngine/Physics/PhysicsCoordinator.swift
@@ -1,0 +1,262 @@
+//
+//  PhysicsCoordinator.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import simd
+
+/// Counts overflow reports and discards everything else. Event delivery to
+/// subscribers (and USC `OnCollision`) is wired in the physics-events PR;
+/// until then a backend's events are drained but go nowhere.
+final class InertPhysicsEventSink: PhysicsEventSink {
+    private(set) var droppedEventCount = 0
+
+    func receiveContact(_: PhysicsContactEvent) {}
+    func receiveTrigger(_: PhysicsTriggerEvent) {}
+    func receiveActivation(_: PhysicsBodyActivationEvent) {}
+    func reportDroppedEvents(count: Int) {
+        droppedEventCount += count
+    }
+
+    func reset() {
+        droppedEventCount = 0
+    }
+}
+
+/// Drives the installed external physics backend from the engine's
+/// fixed-timestep loop as an `EngineExtension` — no engine-core seams.
+///
+/// `PhysicsBackendRegistry` registers the coordinator with
+/// `EngineExtensionRegistry` when a backend plugin installs and unregisters it
+/// on uninstall, so with no backend installed nothing is scheduled and the
+/// engine behaves exactly as before. The built-in integrator is untouched
+/// either way: it keeps running for legacy `PhysicsComponents`/
+/// `KineticComponent` entities, while the external backend owns only entities
+/// carrying both `RigidBodyComponent` and `ColliderComponent`.
+///
+/// Each `fixedUpdate` (frame thread, once per fixed substep, right after
+/// `updatePhysicsSystem`):
+/// 1. locks `PhysicsBackendRegistry` for runtime on the first simulated substep,
+///    freezing the backend choice for the rest of the run;
+/// 2. diffs the current `RigidBodyComponent`+`ColliderComponent` query result
+///    against the backend's known-body set → `didAddBody`/`didRemoveBody`
+///    (destruction needs no extra hook: component cleanup removes the entity
+///    from the query and the diff picks it up);
+/// 3. batch-writes kinematic body targets;
+/// 4. steps the backend;
+/// 5. batch-reads active transforms back into `LocalTransformComponent` for
+///    dynamic bodies, marking them dirty for the scenegraph/octree exactly like
+///    the built-in integrator does;
+/// 6. drains buffered events.
+public final class PhysicsCoordinator: EngineExtension, @unchecked Sendable {
+    public static let shared = PhysicsCoordinator()
+
+    public let id = "com.untoldengine.physics.coordinator"
+
+    private let configLock = NSLock()
+    private var worldConfig = PhysicsWorldConfiguration()
+
+    // Frame-thread state: touched only from fixedUpdate and the install path,
+    // which the registry contract requires to happen before runtime starts.
+    private var knownBodies: Set<EntityID> = []
+    private var readbackEntities: [EntityID] = []
+    private var readbackTransforms: [PhysicsBodyTransform] = []
+    private var kinematicEntities: [EntityID] = []
+    private var kinematicTransforms: [PhysicsBodyTransform] = []
+    let eventSink = InertPhysicsEventSink()
+
+    private init() {}
+
+    // MARK: - World configuration
+
+    /// Applies world settings to the active backend immediately and to any
+    /// backend installed later. The built-in integrator reads `gravity` from
+    /// here as well, so legacy and backend-owned bodies share one gravity.
+    public func setWorldConfiguration(_ config: PhysicsWorldConfiguration) {
+        configLock.lock()
+        worldConfig = config
+        configLock.unlock()
+        PhysicsBackendRegistry.shared.activeBackend()?.configure(config)
+    }
+
+    public func worldConfiguration() -> PhysicsWorldConfiguration {
+        configLock.lock()
+        defer { configLock.unlock() }
+        return worldConfig
+    }
+
+    var worldGravity: simd_float3 {
+        configLock.lock()
+        defer { configLock.unlock() }
+        return worldConfig.gravity
+    }
+
+    // MARK: - Install hooks (called by PhysicsBackendRegistry, post-transaction)
+
+    func backendDidInstall(_ backend: any PhysicsBackend) {
+        backend.configure(worldConfiguration())
+        knownBodies.removeAll()
+        eventSink.reset()
+        EngineExtensionRegistry.shared.register(self)
+    }
+
+    func backendDidUninstall() {
+        EngineExtensionRegistry.shared.unregister(id: id)
+    }
+
+    // MARK: - EngineExtension
+
+    public func fixedUpdate(deltaTime: Float, context _: EngineExtensionUpdateContext) {
+        guard let backend = PhysicsBackendRegistry.shared.activeBackend() else { return }
+
+        if !PhysicsBackendRegistry.shared.isLockedForRuntime {
+            PhysicsBackendRegistry.shared.lockForRuntime()
+        }
+
+        syncBodySet(with: backend)
+        pushKinematicTargets(to: backend)
+        backend.step(deltaTime: deltaTime)
+        pullTransforms(from: backend)
+        backend.drainEvents(into: eventSink)
+    }
+
+    public func willUnregister() {
+        knownBodies.removeAll()
+    }
+
+    /// Restores defaults. Test support only.
+    func resetForTesting() {
+        configLock.lock()
+        worldConfig = PhysicsWorldConfiguration()
+        configLock.unlock()
+        knownBodies.removeAll()
+        eventSink.reset()
+    }
+
+    // MARK: - Body lifecycle
+
+    private func syncBodySet(with backend: any PhysicsBackend) {
+        let bodyEntities = queryEntities(with: [
+            RigidBodyComponent.self, ColliderComponent.self, LocalTransformComponent.self,
+        ])
+        let currentSet = Set(bodyEntities)
+
+        for entity in knownBodies.subtracting(currentSet) {
+            backend.didRemoveBody(entity: entity)
+            knownBodies.remove(entity)
+        }
+
+        for entity in bodyEntities where !knownBodies.contains(entity) {
+            guard let descriptor = makeBodyDescriptor(entityId: entity) else { continue }
+            backend.didAddBody(entity: entity, descriptor: descriptor)
+            knownBodies.insert(entity)
+        }
+    }
+
+    private func makeBodyDescriptor(entityId: EntityID) -> PhysicsBodyDescriptor? {
+        guard let rigidBody = scene.get(component: RigidBodyComponent.self, for: entityId),
+              let collider = scene.get(component: ColliderComponent.self, for: entityId),
+              let transform = scene.get(component: LocalTransformComponent.self, for: entityId)
+        else {
+            return nil
+        }
+
+        return PhysicsBodyDescriptor(
+            motionType: rigidBody.motionType,
+            collider: PhysicsColliderDescriptor(
+                shape: collider.shape,
+                localOffset: collider.localOffset,
+                friction: collider.friction,
+                restitution: collider.restitution,
+                isTrigger: collider.isTrigger
+            ),
+            mass: rigidBody.mass,
+            layer: rigidBody.layer,
+            collisionMask: rigidBody.collisionMask,
+            gravityScale: rigidBody.gravityScale,
+            position: transform.position,
+            orientation: transform.rotation,
+            linearVelocity: rigidBody.initialLinearVelocity,
+            angularVelocity: rigidBody.initialAngularVelocity
+        )
+    }
+
+    // MARK: - Transform transfer
+
+    private func pushKinematicTargets(to backend: any PhysicsBackend) {
+        kinematicEntities.removeAll(keepingCapacity: true)
+        kinematicTransforms.removeAll(keepingCapacity: true)
+
+        for entity in knownBodies {
+            guard let rigidBody = scene.get(component: RigidBodyComponent.self, for: entity),
+                  rigidBody.motionType == .kinematic,
+                  let transform = scene.get(component: LocalTransformComponent.self, for: entity)
+            else {
+                continue
+            }
+            kinematicEntities.append(entity)
+            kinematicTransforms.append(
+                PhysicsBodyTransform(position: transform.position, orientation: transform.rotation)
+            )
+        }
+
+        guard !kinematicEntities.isEmpty else { return }
+
+        kinematicEntities.withUnsafeBufferPointer { entities in
+            kinematicTransforms.withUnsafeBufferPointer { transforms in
+                backend.writeKinematicTargets(
+                    PhysicsBodyWriteBatch(entities: entities, transforms: transforms)
+                )
+            }
+        }
+    }
+
+    private func pullTransforms(from backend: any PhysicsBackend) {
+        let capacity = knownBodies.count
+        guard capacity > 0 else { return }
+
+        if readbackEntities.count < capacity {
+            readbackEntities = [EntityID](repeating: 0, count: capacity)
+            readbackTransforms = [PhysicsBodyTransform](
+                repeating: PhysicsBodyTransform(
+                    position: .zero,
+                    orientation: simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
+                ),
+                count: capacity
+            )
+        }
+
+        var written = 0
+        readbackEntities.withUnsafeMutableBufferPointer { entities in
+            readbackTransforms.withUnsafeMutableBufferPointer { transforms in
+                written = backend.readActiveTransforms(
+                    into: PhysicsTransformReadBatch(entities: entities, transforms: transforms)
+                )
+            }
+        }
+
+        guard written > 0 else { return }
+
+        for index in 0 ..< min(written, capacity) {
+            let entity = readbackEntities[index]
+            guard knownBodies.contains(entity),
+                  let rigidBody = scene.get(component: RigidBodyComponent.self, for: entity),
+                  rigidBody.motionType == .dynamic,
+                  let transform = scene.get(component: LocalTransformComponent.self, for: entity)
+            else {
+                continue
+            }
+
+            transform.position = readbackTransforms[index].position
+            transform.rotation = readbackTransforms[index].orientation
+            transform.transformDirty = true
+            anyTransformDirty = true
+        }
+    }
+}

--- a/Sources/UntoldEngine/Systems/PhysicsSystem.swift
+++ b/Sources/UntoldEngine/Systems/PhysicsSystem.swift
@@ -99,13 +99,14 @@ public func updatePhysicsSystem(deltaTime: Float) {
     let physicsId = getComponentId(for: PhysicsComponents.self)
     let transformId = getComponentId(for: LocalTransformComponent.self)
     let entities = queryEntitiesWithComponentIds([kineticId, physicsId, transformId], in: scene)
+    let gravity = PhysicsCoordinator.shared.worldGravity
 
     for entity in entities {
         if isPhysicsComponentPaused(entityId: entity) {
             continue
         }
 
-        addGravity(entityId: entity, gravity: simd_float3(0.0, -9.8, 0.0)) // add gravity
+        addGravity(entityId: entity, gravity: gravity)
         addDrag(entityId: entity, deltaTime: deltaTime)
         accumulateForces(entityId: entity, deltaTime: deltaTime) // Apply accumulated forces to acceleration
         accumulateMoment(entityId: entity, deltaTime: deltaTime)

--- a/Tests/UntoldEngineTests/PhysicsCoordinatorTests.swift
+++ b/Tests/UntoldEngineTests/PhysicsCoordinatorTests.swift
@@ -1,0 +1,377 @@
+//
+//  PhysicsCoordinatorTests.swift
+//  UntoldEngineTests
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import simd
+@testable import UntoldEngine
+import XCTest
+
+private final class RecordingPhysicsBackend: PhysicsBackend, @unchecked Sendable {
+    let id: String
+    let capabilities: PhysicsCapabilities = []
+
+    private(set) var configurations: [PhysicsWorldConfiguration] = []
+    private(set) var addedBodies: [(entity: EntityID, descriptor: PhysicsBodyDescriptor)] = []
+    private(set) var removedBodies: [EntityID] = []
+    private(set) var stepDeltas: [Float] = []
+    private(set) var kinematicWrites: [[(entity: EntityID, transform: PhysicsBodyTransform)]] = []
+    private(set) var drainCount = 0
+    private(set) var callOrder: [String] = []
+
+    /// Transforms handed back on the next `readActiveTransforms`.
+    var pendingReadback: [(entity: EntityID, transform: PhysicsBodyTransform)] = []
+    var droppedEventsToReport = 0
+
+    init(id: String = "com.example.recordingphysics") {
+        self.id = id
+    }
+
+    func configure(_ config: PhysicsWorldConfiguration) {
+        configurations.append(config)
+        callOrder.append("configure")
+    }
+
+    func didAddBody(entity: EntityID, descriptor: PhysicsBodyDescriptor) {
+        addedBodies.append((entity, descriptor))
+        callOrder.append("addBody")
+    }
+
+    func didRemoveBody(entity: EntityID) {
+        removedBodies.append(entity)
+        callOrder.append("removeBody")
+    }
+
+    func step(deltaTime: Float) {
+        stepDeltas.append(deltaTime)
+        callOrder.append("step")
+    }
+
+    func drainEvents(into sink: any PhysicsEventSink) {
+        drainCount += 1
+        callOrder.append("drain")
+        if droppedEventsToReport > 0 {
+            sink.reportDroppedEvents(count: droppedEventsToReport)
+        }
+    }
+
+    func writeKinematicTargets(_ batch: PhysicsBodyWriteBatch) {
+        var entries: [(EntityID, PhysicsBodyTransform)] = []
+        for index in 0 ..< batch.entities.count {
+            entries.append((batch.entities[index], batch.transforms[index]))
+        }
+        kinematicWrites.append(entries)
+        callOrder.append("writeKinematic")
+    }
+
+    func readActiveTransforms(into batch: PhysicsTransformReadBatch) -> Int {
+        callOrder.append("read")
+        let count = min(pendingReadback.count, batch.capacity)
+        for index in 0 ..< count {
+            batch.entities[index] = pendingReadback[index].entity
+            batch.transforms[index] = pendingReadback[index].transform
+        }
+        return count
+    }
+}
+
+private struct RecordingBackendPlugin: PhysicsBackendPlugin {
+    let manifest: PhysicsBackendPluginManifest
+    let backend: RecordingPhysicsBackend
+
+    init(pluginID: String = "com.example.recordingphysics") {
+        manifest = PhysicsBackendPluginManifest(
+            id: pluginID,
+            displayName: "Recording Physics",
+            version: PhysicsBackendVersion(major: 1, minor: 0, patch: 0),
+            requiredAPIVersion: .current
+        )
+        backend = RecordingPhysicsBackend(id: pluginID)
+    }
+
+    func makeBackend() -> any PhysicsBackend {
+        backend
+    }
+}
+
+@MainActor
+final class PhysicsCoordinatorTests: XCTestCase {
+    override func setUp() async throws {
+        resetEngineTestState()
+    }
+
+    override func tearDown() {
+        PhysicsBackendRegistry.shared.resetForTesting()
+        super.tearDown()
+    }
+
+    private func makeContext() -> EngineExtensionUpdateContext {
+        EngineExtensionUpdateContext(
+            viewport: SIMD2<Int>(640, 480),
+            immersionStyle: .none,
+            frameIndex: 0,
+            currentEye: 0,
+            isPrimaryEye: true
+        )
+    }
+
+    private func tick(_ deltaTime: Float = 1.0 / 60.0) {
+        PhysicsCoordinator.shared.fixedUpdate(deltaTime: deltaTime, context: makeContext())
+    }
+
+    @discardableResult
+    private func installRecordingPlugin() -> RecordingPhysicsBackend {
+        let plugin = RecordingBackendPlugin()
+        XCTAssertEqual(PhysicsBackendRegistry.shared.install(plugin), .installed)
+        return plugin.backend
+    }
+
+    private func makeBodyEntity(
+        motionType: PhysicsMotionType = .dynamic,
+        position: simd_float3 = .zero
+    ) -> EntityID {
+        let entityId = createEntity()
+        registerComponent(entityId: entityId, componentType: RigidBodyComponent.self)
+        registerComponent(entityId: entityId, componentType: ColliderComponent.self)
+        scene.get(component: RigidBodyComponent.self, for: entityId)?.motionType = motionType
+        scene.get(component: LocalTransformComponent.self, for: entityId)?.position = position
+        return entityId
+    }
+
+    // MARK: - Scheduling
+
+    func testInstallSchedulesCoordinatorAndUninstallRemovesIt() {
+        XCTAssertFalse(
+            EngineExtensionRegistry.shared.registeredIDs().contains(PhysicsCoordinator.shared.id)
+        )
+
+        installRecordingPlugin()
+        XCTAssertTrue(
+            EngineExtensionRegistry.shared.registeredIDs().contains(PhysicsCoordinator.shared.id)
+        )
+
+        XCTAssertTrue(PhysicsBackendRegistry.shared.uninstall(id: "com.example.recordingphysics"))
+        XCTAssertFalse(
+            EngineExtensionRegistry.shared.registeredIDs().contains(PhysicsCoordinator.shared.id)
+        )
+    }
+
+    func testInstallConfiguresBackendWithCurrentWorldConfiguration() {
+        var config = PhysicsWorldConfiguration()
+        config.gravity = simd_float3(0.0, -3.7, 0.0)
+        PhysicsCoordinator.shared.setWorldConfiguration(config)
+
+        let backend = installRecordingPlugin()
+        XCTAssertEqual(backend.configurations.count, 1)
+        XCTAssertEqual(backend.configurations.first?.gravity, simd_float3(0.0, -3.7, 0.0))
+    }
+
+    func testSetWorldConfigurationReconfiguresActiveBackend() {
+        let backend = installRecordingPlugin()
+        XCTAssertEqual(backend.configurations.count, 1)
+
+        var config = PhysicsWorldConfiguration()
+        config.gravity = simd_float3(0.0, -1.6, 0.0)
+        PhysicsCoordinator.shared.setWorldConfiguration(config)
+
+        XCTAssertEqual(backend.configurations.count, 2)
+        XCTAssertEqual(backend.configurations.last?.gravity, simd_float3(0.0, -1.6, 0.0))
+    }
+
+    func testFixedUpdateWithoutBackendIsInert() {
+        _ = makeBodyEntity()
+        tick()
+        // Nothing to assert beyond "no trap": no backend, no coordinator work.
+        XCTAssertFalse(PhysicsBackendRegistry.shared.isLockedForRuntime)
+    }
+
+    // MARK: - Runtime lock
+
+    func testFirstSimulatedSubstepLocksRegistry() {
+        installRecordingPlugin()
+        XCTAssertFalse(PhysicsBackendRegistry.shared.isLockedForRuntime)
+
+        tick()
+        XCTAssertTrue(PhysicsBackendRegistry.shared.isLockedForRuntime)
+
+        XCTAssertFalse(PhysicsBackendRegistry.shared.uninstall(id: "com.example.recordingphysics"))
+        if case .rejected = PhysicsBackendRegistry.shared.install(RecordingBackendPlugin()) {
+        } else {
+            XCTFail("Install after the first simulated substep should be rejected")
+        }
+    }
+
+    // MARK: - Body lifecycle
+
+    func testBodyEntityIsAddedWithDescriptorSnapshot() throws {
+        let backend = installRecordingPlugin()
+        let entityId = makeBodyEntity(position: simd_float3(1.0, 2.0, 3.0))
+
+        let rigidBody = scene.get(component: RigidBodyComponent.self, for: entityId)
+        rigidBody?.mass = 4.0
+        rigidBody?.layer = 2
+        rigidBody?.initialLinearVelocity = simd_float3(0.0, 0.0, 5.0)
+        let collider = scene.get(component: ColliderComponent.self, for: entityId)
+        collider?.shape = .box(halfExtents: simd_float3(0.5, 0.5, 0.5))
+        collider?.isTrigger = true
+
+        tick()
+
+        XCTAssertEqual(backend.addedBodies.count, 1)
+        let added = try XCTUnwrap(backend.addedBodies.first)
+        XCTAssertEqual(added.entity, entityId)
+        XCTAssertEqual(added.descriptor.motionType, .dynamic)
+        XCTAssertEqual(added.descriptor.mass, 4.0)
+        XCTAssertEqual(added.descriptor.layer, 2)
+        XCTAssertEqual(added.descriptor.position, simd_float3(1.0, 2.0, 3.0))
+        XCTAssertEqual(added.descriptor.linearVelocity, simd_float3(0.0, 0.0, 5.0))
+        XCTAssertEqual(added.descriptor.collider.shape, .box(halfExtents: simd_float3(0.5, 0.5, 0.5)))
+        XCTAssertTrue(added.descriptor.collider.isTrigger)
+
+        // Known bodies are not re-added on later substeps.
+        tick()
+        XCTAssertEqual(backend.addedBodies.count, 1)
+    }
+
+    func testEntityWithoutColliderIsNotABody() {
+        let backend = installRecordingPlugin()
+        let entityId = createEntity()
+        registerComponent(entityId: entityId, componentType: RigidBodyComponent.self)
+
+        tick()
+        XCTAssertTrue(backend.addedBodies.isEmpty)
+    }
+
+    func testDestroyedEntityIsRemovedFromBackend() {
+        let backend = installRecordingPlugin()
+        let entityId = makeBodyEntity()
+
+        tick()
+        XCTAssertEqual(backend.addedBodies.count, 1)
+
+        destroyEntity(entityId: entityId)
+        scene.finalizePendingDestroys()
+
+        tick()
+        XCTAssertEqual(backend.removedBodies, [entityId])
+    }
+
+    func testRemovingPhysicsComponentsRemovesBody() {
+        let backend = installRecordingPlugin()
+        let entityId = makeBodyEntity()
+
+        tick()
+        XCTAssertEqual(backend.addedBodies.count, 1)
+
+        scene.remove(component: RigidBodyComponent.self, from: entityId)
+
+        tick()
+        XCTAssertEqual(backend.removedBodies, [entityId])
+    }
+
+    // MARK: - Transform transfer
+
+    func testDynamicTransformReadbackUpdatesLocalTransform() throws {
+        let backend = installRecordingPlugin()
+        let entityId = makeBodyEntity(position: simd_float3(0.0, 10.0, 0.0))
+
+        let newOrientation = simd_quatf(angle: .pi / 2, axis: simd_float3(0.0, 1.0, 0.0))
+        backend.pendingReadback = [(
+            entityId,
+            PhysicsBodyTransform(position: simd_float3(0.0, 9.5, 0.0), orientation: newOrientation)
+        )]
+
+        anyTransformDirty = false
+        tick()
+
+        let transform = try XCTUnwrap(scene.get(component: LocalTransformComponent.self, for: entityId))
+        XCTAssertEqual(transform.position, simd_float3(0.0, 9.5, 0.0))
+        XCTAssertEqual(transform.rotation.vector, newOrientation.vector)
+        XCTAssertTrue(transform.transformDirty)
+        XCTAssertTrue(anyTransformDirty)
+    }
+
+    func testReadbackIgnoresKinematicAndUnknownEntities() throws {
+        let backend = installRecordingPlugin()
+        let kinematicId = makeBodyEntity(motionType: .kinematic, position: simd_float3(1.0, 0.0, 0.0))
+        let strangerId: EntityID = 987_654
+
+        backend.pendingReadback = [
+            (kinematicId, PhysicsBodyTransform(
+                position: simd_float3(5.0, 5.0, 5.0),
+                orientation: simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
+            )),
+            (strangerId, PhysicsBodyTransform(
+                position: simd_float3(6.0, 6.0, 6.0),
+                orientation: simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
+            )),
+        ]
+
+        tick()
+
+        let transform = try XCTUnwrap(scene.get(component: LocalTransformComponent.self, for: kinematicId))
+        XCTAssertEqual(transform.position, simd_float3(1.0, 0.0, 0.0))
+    }
+
+    func testKinematicTargetsAreBatchWritten() throws {
+        let backend = installRecordingPlugin()
+        let kinematicId = makeBodyEntity(motionType: .kinematic, position: simd_float3(2.0, 0.0, 2.0))
+        _ = makeBodyEntity(motionType: .dynamic)
+
+        tick()
+
+        XCTAssertEqual(backend.kinematicWrites.count, 1)
+        let write = try XCTUnwrap(backend.kinematicWrites.first)
+        XCTAssertEqual(write.count, 1)
+        XCTAssertEqual(write.first?.entity, kinematicId)
+        XCTAssertEqual(write.first?.transform.position, simd_float3(2.0, 0.0, 2.0))
+    }
+
+    // MARK: - Step orchestration
+
+    func testSubstepCallOrderAndEventDrain() {
+        let backend = installRecordingPlugin()
+        _ = makeBodyEntity(motionType: .kinematic)
+        backend.droppedEventsToReport = 3
+
+        tick(1.0 / 60.0)
+
+        XCTAssertEqual(backend.callOrder, ["configure", "addBody", "writeKinematic", "step", "read", "drain"])
+        XCTAssertEqual(backend.stepDeltas, [1.0 / 60.0])
+        XCTAssertEqual(backend.drainCount, 1)
+        XCTAssertEqual(PhysicsCoordinator.shared.eventSink.droppedEventCount, 3)
+    }
+
+    // MARK: - Built-in integrator gravity seam
+
+    func testBuiltInIntegratorReadsConfigurableGravity() {
+        let entityId = createEntity()
+        registerComponent(entityId: entityId, componentType: PhysicsComponents.self)
+        registerComponent(entityId: entityId, componentType: KineticComponent.self)
+        setMass(entityId: entityId, mass: 1.0)
+        setGravityScale(entityId: entityId, gravityScale: 1.0)
+
+        var config = PhysicsWorldConfiguration()
+        config.gravity = .zero
+        PhysicsCoordinator.shared.setWorldConfiguration(config)
+
+        updatePhysicsSystem(deltaTime: 1.0 / 60.0)
+        XCTAssertEqual(getVelocity(entityId: entityId), .zero)
+
+        PhysicsCoordinator.shared.setWorldConfiguration(PhysicsWorldConfiguration())
+        updatePhysicsSystem(deltaTime: 1.0 / 60.0)
+        XCTAssertLessThan(getVelocity(entityId: entityId).y, 0.0)
+    }
+
+    func testDefaultWorldConfigurationMatchesLegacyGravity() {
+        XCTAssertEqual(
+            PhysicsCoordinator.shared.worldConfiguration().gravity,
+            simd_float3(0.0, -9.8, 0.0)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

PR B of the narrowed phase-1 plan from discussion #1116 (follows #1123), reworked per your review guidance to sit entirely on the #1127 `EngineExtension` infrastructure — **no `runFrame` seam, no engine-core changes**. Rebased on current `develop` (post the repo-wide format commit); `make lint` passes clean on the branch. With no backend installed, nothing is even scheduled: the coordinator is only registered while a backend plugin is installed, so runtime behavior is unchanged by construction. The built-in integrator is untouched and keeps running legacy `PhysicsComponents`/`KineticComponent` entities in all cases (the coexistence rule from the plan).

- `Sources/UntoldEngine/Physics/PhysicsCoordinator.swift` — `PhysicsCoordinator` conforming to `EngineExtension` (`id: com.untoldengine.physics.coordinator`). Its `fixedUpdate` runs once per fixed substep right after `updatePhysicsSystem`, and per substep: (1) diffs the `RigidBodyComponent`+`ColliderComponent`+`LocalTransformComponent` query result against the backend's known-body set → `didAddBody`/`didRemoveBody` (entity destruction needs no extra hook — component cleanup drops the entity out of the query and the diff catches it); (2) batch-writes kinematic targets; (3) `backend.step`; (4) batch-reads active transforms back into `LocalTransformComponent` for dynamic bodies, marking `transformDirty`/`anyTransformDirty` exactly like the built-in integrator; (5) drains events into an inert sink (delivery/USC wiring is PR C).
- `PhysicsBackendRegistry` now registers the coordinator with `EngineExtensionRegistry.shared.register(_:)` on successful install (also pushing the current `PhysicsWorldConfiguration` to the backend) and unregisters it on uninstall — both outside the registry lock. The `lockForRuntime()` seam from #1123 is wired with zero core edits: the coordinator locks the registry on the first substep it simulates, freezing the backend choice for the run.
- Configurable gravity: `PhysicsCoordinator.setWorldConfiguration(_:)` applies to the active backend and to the built-in integrator, whose hardcoded `(0, -9.8, 0)` in `updatePhysicsSystem` now reads the same configuration (default identical, hoisted out of the per-entity loop).
- 15 unit tests with a recording mock backend: install/uninstall scheduling, world-config propagation, body add/remove lifecycle (destroy and component removal), descriptor snapshot fidelity, kinematic batch writes, dynamic read-back (including ignoring kinematic/unknown entities), per-substep call order, runtime lock, and built-in-integrator gravity parity/configurability.

Engine touch outside `Physics/`: one hoisted gravity read in `Systems/PhysicsSystem.swift` (3 lines). Follow-ups per the plan: PR C (event sink subscriptions + USC `OnCollision`), PR D (raycast facade).


## Test plan

- [x] `swift test --filter PhysicsCoordinatorTests` — 15/15 pass
- [x] `PhysicsBackendRegistryTests`, `ComponentRegistryTest`, `ECSTests`, `EngineExtensionLifecycleTest`, `CustomSystemTest` — all pass
- [x] Full `UntoldEngineTests` module: 1060 tests, no new failures (the one failure, `ExternalRenderExtensionPackageTests`, fails identically on clean `develop` on this machine)
