### PR TITLE
[Feature] Inertialize root-motion velocity and pace motion-matching jumps

### DIFF
--- a/Sources/UntoldEngine/Animation/MotionMatching.swift
+++ b/Sources/UntoldEngine/Animation/MotionMatching.swift
@@ -43,6 +43,14 @@ public struct MotionMatchingDescriptor {
     /// velocity — lower is more responsive, higher is smoother.
     public var predictionHalflife: Float
 
+    /// Minimum time playback runs before another jump may fire. The search
+    /// still runs every `searchInterval`, but without this floor a frame
+    /// that systematically beats the incumbent (for example the velocity
+    /// peak of a cycle when the goal speed exceeds the clip's mean) wins
+    /// every search and playback treadmills on one spot — a frozen-looking
+    /// pose that never advances through the cycle.
+    public var minPlayTime: Float
+
     public var weights: MotionMatchingWeights
 
     public init(
@@ -53,6 +61,7 @@ public struct MotionMatchingDescriptor {
         searchInterval: Float = 0.1,
         transitionHalflife: Float = 0.1,
         predictionHalflife: Float = 0.25,
+        minPlayTime: Float = 0.3,
         weights: MotionMatchingWeights = MotionMatchingWeights()
     ) {
         self.leftFootPath = leftFootPath
@@ -62,6 +71,7 @@ public struct MotionMatchingDescriptor {
         self.searchInterval = searchInterval
         self.transitionHalflife = transitionHalflife
         self.predictionHalflife = predictionHalflife
+        self.minPlayTime = minPlayTime
         self.weights = weights
     }
 }
@@ -86,6 +96,7 @@ struct MotionMatchingState {
     var simulatedVelocity = simd_float3.zero
 
     var searchClock: Float = 0
+    var timeSinceJump: Float = .greatestFiniteMagnitude
 
     /// Query history for finite-difference features.
     var hasHistory = false
@@ -155,6 +166,7 @@ func updateMotionMatching(
 
     animationComponent.motionMatching.searchClock += deltaTime
     animationComponent.motionMatching.historyElapsed += deltaTime
+    animationComponent.motionMatching.timeSinceJump += deltaTime
     guard animationComponent.motionMatching.searchClock >= descriptor.searchInterval else { return }
     animationComponent.motionMatching.searchClock = 0
 
@@ -206,6 +218,8 @@ func updateMotionMatching(
             return
         }
     }
+
+    guard animationComponent.motionMatching.timeSinceJump >= descriptor.minPlayTime else { return }
 
     motionMatchingJump(
         entityId: entityId,
@@ -370,6 +384,8 @@ func motionMatchingJump(
     )
     animationComponent.currentAnimation = clip
     animationComponent.currentTime = frame.time
+    animationComponent.motionMatching.timeSinceJump = 0
+    animationComponent.rootMotion.beginVelocityBlend(halflife: halflife)
     animationComponent.rootMotion.resetHistory()
 }
 

--- a/Sources/UntoldEngine/Animation/RootMotion.swift
+++ b/Sources/UntoldEngine/Animation/RootMotion.swift
@@ -54,10 +54,46 @@ struct RootMotionState {
     var previousTranslationTime: Float = 0
     var previousRotationTime: Float = 0
 
+    /// World-space velocity the driver applied last frame — the outgoing
+    /// velocity when an inertialized transition begins.
+    var lastWorldVelocity = simd_float3.zero
+    var lastYawRate: Float = 0
+
+    /// Velocity crossfade across a clip transition: while `blendWeight` is
+    /// nonzero the applied travel blends from the frozen outgoing velocity
+    /// to the incoming clip's extraction, decaying with the transition's
+    /// halflife — the entity accelerates in step with the pose blend
+    /// instead of snapping to the new clip's speed (feet skate otherwise).
+    var blendWeight: Float = 0
+    var blendHalflife: Float = 0
+    var frozenVelocity = simd_float3.zero
+    var frozenYawRate: Float = 0
+
     /// Forget the sample history (clip switches, enable toggles); the next
     /// frame re-baselines with a zero delta.
     mutating func resetHistory() {
         hasPreviousSample = false
+    }
+
+    /// Starts the velocity crossfade for a clip switch: freezes the
+    /// currently applied velocity and decays toward the incoming clip's.
+    /// A zero halflife is a hard cut, matching the pose transition.
+    mutating func beginVelocityBlend(halflife: Float) {
+        guard halflife > 0 else {
+            blendWeight = 0
+            return
+        }
+        // A negligible outgoing velocity needs no crossfade — arming one
+        // would only sustain residual drift when searches re-jump between
+        // near-idle frames.
+        guard simd_length(lastWorldVelocity) > 0.05 || abs(lastYawRate) > 0.1 else {
+            blendWeight = 0
+            return
+        }
+        blendWeight = 1
+        blendHalflife = halflife
+        frozenVelocity = lastWorldVelocity
+        frozenYawRate = lastYawRate
     }
 }
 
@@ -138,7 +174,8 @@ func applyRootMotion(
     skeleton: Skeleton,
     compiledClip: CompiledAnimationClip,
     clipDuration: Float,
-    clipSpeed: Float
+    clipSpeed: Float,
+    deltaTime: Float
 ) {
     guard animationComponent.rootMotion.isEnabled else { return }
     guard let rootIndex = resolveRootMotionJointIndex(
@@ -165,35 +202,60 @@ func applyRootMotion(
         ? entityId
         : animationComponent.rootMotion.anchorEntity
 
-    if animationComponent.rootMotion.hasPreviousSample, animationComponent.rootMotion.drivesAnchor {
+    // Extracted travel this frame; zero on the re-baseline frame right
+    // after a clip switch (the crossfade below still carries the frozen
+    // outgoing velocity through that frame). Only the driving component
+    // extracts and applies; the others just ground their poses.
+    let drivesAnchor = animationComponent.rootMotion.drivesAnchor
+    var horizontal = simd_float3.zero
+    var yawDelta: Float = 0
+    if animationComponent.rootMotion.hasPreviousSample, drivesAnchor {
         var delta = translation - animationComponent.rootMotion.previousTranslation
         if translationTime < animationComponent.rootMotion.previousTranslationTime {
             delta += compiledClip.rootTranslationPerLoop
         }
-
-        var yawDelta = yaw - animationComponent.rootMotion.previousYaw
+        yawDelta = yaw - animationComponent.rootMotion.previousYaw
         if rotationTime < animationComponent.rootMotion.previousRotationTime {
             yawDelta += compiledClip.rootYawPerLoop
         }
         yawDelta = wrapAngle(yawDelta)
+        horizontal = simd_float3(delta.x, 0, delta.z)
+    }
 
-        let horizontal = simd_float3(delta.x, 0, delta.z)
-        if scene.get(component: LocalTransformComponent.self, for: motionEntity) != nil {
-            // LocalTransformComponent's default rotation is the zero
-            // quaternion (simd_quatf()), which rotates every vector to zero
-            // — treat it as identity so deltas survive on never-rotated
-            // entities.
-            var entityRotation = getRotationQuaternion(entityId: motionEntity)
-            if simd_length_squared(entityRotation.vector) < 1e-8 {
-                entityRotation = simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
-            }
-            if simd_length_squared(horizontal) > 0 {
-                translateBy(entityId: motionEntity, position: entityRotation.act(horizontal))
-            }
-            if yawDelta != 0 {
-                let yawRotation = simd_quatf(angle: yawDelta, axis: simd_float3(0, 1, 0))
-                rotateTo(entityId: motionEntity, rotation: simd_normalize(entityRotation * yawRotation))
-            }
+    if drivesAnchor, scene.get(component: LocalTransformComponent.self, for: motionEntity) != nil {
+        // LocalTransformComponent's default rotation is the zero
+        // quaternion (simd_quatf()), which rotates every vector to zero
+        // — treat it as identity so deltas survive on never-rotated
+        // entities.
+        var entityRotation = getRotationQuaternion(entityId: motionEntity)
+        if simd_length_squared(entityRotation.vector) < 1e-8 {
+            entityRotation = simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
+        }
+
+        // Velocity crossfade: blend the frozen outgoing velocity with the
+        // incoming clip's extraction while the pose transition decays, so
+        // the entity accelerates in step with the pose instead of snapping
+        // to the new clip's travel (which skates the feet).
+        let w = animationComponent.rootMotion.blendWeight
+        var applied = entityRotation.act(horizontal)
+        var appliedYaw = yawDelta
+        if w > 0, deltaTime > 0 {
+            applied = applied * (1 - w) + animationComponent.rootMotion.frozenVelocity * (deltaTime * w)
+            appliedYaw = yawDelta * (1 - w) + animationComponent.rootMotion.frozenYawRate * (deltaTime * w)
+            let decay = exp(-0.693_147_18 * deltaTime / max(animationComponent.rootMotion.blendHalflife, 1e-4))
+            animationComponent.rootMotion.blendWeight = w * decay < 1e-3 ? 0 : w * decay
+        }
+
+        if simd_length_squared(applied) > 0 {
+            translateBy(entityId: motionEntity, position: applied)
+        }
+        if appliedYaw != 0 {
+            let yawRotation = simd_quatf(angle: appliedYaw, axis: simd_float3(0, 1, 0))
+            rotateTo(entityId: motionEntity, rotation: simd_normalize(entityRotation * yawRotation))
+        }
+        if deltaTime > 0, animationComponent.rootMotion.hasPreviousSample || w > 0 {
+            animationComponent.rootMotion.lastWorldVelocity = applied / deltaTime
+            animationComponent.rootMotion.lastYawRate = appliedYaw / deltaTime
         }
     }
 

--- a/Sources/UntoldEngine/Systems/AnimationSystem.swift
+++ b/Sources/UntoldEngine/Systems/AnimationSystem.swift
@@ -210,7 +210,8 @@ private func updateAnimationSystem(deltaTime: Float) {
             skeleton: skeletonComponent.skeleton,
             compiledClip: compiledClip,
             clipDuration: animationClip.duration,
-            clipSpeed: animationClip.speed
+            clipSpeed: animationClip.speed,
+            deltaTime: deltaTime
         )
 
         // Transitions decay in real time, independent of playback speed.
@@ -358,8 +359,10 @@ public func changeAnimation(entityId: EntityID, name: String, transitionHalflife
         animationComponent.currentAnimation = animationClip
         animationComponent.currentTime = 0
         animationComponent.pause = withPause
-        // Re-baseline root motion on the new clip; the first frame after a
-        // switch contributes no delta.
+        // Re-baseline root motion on the new clip (the first frame after a
+        // switch contributes no delta) and crossfade the applied velocity
+        // with the same halflife the pose blends with.
+        animationComponent.rootMotion.beginVelocityBlend(halflife: transitionHalflife)
         animationComponent.rootMotion.resetHistory()
     }
 }

--- a/Tests/UntoldEngineTests/AnimationRootMotionTests.swift
+++ b/Tests/UntoldEngineTests/AnimationRootMotionTests.swift
@@ -384,6 +384,29 @@ final class AnimationRootMotionTests: XCTestCase {
         }
     }
 
+    /// A clip switch with a transition must not snap the entity's travel:
+    /// the applied velocity crossfades from the outgoing clip's to the
+    /// incoming clip's with the transition halflife.
+    func testTransitionCrossfadesAppliedVelocity() {
+        setRootMotionEnabled(entityId: entityId, enabled: true)
+        changeAnimation(entityId: entityId, name: "walk", transitionHalflife: 0)
+        run(frames: 90) // steady 1 m/s walk
+
+        let zBefore = getLocalPosition(entityId: entityId).z
+        changeAnimation(entityId: entityId, name: "turn", transitionHalflife: 0.15)
+        run(frames: 2)
+        let earlySpeed = (getLocalPosition(entityId: entityId).z - zBefore) / (2 * deltaTime)
+        XCTAssertGreaterThan(earlySpeed, 0.5,
+                             "Right after the switch the entity must keep most of the walk speed, not snap to the turn's zero travel")
+
+        run(frames: 90) // 1 s = ~6.7 halflives
+        let zSettled = getLocalPosition(entityId: entityId).z
+        AnimationSystem.shared.update(deltaTime)
+        let settledSpeed = (getLocalPosition(entityId: entityId).z - zSettled) / deltaTime
+        XCTAssertLessThan(abs(settledSpeed), 0.05,
+                          "The crossfade must settle to the incoming clip's travel")
+    }
+
     // MARK: - Root joint override
 
     func testRootJointPathOverride() {

--- a/docs/API/UsingMotionMatching.md
+++ b/docs/API/UsingMotionMatching.md
@@ -83,6 +83,13 @@ That's the whole integration — no `changeAnimation` calls, no states.
 - **Weights are the tuning surface.** Raise `trajectoryPosition`/
   `trajectoryDirection` for responsiveness to the goal; raise the foot
   weights for pose fidelity (less foot sliding at transitions).
+- `minPlayTime` (default 0.3 s) is the floor on how long a chosen frame
+  plays before the next jump may fire. Without it, a frame that
+  systematically beats the incumbent — the velocity peak of a cycle
+  whenever the goal speed exceeds the clip's mean — wins every search
+  and playback treadmills on one spot: a frozen-looking pose drifting
+  across the floor. Raise it for calmer motion, lower it for snappier
+  reactions.
 - `searchInterval` trades responsiveness for cost; 0.1 s is a good
   default. Databases of a few thousand frames need no acceleration
   structure.

--- a/docs/API/UsingRootMotion.md
+++ b/docs/API/UsingRootMotion.md
@@ -63,6 +63,12 @@ if isRootMotionEnabled(entityId: zombie) {
 
 Inertialized transitions compose cleanly with root motion: transitions
 blend grounded poses, so switching clips never teleports the character.
+The applied travel is inertialized too — at a switch the entity's
+velocity crossfades from the outgoing clip's to the incoming clip's
+with the same halflife the pose blends with, so a walk-to-sprint switch
+accelerates the character in step with its legs instead of snapping to
+the new speed (which would skate the feet). A zero halflife remains an
+exact hard cut.
 
 ## Tips and Best Practices
 


### PR DESCRIPTION
## Summary

Driving a real character (a 14-part game zombie with a motion-matching database built from its in-place clips) through the full stack — motion matching (#1156) picking frames, root motion (#1135) moving the entity, inertialized transitions (#1125) blending jumps — exposed two transition artifacts. Both were diagnosed by replicating the game scene headless and logging every search decision, and each gets a small mechanism:

### 1. Root velocity is now inertialized across clip transitions

A clip switch snapped the entity's travel to the incoming clip's root velocity instantly, while the displayed pose still blended out of the outgoing clip — walking legs with a sprinting body, skating the feet through every switch (worst across large speed jumps, e.g. a database with a walk-to-sprint gap). The applied travel and yaw rate now **crossfade from the frozen outgoing velocity to the incoming clip's extraction, decaying with the same halflife as the pose transition** — the entity accelerates in step with its legs. Measured at a walk→sprint jump, the applied velocity ramps 0.53 → 0.83 → 1.11 → 1.34 → … instead of teleporting to the sprint speed.

- The re-baseline frame right after a switch is covered by the frozen velocity, removing a pre-existing one-frame stall.
- A zero halflife stays an exact hard cut.
- A negligible outgoing velocity arms no blend — without that guard, re-jumps between near-idle frames re-froze residual velocities and sustained a slow drift while standing.

### 2. `MotionMatchingDescriptor.minPlayTime` — a floor between jumps (default 0.3 s)

The search runs every `searchInterval`, and the incumbent switch margin **cannot** stop a frame that systematically beats the current phase: whenever the goal speed exceeds a clip's mean travel, the velocity peak of the cycle wins every search. Playback treadmills — jump to the peak, play a tenth of a second, jump back, forever — a frozen-looking pose drifting across the floor. With the floor, each chosen frame plays through before the next jump may fire; searches continue unchanged.

Measured on the reproducing scene: **223 jumps over 25 s → 53**, with clip time advancing between jumps and travel holding at the goal speed.

`applyRootMotion` takes the frame `deltaTime` (internal) to convert deltas to velocities. Single commit on current develop (b5cb91c5).

> Note: this touches the same `applyRootMotion` region as open #1171; whichever lands second I'll rebase promptly.

## Testing

- New regression test: after a transition out of a traveling clip, the entity keeps most of the outgoing speed on the first frames and settles to the incoming clip's travel.
- All animation suites pass on this base (72 tests: root motion, motion matching, inertialization, foot IK, compiled sampler, policy). SwiftFormat lint clean.
- Docs updated: `UsingRootMotion.md` (velocity crossfade) and `UsingMotionMatching.md` (`minPlayTime`, with the treadmill failure mode described).
