### PR TITLE
Harden GameData asset path resolution

### DIFF
--- a/Sources/UntoldEngine/Scenes/SceneSerializer.swift
+++ b/Sources/UntoldEngine/Scenes/SceneSerializer.swift
@@ -1804,13 +1804,22 @@ public func loadUntoldScene(
         return
     }
 
-    let sceneURL = gameDataURL
+    let preferredSceneURL = gameDataURL
         .appendingPathComponent("Scenes", isDirectory: true)
         .appendingPathComponent(sceneBaseName)
         .appendingPathExtension(untoldSceneFileExtension)
 
-    guard FileManager.default.fileExists(atPath: sceneURL.path) else {
-        Logger.log(message: "❌ Scene file not found: \(sceneURL.path)")
+    let sceneURL: URL?
+    if FileManager.default.fileExists(atPath: preferredSceneURL.path) {
+        sceneURL = preferredSceneURL
+    } else {
+        // SwiftPM test resources can be flattened by `.process("Resources")`; fall back
+        // through the shared resolver after preserving the BuildSystem `Scenes/` priority.
+        sceneURL = LoadingSystem.shared.resourceURL(forResource: sceneBaseName, withExtension: untoldSceneFileExtension)
+    }
+
+    guard let sceneURL else {
+        Logger.log(message: "❌ Scene file not found: \(sceneBaseName).\(untoldSceneFileExtension)")
         completion?(false)
         return
     }

--- a/Sources/UntoldEngine/Systems/LoadingSystem.swift
+++ b/Sources/UntoldEngine/Systems/LoadingSystem.swift
@@ -60,6 +60,25 @@ public func getResourceURL(resourceName: String, ext: String, subName: String?) 
         if fm.fileExists(atPath: urlWithExt.path) {
             return urlWithExt
         }
+
+        if let assetBasePath {
+            let base = effectiveAssetBaseURL(assetBasePath)
+            // If a scene stores an absolute path from another machine, preserve any
+            // known GameData suffix first, then fall back to flattened SwiftPM resources.
+            let requestedURL = absoluteURL.pathExtension.isEmpty ? urlWithExt : absoluteURL
+            if let relativeComponents = resourceSuffixComponents(from: requestedURL) {
+                let structuredCandidate = relativeComponents.reduce(base) { $0.appendingPathComponent($1) }
+                if fm.fileExists(atPath: structuredCandidate.path) {
+                    return structuredCandidate
+                }
+            }
+
+            let flatName = requestedURL.deletingPathExtension().lastPathComponent
+            let flatCandidate = base.appendingPathComponent(flatName).appendingPathExtension(ext)
+            if fm.fileExists(atPath: flatCandidate.path) {
+                return flatCandidate
+            }
+        }
     }
 
     // Flat layout (no top-level "Assets")
@@ -71,6 +90,7 @@ public func getResourceURL(resourceName: String, ext: String, subName: String?) 
         ["Gaussians", "\(resourceName).\(ext)"],
         ["Scripts", "\(resourceName).\(ext)"],
         ["Scenes", "\(resourceName).\(ext)"],
