### PR TITLE
[Feature] Deliver physics backend events to subscribers and USC scripts

### DIFF
--- a/Sources/UntoldEngine/Physics/PhysicsCoordinator.swift
+++ b/Sources/UntoldEngine/Physics/PhysicsCoordinator.swift
@@ -11,24 +11,6 @@
 import Foundation
 import simd
 
-/// Counts overflow reports and discards everything else. Event delivery to
-/// subscribers (and USC `OnCollision`) is wired in the physics-events PR;
-/// until then a backend's events are drained but go nowhere.
-final class InertPhysicsEventSink: PhysicsEventSink {
-    private(set) var droppedEventCount = 0
-
-    func receiveContact(_: PhysicsContactEvent) {}
-    func receiveTrigger(_: PhysicsTriggerEvent) {}
-    func receiveActivation(_: PhysicsBodyActivationEvent) {}
-    func reportDroppedEvents(count: Int) {
-        droppedEventCount += count
-    }
-
-    func reset() {
-        droppedEventCount = 0
-    }
-}
-
 /// Drives the installed external physics backend from the engine's
 /// fixed-timestep loop as an `EngineExtension` — no engine-core seams.
 ///
@@ -69,7 +51,7 @@ public final class PhysicsCoordinator: EngineExtension, @unchecked Sendable {
     private var readbackTransforms: [PhysicsBodyTransform] = []
     private var kinematicEntities: [EntityID] = []
     private var kinematicTransforms: [PhysicsBodyTransform] = []
-    let eventSink = InertPhysicsEventSink()
+    let eventSink = PhysicsEventDispatchSink()
 
     private init() {}
 
@@ -102,7 +84,6 @@ public final class PhysicsCoordinator: EngineExtension, @unchecked Sendable {
     func backendDidInstall(_ backend: any PhysicsBackend) {
         backend.configure(worldConfiguration())
         knownBodies.removeAll()
-        eventSink.reset()
         EngineExtensionRegistry.shared.register(self)
     }
 
@@ -136,7 +117,7 @@ public final class PhysicsCoordinator: EngineExtension, @unchecked Sendable {
         worldConfig = PhysicsWorldConfiguration()
         configLock.unlock()
         knownBodies.removeAll()
-        eventSink.reset()
+        PhysicsEvents.shared.reset()
     }
 
     // MARK: - Body lifecycle

--- a/Sources/UntoldEngine/Physics/PhysicsEvents.swift
+++ b/Sources/UntoldEngine/Physics/PhysicsEvents.swift
@@ -1,0 +1,161 @@
+//
+//  PhysicsEvents.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// Subscription hub for physics simulation events, in the `FrameEvents` style.
+///
+/// Events originate in the active `PhysicsBackend`, which buffers them internally
+/// during `step` and hands them over on the frame thread when the coordinator calls
+/// `drainEvents(into:)` after each fixed substep. Handlers therefore run on the
+/// frame thread, once per event, in backend delivery order. Subscriptions can be
+/// created or cancelled from any thread.
+///
+/// With no external backend installed nothing is ever dispatched — the built-in
+/// integrator has no collision detection, so this hub is dormant, exactly as before.
+public final class PhysicsEvents: @unchecked Sendable {
+    public static let shared = PhysicsEvents()
+
+    private let lock = NSLock()
+    private var contactHandlers: [UUID: (PhysicsContactEvent) -> Void] = [:]
+    private var triggerHandlers: [UUID: (PhysicsTriggerEvent) -> Void] = [:]
+    private var activationHandlers: [UUID: (PhysicsBodyActivationEvent) -> Void] = [:]
+    private var totalDroppedEvents = 0
+
+    private init() {}
+
+    // MARK: - Subscriptions
+
+    public func onContact(_ handler: @escaping (PhysicsContactEvent) -> Void) -> EventSubscription {
+        subscribe(handler, into: \.contactHandlers)
+    }
+
+    public func onTrigger(_ handler: @escaping (PhysicsTriggerEvent) -> Void) -> EventSubscription {
+        subscribe(handler, into: \.triggerHandlers)
+    }
+
+    public func onActivation(_ handler: @escaping (PhysicsBodyActivationEvent) -> Void) -> EventSubscription {
+        subscribe(handler, into: \.activationHandlers)
+    }
+
+    /// Running total of events a backend discarded because its fixed-capacity
+    /// buffers overflowed. A growing number means handlers are missing events;
+    /// it never causes an allocation or error mid-step.
+    public var droppedEventCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return totalDroppedEvents
+    }
+
+    private func subscribe<Event>(
+        _ handler: @escaping (Event) -> Void,
+        into keyPath: ReferenceWritableKeyPath<PhysicsEvents, [UUID: (Event) -> Void]>
+    ) -> EventSubscription {
+        let id = UUID()
+        lock.lock()
+        self[keyPath: keyPath][id] = handler
+        lock.unlock()
+        return EventSubscription { [weak self] in
+            guard let self else { return }
+            lock.lock()
+            self[keyPath: keyPath].removeValue(forKey: id)
+            lock.unlock()
+        }
+    }
+
+    // MARK: - Dispatch (frame thread, called by the coordinator's sink)
+
+    func dispatchContact(_ event: PhysicsContactEvent) {
+        // Snapshot under the lock, invoke outside it, matching FrameEventDispatcher:
+        // handlers may subscribe or cancel reentrantly without deadlocking.
+        lock.lock()
+        let snapshot = Array(contactHandlers.values)
+        lock.unlock()
+        for handler in snapshot {
+            handler(event)
+        }
+    }
+
+    func dispatchTrigger(_ event: PhysicsTriggerEvent) {
+        lock.lock()
+        let snapshot = Array(triggerHandlers.values)
+        lock.unlock()
+        for handler in snapshot {
+            handler(event)
+        }
+    }
+
+    func dispatchActivation(_ event: PhysicsBodyActivationEvent) {
+        lock.lock()
+        let snapshot = Array(activationHandlers.values)
+        lock.unlock()
+        for handler in snapshot {
+            handler(event)
+        }
+    }
+
+    func recordDroppedEvents(count: Int) {
+        lock.lock()
+        totalDroppedEvents += count
+        lock.unlock()
+    }
+
+    /// Restores defaults. Test support only.
+    func reset() {
+        lock.lock()
+        contactHandlers.removeAll()
+        triggerHandlers.removeAll()
+        activationHandlers.removeAll()
+        totalDroppedEvents = 0
+        lock.unlock()
+    }
+}
+
+/// The coordinator's event sink: fans backend events out to `PhysicsEvents`
+/// subscribers and fires the corresponding USC script events.
+///
+/// USC wiring (runs once per event, on both involved entities):
+/// - `contactBegan` → `OnCollision`, plus `OnCollision:<name>` when the *other*
+///   entity has an explicit name (the builder's `onCollision(tag:)` form).
+/// - `triggerEntered`/`triggerExited` → `OnTriggerEnter`/`OnTriggerExit` on the
+///   trigger and the other entity, with the same named-tag variants.
+final class PhysicsEventDispatchSink: PhysicsEventSink {
+    func receiveContact(_ event: PhysicsContactEvent) {
+        PhysicsEvents.shared.dispatchContact(event)
+
+        if event.phase == .began {
+            fireScriptEvent("OnCollision", on: event.entityA, other: event.entityB)
+            fireScriptEvent("OnCollision", on: event.entityB, other: event.entityA)
+        }
+    }
+
+    func receiveTrigger(_ event: PhysicsTriggerEvent) {
+        PhysicsEvents.shared.dispatchTrigger(event)
+
+        let name = event.phase == .entered ? "OnTriggerEnter" : "OnTriggerExit"
+        fireScriptEvent(name, on: event.triggerEntity, other: event.otherEntity)
+        fireScriptEvent(name, on: event.otherEntity, other: event.triggerEntity)
+    }
+
+    func receiveActivation(_ event: PhysicsBodyActivationEvent) {
+        PhysicsEvents.shared.dispatchActivation(event)
+    }
+
+    func reportDroppedEvents(count: Int) {
+        PhysicsEvents.shared.recordDroppedEvents(count: count)
+    }
+
+    private func fireScriptEvent(_ eventName: String, on entityId: EntityID, other: EntityID) {
+        USCSystem.shared.triggerEvent(eventName, for: entityId)
+        if let otherName = entityNameMap[other], !otherName.isEmpty {
+            USCSystem.shared.triggerEvent("\(eventName):\(otherName)", for: entityId)
+        }
+    }
+}

--- a/Tests/UntoldEngineTests/PhysicsCoordinatorTests.swift
+++ b/Tests/UntoldEngineTests/PhysicsCoordinatorTests.swift
@@ -344,7 +344,7 @@ final class PhysicsCoordinatorTests: XCTestCase {
         XCTAssertEqual(backend.callOrder, ["configure", "addBody", "writeKinematic", "step", "read", "drain"])
         XCTAssertEqual(backend.stepDeltas, [1.0 / 60.0])
         XCTAssertEqual(backend.drainCount, 1)
-        XCTAssertEqual(PhysicsCoordinator.shared.eventSink.droppedEventCount, 3)
+        XCTAssertEqual(PhysicsEvents.shared.droppedEventCount, 3)
     }
 
     // MARK: - Built-in integrator gravity seam

--- a/Tests/UntoldEngineTests/PhysicsEventsTests.swift
+++ b/Tests/UntoldEngineTests/PhysicsEventsTests.swift
@@ -1,0 +1,316 @@
+//
+//  PhysicsEventsTests.swift
+//  UntoldEngineTests
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import simd
+@testable import UntoldEngine
+import XCTest
+
+private final class EventEmittingPhysicsBackend: PhysicsBackend, @unchecked Sendable {
+    let id: String
+    let capabilities: PhysicsCapabilities = [.collisions, .triggers]
+
+    var pendingContacts: [PhysicsContactEvent] = []
+    var pendingTriggers: [PhysicsTriggerEvent] = []
+    var pendingActivations: [PhysicsBodyActivationEvent] = []
+    var droppedEventsToReport = 0
+
+    init(id: String = "com.example.eventphysics") {
+        self.id = id
+    }
+
+    func configure(_: PhysicsWorldConfiguration) {}
+
+    func step(deltaTime _: Float) {}
+
+    func drainEvents(into sink: any PhysicsEventSink) {
+        for event in pendingContacts {
+            sink.receiveContact(event)
+        }
+        for event in pendingTriggers {
+            sink.receiveTrigger(event)
+        }
+        for event in pendingActivations {
+            sink.receiveActivation(event)
+        }
+        pendingContacts.removeAll()
+        pendingTriggers.removeAll()
+        pendingActivations.removeAll()
+
+        if droppedEventsToReport > 0 {
+            sink.reportDroppedEvents(count: droppedEventsToReport)
+            droppedEventsToReport = 0
+        }
+    }
+}
+
+private struct EventBackendPlugin: PhysicsBackendPlugin {
+    let manifest: PhysicsBackendPluginManifest
+    let backend: EventEmittingPhysicsBackend
+
+    init(pluginID: String = "com.example.eventphysics") {
+        manifest = PhysicsBackendPluginManifest(
+            id: pluginID,
+            displayName: "Event Physics",
+            version: PhysicsBackendVersion(major: 1, minor: 0, patch: 0),
+            requiredAPIVersion: .current
+        )
+        backend = EventEmittingPhysicsBackend(id: pluginID)
+    }
+
+    func makeBackend() -> any PhysicsBackend {
+        backend
+    }
+}
+
+@MainActor
+final class PhysicsEventsTests: XCTestCase {
+    private var subscriptions: [EventSubscription] = []
+
+    override func setUp() async throws {
+        resetEngineTestState()
+        initScriptingSystem()
+        USCSystem.shared.initialize()
+    }
+
+    override func tearDown() {
+        for subscription in subscriptions {
+            subscription.cancel()
+        }
+        subscriptions.removeAll()
+        gameMode = false
+        PhysicsBackendRegistry.shared.resetForTesting()
+        super.tearDown()
+    }
+
+    private func makeContext() -> EngineExtensionUpdateContext {
+        EngineExtensionUpdateContext(
+            viewport: SIMD2<Int>(640, 480),
+            immersionStyle: .none,
+            frameIndex: 0,
+            currentEye: 0,
+            isPrimaryEye: true
+        )
+    }
+
+    private func tick() {
+        PhysicsCoordinator.shared.fixedUpdate(deltaTime: 1.0 / 60.0, context: makeContext())
+    }
+
+    @discardableResult
+    private func installEventPlugin() -> EventEmittingPhysicsBackend {
+        let plugin = EventBackendPlugin()
+        XCTAssertEqual(PhysicsBackendRegistry.shared.install(plugin), .installed)
+        return plugin.backend
+    }
+
+    private func makeContact(
+        phase: PhysicsContactPhase,
+        entityA: EntityID,
+        entityB: EntityID
+    ) -> PhysicsContactEvent {
+        PhysicsContactEvent(
+            phase: phase,
+            entityA: entityA,
+            entityB: entityB,
+            position: simd_float3(0.0, 1.0, 0.0),
+            normal: simd_float3(0.0, 1.0, 0.0),
+            impulse: 2.5
+        )
+    }
+
+    // MARK: - Subscriptions
+
+    func testContactSubscriptionReceivesDrainedEvents() {
+        let backend = installEventPlugin()
+        let entityA = createEntity()
+        let entityB = createEntity()
+
+        var received: [PhysicsContactEvent] = []
+        subscriptions.append(PhysicsEvents.shared.onContact { received.append($0) })
+
+        backend.pendingContacts = [makeContact(phase: .began, entityA: entityA, entityB: entityB)]
+        tick()
+
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(received.first?.phase, .began)
+        XCTAssertEqual(received.first?.entityA, entityA)
+        XCTAssertEqual(received.first?.entityB, entityB)
+        XCTAssertEqual(received.first?.impulse, 2.5)
+
+        // Nothing queued → nothing dispatched on later substeps.
+        tick()
+        XCTAssertEqual(received.count, 1)
+    }
+
+    func testCancelledSubscriptionStopsReceiving() {
+        let backend = installEventPlugin()
+
+        var received = 0
+        let subscription = PhysicsEvents.shared.onContact { _ in received += 1 }
+
+        backend.pendingContacts = [makeContact(phase: .began, entityA: 1, entityB: 2)]
+        tick()
+        XCTAssertEqual(received, 1)
+
+        subscription.cancel()
+        backend.pendingContacts = [makeContact(phase: .persisted, entityA: 1, entityB: 2)]
+        tick()
+        XCTAssertEqual(received, 1)
+    }
+
+    func testTriggerAndActivationSubscriptions() {
+        let backend = installEventPlugin()
+
+        var triggers: [PhysicsTriggerEvent] = []
+        var activations: [PhysicsBodyActivationEvent] = []
+        subscriptions.append(PhysicsEvents.shared.onTrigger { triggers.append($0) })
+        subscriptions.append(PhysicsEvents.shared.onActivation { activations.append($0) })
+
+        backend.pendingTriggers = [
+            PhysicsTriggerEvent(phase: .entered, triggerEntity: 7, otherEntity: 9),
+        ]
+        backend.pendingActivations = [
+            PhysicsBodyActivationEvent(entity: 9, isActive: false),
+        ]
+        tick()
+
+        XCTAssertEqual(triggers.count, 1)
+        XCTAssertEqual(triggers.first?.phase, .entered)
+        XCTAssertEqual(activations.count, 1)
+        XCTAssertEqual(activations.first?.isActive, false)
+    }
+
+    func testDormantWithoutBackend() {
+        var received = 0
+        subscriptions.append(PhysicsEvents.shared.onContact { _ in received += 1 })
+
+        tick()
+        XCTAssertEqual(received, 0)
+        XCTAssertEqual(PhysicsEvents.shared.droppedEventCount, 0)
+    }
+
+    func testDroppedEventsAccumulateAcrossSubsteps() {
+        let backend = installEventPlugin()
+
+        backend.droppedEventsToReport = 3
+        tick()
+        backend.droppedEventsToReport = 2
+        tick()
+
+        XCTAssertEqual(PhysicsEvents.shared.droppedEventCount, 5)
+    }
+
+    // MARK: - USC wiring
+
+    private func attachScript(
+        _ build: (USCBuilder) -> USCBuilder,
+        named name: String,
+        to entityId: EntityID,
+        recording flagName: String,
+        into counter: @escaping () -> Void
+    ) {
+        USCActionRegistry.shared.register(name: flagName) { _, _ in
+            counter()
+            return nil
+        }
+        let builder = USCBuilder()
+        _ = build(builder).callAction(flagName)
+        let script = builder.build(name: name)
+        USCSystem.shared.attachScript(script, to: entityId)
+    }
+
+    func testContactBeganFiresUSCOnCollision() {
+        gameMode = true
+        let backend = installEventPlugin()
+        let scripted = createEntity()
+        let other = createEntity()
+
+        var hits = 0
+        attachScript({ $0.onCollision() }, named: "HitScript", to: scripted,
+                     recording: "recordHit", into: { hits += 1 })
+
+        backend.pendingContacts = [makeContact(phase: .began, entityA: scripted, entityB: other)]
+        tick()
+        XCTAssertEqual(hits, 1, "contactBegan must fire OnCollision on the scripted entity")
+
+        // Later phases of the same contact must not re-fire the collision event.
+        backend.pendingContacts = [
+            makeContact(phase: .persisted, entityA: scripted, entityB: other),
+            makeContact(phase: .ended, entityA: scripted, entityB: other),
+        ]
+        tick()
+        XCTAssertEqual(hits, 1)
+    }
+
+    func testContactFiresTaggedOnCollisionForNamedOther() {
+        gameMode = true
+        let backend = installEventPlugin()
+        let scripted = createEntity()
+        let ball = createEntity()
+        setEntityName(entityId: ball, name: "Ball")
+
+        var taggedHits = 0
+        attachScript({ $0.onCollision(tag: "Ball") }, named: "BallScript", to: scripted,
+                     recording: "recordBallHit", into: { taggedHits += 1 })
+
+        // Contact with an unnamed entity: the tagged handler must stay silent.
+        let stranger = createEntity()
+        backend.pendingContacts = [makeContact(phase: .began, entityA: scripted, entityB: stranger)]
+        tick()
+        XCTAssertEqual(taggedHits, 0)
+
+        // Contact with the named entity fires the tagged event, on either side.
+        backend.pendingContacts = [makeContact(phase: .began, entityA: ball, entityB: scripted)]
+        tick()
+        XCTAssertEqual(taggedHits, 1)
+    }
+
+    func testTriggerFiresUSCOnTriggerEnterAndExit() {
+        gameMode = true
+        let backend = installEventPlugin()
+        let scripted = createEntity()
+        let volume = createEntity()
+
+        var enters = 0
+        var exits = 0
+        attachScript({ $0.onEvent("OnTriggerEnter") }, named: "EnterScript", to: scripted,
+                     recording: "recordEnter", into: { enters += 1 })
+        attachScript({ $0.onEvent("OnTriggerExit") }, named: "ExitScript", to: scripted,
+                     recording: "recordExit", into: { exits += 1 })
+
+        backend.pendingTriggers = [
+            PhysicsTriggerEvent(phase: .entered, triggerEntity: volume, otherEntity: scripted),
+        ]
+        tick()
+        XCTAssertEqual(enters, 1)
+        XCTAssertEqual(exits, 0)
+
+        backend.pendingTriggers = [
+            PhysicsTriggerEvent(phase: .exited, triggerEntity: volume, otherEntity: scripted),
+        ]
+        tick()
+        XCTAssertEqual(enters, 1)
+        XCTAssertEqual(exits, 1)
+    }
+
+    func testUSCEventsRespectGameMode() {
+        gameMode = false
+        let backend = installEventPlugin()
+        let scripted = createEntity()
+
+        var hits = 0
+        attachScript({ $0.onCollision() }, named: "PausedScript", to: scripted,
+                     recording: "recordPausedHit", into: { hits += 1 })
+
+        backend.pendingContacts = [makeContact(phase: .began, entityA: scripted, entityB: 42)]
+        tick()
+        XCTAssertEqual(hits, 0, "USC events must not fire outside Play mode")
+    }
+}


### PR DESCRIPTION
## Summary

PR C of the narrowed phase-1 plan from discussion #1116 (follows #1123 and #1129): event delivery. Backends already buffer contact/trigger/activation events internally and hand them to the coordinator's sink on the frame thread after each fixed substep (`drainEvents`, from PR A's threading contract) — this PR makes that drain go somewhere. **With no external backend installed nothing is ever dispatched**: the built-in integrator has no collision detection, so the whole path stays dormant and runtime behavior is unchanged.

- `Sources/UntoldEngine/Physics/PhysicsEvents.swift` — subscription hub in the `FrameEvents` style: `onContact`/`onTrigger`/`onActivation` return the existing `EventSubscription` token; handlers run on the frame thread during the post-step drain, in backend delivery order; subscriptions can be created/cancelled from any thread (snapshot-under-lock dispatch, same reentrancy semantics as `FrameEventDispatcher`). `droppedEventCount` surfaces backend fixed-capacity buffer overflow as a running counter — never an allocation or error mid-step.
- `PhysicsEventDispatchSink` replaces the coordinator's inert placeholder sink and also wires USC: **`contactBegan` fires the previously never-fired `OnCollision`** on both entities, plus the builder's tagged form `OnCollision:<name>` when the other entity has an explicit name; `triggerEntered`/`triggerExited` fire `OnTriggerEnter`/`OnTriggerExit` the same way (both names already appear in `USCInstruction`'s event-handler documentation). Firing respects `gameMode`, via the existing `USCSystem.triggerEvent` path — no USC internals changed.
- 9 new tests with an event-emitting mock backend: subscription dispatch and cancellation, dormancy without a backend, drop-counter accumulation across substeps, USC `OnCollision` (untagged, tagged-by-name, and phase-filtered — persisted/ended must not re-fire), trigger enter/exit scripts, and `gameMode` gating.

The only files touched are in `Physics/` plus the two physics test files. Follow-up per the plan: PR D (raycast facade) completes phase 1.

## Test plan

- [x] `swift test --filter PhysicsEventsTests` — 9/9 pass
- [x] `PhysicsCoordinatorTests` + `PhysicsBackendRegistryTests` — 30/30 pass
- [x] Full `UntoldEngineTests` module: 1093 tests, no new failures (only the known env-dependent `ExternalRenderExtensionPackageTests`)
- [x] `make lint` with pinned SwiftFormat 0.60.1 — clean
