### PR TITLE
[Patch] Apply root motion once per anchor on modular assets

### DIFF
--- a/Sources/UntoldEngine/Animation/RootMotion.swift
+++ b/Sources/UntoldEngine/Animation/RootMotion.swift
@@ -35,6 +35,13 @@ struct RootMotionState {
     /// games move the asset root.
     var anchorEntity: EntityID = .invalid
 
+    /// Whether this component applies its deltas to the anchor. Modular
+    /// assets carry one AnimationComponent per skinned part, all sampling
+    /// the same clips against the same anchor; exactly one of them drives
+    /// the transform or the anchor moves at N× clip speed. The others still
+    /// extract and ground their poses so every part stays in sync.
+    var drivesAnchor = true
+
     /// Optional joint-path override; by default the skeleton's first
     /// parentless joint drives root motion.
     var rootJointPath: String?
@@ -158,7 +165,7 @@ func applyRootMotion(
         ? entityId
         : animationComponent.rootMotion.anchorEntity
 
-    if animationComponent.rootMotion.hasPreviousSample {
+    if animationComponent.rootMotion.hasPreviousSample, animationComponent.rootMotion.drivesAnchor {
         var delta = translation - animationComponent.rootMotion.previousTranslation
         if translationTime < animationComponent.rootMotion.previousTranslationTime {
             delta += compiledClip.rootTranslationPerLoop

--- a/Sources/UntoldEngine/Systems/AnimationSystem.swift
+++ b/Sources/UntoldEngine/Systems/AnimationSystem.swift
@@ -370,6 +370,11 @@ public func changeAnimation(entityId: EntityID, name: String, transitionHalflife
 /// pose; vertical motion, pitch, and roll stay in the pose. By default the
 /// skeleton's first parentless joint is the root; pass `rootJointPath` to
 /// designate a different joint.
+///
+/// Modular assets resolve to several animation components; only the first
+/// one drives the anchor's transform, so the deltas apply once no matter
+/// how many skinned parts share the skeleton. Every component still grounds
+/// its own pose.
 public func setRootMotionEnabled(entityId: EntityID, enabled: Bool, rootJointPath: String? = nil) {
     let animationComponents = animationComponentsForEntityOrDescendants(entityId: entityId)
     guard animationComponents.isEmpty == false else {
@@ -377,10 +382,11 @@ public func setRootMotionEnabled(entityId: EntityID, enabled: Bool, rootJointPat
         return
     }
 
-    for (_, animationComponent) in animationComponents {
+    for (index, (_, animationComponent)) in animationComponents.enumerated() {
         animationComponent.rootMotion.isEnabled = enabled
         animationComponent.rootMotion.rootJointPath = rootJointPath
         animationComponent.rootMotion.anchorEntity = entityId
+        animationComponent.rootMotion.drivesAnchor = index == 0
         animationComponent.rootMotion.resolvedRootIndex = nil
         animationComponent.rootMotion.resetHistory()
     }

--- a/Tests/UntoldEngineTests/AnimationRootMotionTests.swift
+++ b/Tests/UntoldEngineTests/AnimationRootMotionTests.swift
@@ -331,6 +331,59 @@ final class AnimationRootMotionTests: XCTestCase {
         )
     }
 
+    /// Modular assets (one skinned part per mesh, e.g. a UE character
+    /// exported per body part) resolve to SEVERAL animation components that
+    /// all sample the same clips against the same anchor. The extracted
+    /// deltas must move the anchor once — not once per part.
+    func testMultiComponentAssetAppliesRootMotionOnce() throws {
+        let root = createEntity()
+        registerComponent(entityId: root, componentType: LocalTransformComponent.self)
+        registerComponent(entityId: root, componentType: WorldTransformComponent.self)
+        registerComponent(entityId: root, componentType: ScenegraphComponent.self)
+
+        // A second skinned part: same skeleton, same clip, own components.
+        let sibling = createEntity()
+        registerComponent(entityId: sibling, componentType: SkeletonComponent.self)
+        registerComponent(entityId: sibling, componentType: AnimationComponent.self)
+        registerComponent(entityId: sibling, componentType: RenderComponent.self)
+        registerComponent(entityId: sibling, componentType: ScenegraphComponent.self)
+        registerComponent(entityId: sibling, componentType: LocalTransformComponent.self)
+        registerComponent(entityId: sibling, componentType: WorldTransformComponent.self)
+        let runtimeSkeleton = RuntimeSkeleton(
+            jointPaths: ["root", "root/hips"],
+            parentIndices: [nil, 0],
+            bindTransforms: [.identity, simd_float4x4(translation: simd_float3(0, 1, 0))],
+            restTransforms: [.identity, simd_float4x4(translation: simd_float3(0, 1, 0))]
+        )
+        scene.get(component: SkeletonComponent.self, for: sibling)?.skeleton =
+            Skeleton(runtimeSkeleton: runtimeSkeleton)
+        let siblingAnimation = try XCTUnwrap(scene.get(component: AnimationComponent.self, for: sibling))
+        siblingAnimation.animationClips["walk"] = makeWalkClip()
+        defer {
+            destroyEntity(entityId: sibling)
+            destroyEntity(entityId: root)
+        }
+
+        setParent(childId: entityId, parentId: root)
+        setParent(childId: sibling, parentId: root)
+
+        setRootMotionEnabled(entityId: root, enabled: true)
+        changeAnimation(entityId: root, name: "walk", transitionHalflife: 0)
+        run(frames: 90) // 1 s of the 1 m/s walk
+
+        XCTAssertEqual(
+            getLocalPosition(entityId: root).z, 1.0 - deltaTime, accuracy: 1e-3,
+            "Two components sharing an anchor must move it at clip speed, not 2x"
+        )
+        for part in try [XCTUnwrap(entityId), sibling] {
+            let animationComponent = try XCTUnwrap(scene.get(component: AnimationComponent.self, for: part))
+            XCTAssertEqual(
+                animationComponent.localPose.translations[0].z, 0, accuracy: 1e-4,
+                "Every part must still ground its own pose"
+            )
+        }
+    }
+
     // MARK: - Root joint override
 
     func testRootJointPathOverride() {


### PR DESCRIPTION
## Summary

Follow-up fix to root motion (#1135), found by driving a real modular character: an asset that carries **one skinned mesh per body part** (a common UE export shape) resolves to several `AnimationComponent`s, all sampling the same clips against the same anchor. `setRootMotionEnabled` armed root motion on every one of them, and each extracted the same horizontal/yaw delta and applied it to the shared anchor via `translateBy`/`rotateTo` — so the character moved at **N× clip speed**. A 14-part zombie traveled at exactly 14×; nothing looked wrong in the pose, only the transform raced.

### Fix

`setRootMotionEnabled` designates the **first resolved component as the anchor's transform driver** (`RootMotionState.drivesAnchor`); `applyRootMotion` gates only the delta application on it. Every component still runs extraction and pose grounding (`stripRootMotion`), so all parts stay visually in sync. Flat assets are unchanged — their single component is the driver.

Motion matching's anchor uses (`MotionMatchingState.anchorEntity`) were audited too: they only *read* position/heading for the query, so no equivalent write amplification exists there.

## Testing

New regression test in `AnimationRootMotionTests`: a parent root with **two** skinned children carrying animation components, root motion enabled on the parent — asserts the anchor travels at clip speed (not 2×) and that both parts' poses stay grounded. Verified the test fails at exactly 2× with the gate removed.

All animation suites pass on this base (72 tests: root motion, inertialization, foot IK, motion matching, compiled sampler, policy). SwiftFormat lint clean.