+        ["Textures", "\(resourceName).\(ext)"],
     ]
     if let subName {
         searchPaths.append(["Materials", subName, "\(resourceName).\(ext)"])
@@ -78,16 +98,7 @@ public func getResourceURL(resourceName: String, ext: String, subName: String?) 
 
     // 1) External base path (folder OR .bundle OR already a Resources dir)
     if let basePath = assetBasePath {
-        // If .bundle, hop into Contents/Resources on macOS
-        let base: URL = {
-            if basePath.pathExtension == "bundle",
-               let bundle = Bundle(url: basePath),
-               let res = bundle.resourceURL
-            {
-                return res
-            }
-            return basePath
-        }()
+        let base = effectiveAssetBaseURL(basePath)
 
         // Try FLAT root first (handles your current packaging)
         let flat = base.appendingPathComponent("\(resourceName).\(ext)")
@@ -102,6 +113,7 @@ public func getResourceURL(resourceName: String, ext: String, subName: String?) 
             ["Gaussians", "\(resourceName).\(ext)"],
             ["Scripts", "\(resourceName).\(ext)"],
             ["Scenes", "\(resourceName).\(ext)"],
+            ["Textures", "\(resourceName).\(ext)"],
         ] + (subName.map { [["Materials", $0, "\(resourceName).\(ext)"]] } ?? [])
 
         for components in searchPaths {
@@ -124,6 +136,39 @@ public func getResourceURL(resourceName: String, ext: String, subName: String?) 
 
     // 4) Module bundle (UNCHANGED: top-level only, for engine-internal content)
     return Bundle.module.url(forResource: resourceName, withExtension: ext)
+}
+
+private func effectiveAssetBaseURL(_ basePath: URL) -> URL {
+    if basePath.pathExtension == "bundle",
+       let bundle = Bundle(url: basePath),
+       let resourceURL = bundle.resourceURL
+    {
+        return resourceURL
+    }
+
+    return basePath
+}
+
+private func resourceSuffixComponents(from url: URL) -> [String]? {
+    let knownResourceDirectories: Set<String> = [
+        "Models",
+        "StreamModels",
+        "Animations",
+        "HDR",
+        "Gaussians",
+        "Scripts",
+        "Scenes",
+        "Materials",
+        "Textures",
+        "Shaders",
+    ]
+    let components = url.pathComponents
+
+    guard let resourceDirectoryIndex = components.firstIndex(where: { knownResourceDirectories.contains($0) }) else {
+        return nil
+    }
+
+    return Array(components[resourceDirectoryIndex...])
 }
 
 private func urlInBundle(_ bundle: Bundle, components: [String]) -> URL? {

--- a/Sources/UntoldEngine/Systems/LoadingSystem.swift
+++ b/Sources/UntoldEngine/Systems/LoadingSystem.swift
@@ -150,7 +150,7 @@ private func effectiveAssetBaseURL(_ basePath: URL) -> URL {
 }
 
 private func resourceSuffixComponents(from url: URL) -> [String]? {
-    let knownResourceDirectories: Set<String> = [
+    let knownResourceDirectories: Set = [
         "Models",
         "StreamModels",
         "Animations",

--- a/Tests/UntoldEngineTests/LoadUntoldSceneContractTests.swift
+++ b/Tests/UntoldEngineTests/LoadUntoldSceneContractTests.swift
@@ -67,11 +67,42 @@ final class LoadUntoldSceneContractTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    private func writeScene(named name: String) throws {
-        let scenesDirectory = tempRoot.appendingPathComponent("Scenes", isDirectory: true)
-        try FileManager.default.createDirectory(at: scenesDirectory, withIntermediateDirectories: true)
+    func testLoadUntoldSceneFallsBackToFlatGameDataResource() throws {
+        try writeScene(named: "FlatLevel", inScenesDirectory: false)
 
-        let sceneURL = scenesDirectory
+        let expectation = expectation(description: "flat scene load completes")
+        loadUntoldScene(named: "FlatLevel", meshLoadingMode: .sync) { success in
+            XCTAssertTrue(success)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testLoadUntoldScenePrefersScenesDirectoryOverFlatResource() throws {
+        try writeScene(named: "PreferredLevel", inScenesDirectory: true)
+
+        let flatSceneURL = tempRoot
+            .appendingPathComponent("PreferredLevel")
+            .appendingPathExtension("untoldscene")
+        try Data("not valid scene json".utf8).write(to: flatSceneURL)
+
+        let expectation = expectation(description: "structured scene load completes")
+        loadUntoldScene(named: "PreferredLevel", meshLoadingMode: .sync) { success in
+            XCTAssertTrue(success)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    private func writeScene(named name: String, inScenesDirectory: Bool = true) throws {
+        let directory = inScenesDirectory
+            ? tempRoot.appendingPathComponent("Scenes", isDirectory: true)
+            : tempRoot!
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let sceneURL = directory
             .appendingPathComponent(name)
             .appendingPathExtension("untoldscene")
         let sceneData = SceneData()

--- a/Tests/UntoldEngineTests/LoadingSystemPathResolutionTests.swift
+++ b/Tests/UntoldEngineTests/LoadingSystemPathResolutionTests.swift
@@ -1,0 +1,124 @@
+//
+//  LoadingSystemPathResolutionTests.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+
+@testable import UntoldEngine
+import XCTest
+
+final class LoadingSystemPathResolutionTests: XCTestCase {
+    private var previousAssetBasePath: URL?
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        previousAssetBasePath = assetBasePath
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LoadingSystemPathResolutionTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        assetBasePath = previousAssetBasePath
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try super.tearDownWithError()
+    }
+
+    func testAbsoluteStalePathFallsBackToCurrentStructuredResourceSuffix() throws {
+        let currentResource = tempRoot
+            .appendingPathComponent("Models/redplayer", isDirectory: true)
+            .appendingPathComponent("redplayer")
+            .appendingPathExtension("usdz")
+        try FileManager.default.createDirectory(at: currentResource.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data().write(to: currentResource)
+        assetBasePath = tempRoot
+
+        let resolved = getResourceURL(
+            resourceName: "/old/build/GameData/Models/redplayer/redplayer.usdz",
+            ext: "usdz",
+            subName: nil
+        )
+
+        XCTAssertEqual(resolved?.standardizedFileURL, currentResource.standardizedFileURL)
+    }
+
+    func testAbsoluteStalePathFallsBackToFlatResourceWithoutDuplicatingExtension() throws {
+        let currentResource = tempRoot
+            .appendingPathComponent("redplayer")
+            .appendingPathExtension("usdz")
+        try Data().write(to: currentResource)
+        assetBasePath = tempRoot
+
+        let resolved = getResourceURL(
+            resourceName: "/old/build/GameData/Models/redplayer/redplayer.usdz",
+            ext: "usdz",
+            subName: nil
+        )
+
+        XCTAssertEqual(resolved?.standardizedFileURL, currentResource.standardizedFileURL)
+    }
+
+    func testAbsoluteStalePathFallbackUsesBundleResourceDirectory() throws {
+        let bundleURL = tempRoot.appendingPathComponent("GameData.bundle", isDirectory: true)
+        let resourcesURL = bundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+        try FileManager.default.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
+
+        let infoPlistURL = bundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Info.plist")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleIdentifier</key>
+            <string>com.untoldengine.tests.gamedata</string>
+            <key>CFBundlePackageType</key>
+            <string>BNDL</string>
+        </dict>
+        </plist>
+        """.write(to: infoPlistURL, atomically: true, encoding: .utf8)
+
+        let currentResource = resourcesURL
+            .appendingPathComponent("redplayer")
+            .appendingPathExtension("usdz")
+        try Data().write(to: currentResource)
+        assetBasePath = bundleURL
+
+        let resolved = getResourceURL(
+            resourceName: "/old/build/GameData/Models/redplayer/redplayer.usdz",
+            ext: "usdz",
+            subName: nil
+        )
+
+        XCTAssertEqual(resolved?.standardizedFileURL, currentResource.standardizedFileURL)
+    }
+
+    func testBareResourceNameResolvesUnderTexturesDirectory() throws {
+        // GameData/Textures is a canonical asset directory created by the project
+        // scaffolding (see createGameDataDirectories()), but standalone texture
+        // loads (loadTexture(textureName:)) pass subResource: nil, so this must
+        // resolve through the plain structured search, not the Materials/subName one.
+        let texturesDirectory = tempRoot.appendingPathComponent("Textures", isDirectory: true)
+        try FileManager.default.createDirectory(at: texturesDirectory, withIntermediateDirectories: true)
+        let currentResource = texturesDirectory
+            .appendingPathComponent("icon")
+            .appendingPathExtension("png")
+        try Data().write(to: currentResource)
+        assetBasePath = tempRoot
+
+        let resolved = getResourceURL(resourceName: "icon", ext: "png", subName: nil)
+
+        XCTAssertEqual(resolved?.standardizedFileURL, currentResource.standardizedFileURL)
+    }
+}

--- a/docs/API/UsingAssetPaths.md
+++ b/docs/API/UsingAssetPaths.md
@@ -1,0 +1,80 @@
+# Asset Paths
+
+## Introduction
+
+Every mesh, animation, texture, and scene a game loads by name — `setEntityMesh(filename: "redplayer", ...)`, `loadUntoldScene(named: "Level1")`, `loadTexture(textureName: "icon", ...)` — has to turn that short name into a real file on disk (or inside the shipped app bundle). That resolution goes through `assetBasePath` and a small, fixed set of conventional folders under it. Knowing that convention is what keeps "why didn't my asset load?" from becoming a debugging session.
+
+## The `GameData` Folder
+
+A project created with the CLI (`untoldengine create`) or Xcode template ships with a `GameData` folder alongside your source:
+
+```
+GameData/
+├── Scenes/
+├── Scripts/
+├── Models/
+├── StreamModels/
+├── Animations/
+├── Gaussians/
+├── Textures/
+└── Shaders/
+```
+
+These are the **canonical asset directories** the engine's resource resolver knows about. The project generator creates them for you, and Xcode adds `GameData` as a folder reference — meaning it's copied into the built app **verbatim**, subfolders and all, on macOS, iOS, and visionOS. You don't need to worry about your directory structure surviving into a shipped build.
+
+Where each asset type belongs:
+
+| Folder | What goes there |
+|---|---|
+| `Scenes/` | `.untoldscene` files |
+| `Scripts/` | scripting-system script files |
+| `Models/` | `.untold` meshes, one subfolder per asset (e.g. `Models/robot/robot.untold`) |
+| `StreamModels/` | tile-streamed geometry (`export-untold-tiles` output) |
+| `Animations/` | `.untold` animation clips |
+| `Gaussians/` | Gaussian splat assets |
+| `Textures/` | standalone textures loaded by name, outside of a material |
+| `Shaders/` | custom shader source |
+
+Materials are the one exception: they resolve under `Materials/<subName>/...`, keyed by the material name passed alongside the resource name, rather than a fixed top-level folder.
+
+## `assetBasePath`
+
+`assetBasePath` is the root the resolver searches under — everything in the table above is resolved as `<assetBasePath>/<Folder>/...`. A generated project sets it for you during startup:
+
+```swift
+setupAssetPaths()
+// or, directly:
+setEngine(.assetBasePath(Bundle.main.url(forResource: "GameData", withExtension: nil)!))
+```
+
+If you're not using the generated template — a custom host app, or a tool loading assets from a user-chosen folder — set it yourself before loading anything:
+
+```swift
+assetBasePath = myGameDataFolderURL
+```
+
+## How Resolution Works
+
+Calling an API with a bare resource name (`"redplayer"`, `"icon"`, `"Level1"`) resolves in this order:
+
+1. **Flat root.** `<assetBasePath>/<name>.<ext>` — a fast path for assets dropped directly at the root.
+2. **Structured subdirectories.** Each canonical folder in turn: `Models/<name>/<name>.<ext>`, `Textures/<name>.<ext>`, `Scenes/<name>.<ext>`, and so on. This is the path most assets take.
+3. **App bundle fallback.** `Bundle.main`, then the engine's own module bundle — covers assets bundled outside `GameData` or engine-internal content.
+
+Scene files get one extra rule ahead of all of this: `loadUntoldScene(named:)` always checks `<assetBasePath>/Scenes/<name>.untoldscene` directly first, so a same-named file that happens to sit elsewhere can never shadow the canonical scene.
+
+Inside a `.untoldscene` file, asset references are stored as **paths relative to `assetBasePath`** (e.g. `Models/ball/ball.untold`), not absolute paths — so a project (and its scenes) can move between machines and Xcode's DerivedData without breaking. The resolver also tolerates absolute paths baked by older tooling or another machine's build directory: if the literal path doesn't exist, it looks for a known folder name (`Models`, `Textures`, `Scenes`, ...) anywhere in that stale path and retries from there under the current `assetBasePath`.
+
+## Tips and Best Practices
+
+- **Put assets in their canonical folder.** The flat-root and bundle-fallback tiers exist as safety nets, not primary storage — an asset outside the structured layout is one refactor away from silently failing to load.
+- **Standalone textures go in `Textures/`, not `Materials/`.** `loadTexture(textureName:withExtension:)` passes no material name, so it only ever searches the flat root and the top-level structured folders (including `Textures/`) — never a `Materials/<name>/` subfolder.
+- **Materials still key off `subName`.** A texture referenced as part of a material (`subName` set) resolves under `Materials/<subName>/`, independent of the `Textures/` folder.
+- **Don't hardcode absolute paths in code or scenes** if you can avoid it. They work as a fallback, but every relative reference is guaranteed to keep resolving after a project move; an absolute one is only guaranteed until the next one.
+- If an asset fails to load and you don't see it logged as found, the first thing to check is which canonical folder it's actually sitting in versus where the resolver looks for its type.
+
+## Running the Feature
+
+1. Drop a texture into `GameData/Textures/icon.png`.
+2. Call `loadTexture(device:, textureName: "icon", withExtension: "png")`.
+3. It resolves without any extra configuration — no material, no `subResource`, just the folder convention.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,6 @@ nav:
     - Getting Started: API/GettingStarted.md
     - Untold Engine CLI: API/UsingUntoldEngineCLI.md
     - Usage Examples: API/UsageExamples.md
-    - Scene Builder / UntoldView: API/UsingSceneBuilder.md
     - Engine Settings: API/UsingEngineAPI.md
     - Registration System: API/UsingRegistrationSystem.md
     - Transform System: API/UsingTransformSystem.md
@@ -107,6 +106,8 @@ nav:
     - Color Management: API/UsingColorManagement.md
     - Blender Add-on: API/UsingBlenderAddon.md
     - Optimizations: API/Optimizations.md
+    - Scene Builder / UntoldView: API/UsingSceneBuilder.md
+    - Asset Paths: API/UsingAssetPaths.md
   - Architecture:
     - Rendering System: Architecture/renderingSystem.md
     - Rendering Extensions: Architecture/RenderingExtensions.md


### PR DESCRIPTION
This PR improves runtime asset lookup so generated games keep the existing GameData/Scenes behavior while tests and SwiftPM-
  flattened resources can still resolve correctly.

  Changes include:

  - Prefer GameData/Scenes/<name>.untoldscene when loading scenes by name.
  - Fall back to shared resource resolution for flattened test/package resources.
  - Recover stale absolute asset paths by remapping known GameData folder suffixes into the current assetBasePath.
  - Support .bundle asset bases through Bundle.resourceURL.
  - Add Textures/ to standalone texture lookup.
  - Add focused tests for scene precedence, flat fallback, stale absolute paths, bundle resources, and Textures/ lookup.
  - Add API docs for GameData, assetBasePath, and resolver conventions.

  Validation:

  - swift test --filter LoadingSystemPathResolutionTests
  - swift test --filter LoadUntoldSceneContractTests
  - mkdocs build --strict