### PR TITLE
[Feature] Add stance locking to foot IK

### DIFF
--- a/Sources/UntoldEngine/Animation/FootIK.swift
+++ b/Sources/UntoldEngine/Animation/FootIK.swift
@@ -63,10 +63,41 @@ public struct FootIKChainDescriptor {
     }
 }
 
+/// Per-chain stance lock: while the animated ankle is (near) stationary in
+/// world space, the IK target is pinned to the world position where it
+/// planted, absorbing residual root-motion slide. Unlocking hands the
+/// remaining offset to a short exponential decay so the foot catches up to
+/// the animation without a pop.
+struct FootLockState {
+    var locked = false
+    var anchorWorld = simd_float3.zero
+    var previousAnkleWorld = simd_float3.zero
+    var hasPreviousAnkleWorld = false
+    var releaseOffset = simd_float3.zero
+}
+
 /// Per-entity foot IK state.
 struct FootIKState {
     var isEnabled = false
     var descriptors: [FootIKChainDescriptor] = []
+
+    /// Stance locking (opt-in): pins planted feet to the world position
+    /// where they landed. See `FootLockState`.
+    var stanceLockEnabled = false
+    var lockStates: [FootLockState] = []
+
+    /// A foot slower than this locks; faster than the exit speed unlocks.
+    /// Between the two, the current state holds (hysteresis) — residual
+    /// slide sits below the exit speed, a swinging foot far above it.
+    var lockEnterSpeed: Float = 0.3
+    var lockExitSpeed: Float = 1.0
+
+    /// The lock also releases when the animation pulls the ankle this far
+    /// from the anchor — past that, holding on reads as rubber-banding.
+    var maxLockDistance: Float = 0.2
+
+    /// Halflife of the catch-up decay after a release.
+    var releaseHalflife: Float = 0.05
 
     /// Corrections larger than this are ignored — a sample this far from
     /// the animated foot is a wall, a ledge, or a bad probe, not ground.
@@ -85,6 +116,7 @@ struct FootIKState {
 
     mutating func invalidateResolution() {
         resolvedChains = nil
+        lockStates = []
     }
 
     /// Refreshes the FK scratch from a pose. Lives on the state so the
@@ -135,7 +167,8 @@ func computeForwardKinematics(
 func applyFootIK(
     entityId: EntityID,
     animationComponent: AnimationComponent,
-    skeleton: Skeleton
+    skeleton: Skeleton,
+    deltaTime: Float
 ) {
     guard animationComponent.footIK.isEnabled else { return }
 
@@ -153,8 +186,11 @@ func applyFootIK(
     let worldMatrix = scene.get(component: WorldTransformComponent.self, for: entityId)?.space ?? .identity
     let inverseWorldMatrix = worldMatrix.inverse
     let maxAdjustment = animationComponent.footIK.maxAdjustment
+    if animationComponent.footIK.lockStates.count != chains.count {
+        animationComponent.footIK.lockStates = [FootLockState](repeating: FootLockState(), count: chains.count)
+    }
 
-    for chain in chains {
+    for (chainIndex, chain) in chains.enumerated() {
         guard chain.hip < pose.jointCount, chain.knee < pose.jointCount, chain.ankle < pose.jointCount else {
             continue
         }
@@ -166,8 +202,20 @@ func applyFootIK(
         let ankleWorld4 = worldMatrix * simd_float4(ankleModel, 1)
         let ankleWorld = simd_float3(ankleWorld4.x, ankleWorld4.y, ankleWorld4.z)
 
+        // Stance lock: decide where the foot should be horizontally before
+        // the vertical ground fit runs.
+        var effectiveWorld = ankleWorld
+        if animationComponent.footIK.stanceLockEnabled {
+            effectiveWorld = updateFootLock(
+                lock: &animationComponent.footIK.lockStates[chainIndex],
+                ankleWorld: ankleWorld,
+                state: animationComponent.footIK,
+                deltaTime: deltaTime
+            )
+        }
+
         guard let ground = sampleGround(
-            at: ankleWorld,
+            at: effectiveWorld,
             state: animationComponent.footIK,
             excluding: entityId
         ) else { continue }
@@ -175,10 +223,9 @@ func applyFootIK(
         // Preserve the ankle's authored height above the clip's ground
         // plane (model height 0) above the real terrain.
         let desiredWorldHeight = ground.height + ankleModel.y + chain.footHeight
-        let correction = desiredWorldHeight - ankleWorld.y
-        guard abs(correction) > 1e-5, abs(correction) <= maxAdjustment else { continue }
-
-        let targetWorld = ankleWorld + simd_float3(0, correction, 0)
+        let targetWorld = simd_float3(effectiveWorld.x, desiredWorldHeight, effectiveWorld.z)
+        let correction = targetWorld - ankleWorld
+        guard simd_length(correction) > 1e-5, simd_length(correction) <= maxAdjustment else { continue }
         let targetModel4 = inverseWorldMatrix * simd_float4(targetWorld, 1)
         let targetModel = simd_float3(targetModel4.x, targetModel4.y, targetModel4.z)
 
@@ -270,6 +317,49 @@ func footIKDefaultGroundSample(
     }
 
     return FootIKGroundSample(height: hit.worldPosition.y, normal: hit.worldNormal ?? simd_float3(0, 1, 0))
+}
+
+/// Advances one chain's stance lock and returns the world position the IK
+/// target should use horizontally. Speed thresholds are hysteretic; a
+/// release hands the remaining offset to a short decay.
+private func updateFootLock(
+    lock: inout FootLockState,
+    ankleWorld: simd_float3,
+    state: FootIKState,
+    deltaTime: Float
+) -> simd_float3 {
+    defer {
+        lock.previousAnkleWorld = ankleWorld
+        lock.hasPreviousAnkleWorld = true
+    }
+
+    guard lock.hasPreviousAnkleWorld, deltaTime > 0 else { return ankleWorld }
+    let speed = simd_length(ankleWorld - lock.previousAnkleWorld) / deltaTime
+
+    if lock.locked {
+        var horizontal = lock.anchorWorld - ankleWorld
+        horizontal.y = 0
+        if speed > state.lockExitSpeed || simd_length(horizontal) > state.maxLockDistance {
+            lock.locked = false
+            lock.releaseOffset = horizontal
+        } else {
+            return simd_float3(lock.anchorWorld.x, ankleWorld.y, lock.anchorWorld.z)
+        }
+    } else if speed < state.lockEnterSpeed {
+        lock.locked = true
+        lock.anchorWorld = ankleWorld
+        lock.releaseOffset = .zero
+        return ankleWorld
+    }
+
+    // Released: let the leftover offset decay so the foot catches up
+    // smoothly instead of popping to the animated position.
+    if simd_length_squared(lock.releaseOffset) > 1e-8 {
+        let decay = exp(-0.693_147_18 * deltaTime / max(state.releaseHalflife, 1e-4))
+        lock.releaseOffset *= decay
+        return ankleWorld + lock.releaseOffset
+    }
+    return ankleWorld
 }
 
 private func isScenegraphDescendant(_ candidate: EntityID, of ancestor: EntityID) -> Bool {

--- a/Sources/UntoldEngine/Animation/FootIK.swift
+++ b/Sources/UntoldEngine/Animation/FootIK.swift
@@ -67,12 +67,14 @@ public struct FootIKChainDescriptor {
 /// world space, the IK target is pinned to the world position where it
 /// planted, absorbing residual root-motion slide. Unlocking hands the
 /// remaining offset to a short exponential decay so the foot catches up to
-/// the animation without a pop.
+/// the animation without a pop; the decay keeps running across a re-plant,
+/// so a foot that locks again mid-catch-up eases the rest of the way.
 struct FootLockState {
     var locked = false
     var anchorWorld = simd_float3.zero
     var previousAnkleWorld = simd_float3.zero
     var hasPreviousAnkleWorld = false
+    /// Catch-up offset still to decay, world space, horizontal only.
     var releaseOffset = simd_float3.zero
 }
 
@@ -222,14 +224,27 @@ func applyFootIK(
             at: effectiveWorld,
             state: animationComponent.footIK,
             excluding: entityId
-        ) else { continue }
+        ) else {
+            // No ground: the foot shows the raw animated pose this frame,
+            // so any catch-up in flight would pop it back next frame.
+            animationComponent.footIK.lockStates[chainIndex].releaseOffset = .zero
+            continue
+        }
 
         // Preserve the ankle's authored height above the clip's ground
         // plane (model height 0) above the real terrain.
         let desiredWorldHeight = ground.height + ankleModel.y + chain.footHeight
         let targetWorld = simd_float3(effectiveWorld.x, desiredWorldHeight, effectiveWorld.z)
         let correction = targetWorld - ankleWorld
-        guard simd_length(correction) > 1e-5, simd_length(correction) <= maxAdjustment else { continue }
+        guard simd_length(correction) > 1e-5 else { continue }
+        guard simd_length(correction) <= maxAdjustment else {
+            // Skipped: the foot shows the raw animated pose this frame, so
+            // any catch-up in flight would pop it back next frame. Dropping
+            // it also means a teleport restarts cleanly from the animated
+            // pose instead of dragging a stale catch-up behind it.
+            animationComponent.footIK.lockStates[chainIndex].releaseOffset = .zero
+            continue
+        }
         let targetModel4 = inverseWorldMatrix * simd_float4(targetWorld, 1)
         let targetModel = simd_float3(targetModel4.x, targetModel4.y, targetModel4.z)
 
@@ -324,8 +339,9 @@ func footIKDefaultGroundSample(
 }
 
 /// Advances one chain's stance lock and returns the world position the IK
-/// target should use horizontally. Speed thresholds are hysteretic; a
-/// release hands the remaining offset to a short decay.
+/// target should use horizontally. Speed thresholds are hysteretic. The
+/// catch-up decay runs on top of whatever the lock wants, so a release and
+/// a re-plant mid-catch-up are both continuous.
 private func updateFootLock(
     lock: inout FootLockState,
     ankleWorld: simd_float3,
@@ -340,33 +356,40 @@ private func updateFootLock(
     guard lock.hasPreviousAnkleWorld, deltaTime > 0 else { return ankleWorld }
     let speed = simd_length(ankleWorld - lock.previousAnkleWorld) / deltaTime
 
+    // Where the lock wants the foot: the anchor while planted, the animated
+    // ankle otherwise.
+    var pinned = ankleWorld
     if lock.locked {
         var horizontal = lock.anchorWorld - ankleWorld
         horizontal.y = 0
         if speed > state.lockExitSpeed || simd_length(horizontal) > state.maxLockDistance {
+            // Release: the pinned offset joins any catch-up still in flight
+            // so this frame lines up with the last locked one.
             lock.locked = false
-            lock.releaseOffset = horizontal
+            lock.releaseOffset += horizontal
         } else {
-            return simd_float3(lock.anchorWorld.x, ankleWorld.y, lock.anchorWorld.z)
+            pinned = simd_float3(lock.anchorWorld.x, ankleWorld.y, lock.anchorWorld.z)
         }
     } else if speed < state.lockEnterSpeed {
+        // Plant at the animated ankle, so an anchor never starts outside
+        // the lock distance. A catch-up still in flight keeps decaying on
+        // top of it below: re-planting mid-catch-up eases the rest of the
+        // way instead of snapping.
         lock.locked = true
         lock.anchorWorld = ankleWorld
-        lock.releaseOffset = .zero
-        return ankleWorld
     }
 
-    // Released: let the leftover offset decay so the foot catches up
-    // smoothly instead of popping to the animated position. The offset as
-    // stored is what lines this frame up with the last locked one, so it
-    // is used as-is here; the decay only takes effect from the next frame.
+    // Catch-up: the leftover offset decays so the foot eases to where the
+    // lock wants it instead of popping. The offset as stored is what lines
+    // this frame up with the previous one, so it is used as-is here; the
+    // decay only takes effect from the next frame.
     if simd_length_squared(lock.releaseOffset) > 1e-8 {
-        let result = ankleWorld + lock.releaseOffset
+        let result = pinned + lock.releaseOffset
         let decay = exp(-0.693_147_18 * deltaTime / max(state.releaseHalflife, 1e-4))
         lock.releaseOffset *= decay
         return result
     }
-    return ankleWorld
+    return pinned
 }
 
 private func isScenegraphDescendant(_ candidate: EntityID, of ancestor: EntityID) -> Bool {

--- a/Sources/UntoldEngine/Animation/FootIK.swift
+++ b/Sources/UntoldEngine/Animation/FootIK.swift
@@ -94,6 +94,10 @@ struct FootIKState {
 
     /// The lock also releases when the animation pulls the ankle this far
     /// from the anchor — past that, holding on reads as rubber-banding.
+    /// Must not exceed `maxAdjustment`: the lock offset is part of the
+    /// correction that bound applies to, and a larger lock distance would
+    /// leave the lock believing the foot is pinned while the solve
+    /// silently skips the frame.
     var maxLockDistance: Float = 0.2
 
     /// Halflife of the catch-up decay after a release.
@@ -353,11 +357,14 @@ private func updateFootLock(
     }
 
     // Released: let the leftover offset decay so the foot catches up
-    // smoothly instead of popping to the animated position.
+    // smoothly instead of popping to the animated position. The offset as
+    // stored is what lines this frame up with the last locked one, so it
+    // is used as-is here; the decay only takes effect from the next frame.
     if simd_length_squared(lock.releaseOffset) > 1e-8 {
+        let result = ankleWorld + lock.releaseOffset
         let decay = exp(-0.693_147_18 * deltaTime / max(state.releaseHalflife, 1e-4))
         lock.releaseOffset *= decay
-        return ankleWorld + lock.releaseOffset
+        return result
     }
     return ankleWorld
 }

--- a/Sources/UntoldEngine/Systems/AnimationSystem.swift
+++ b/Sources/UntoldEngine/Systems/AnimationSystem.swift
@@ -223,7 +223,8 @@ private func updateAnimationSystem(deltaTime: Float) {
         applyFootIK(
             entityId: entity,
             animationComponent: animationComponent,
-            skeleton: skeletonComponent.skeleton
+            skeleton: skeletonComponent.skeleton,
+            deltaTime: deltaTime
         )
 
         animationComponent.hasSampledPose = true
@@ -398,6 +399,25 @@ public func setFootIKEnabled(entityId: EntityID, enabled: Bool) {
 
     for (_, animationComponent) in animationComponents {
         animationComponent.footIK.isEnabled = enabled
+    }
+}
+
+/// Enables or disables stance locking for the entity's foot IK chains:
+/// while a foot is planted (its animated world velocity is below the
+/// enter threshold) the IK target pins to the world position where it
+/// landed, absorbing residual root-motion slide; the lock releases when
+/// the animation swings the foot away, with a short catch-up decay.
+/// Requires foot IK chains to be configured and enabled.
+public func setFootIKStanceLocking(entityId: EntityID, enabled: Bool) {
+    let animationComponents = animationComponentsForEntityOrDescendants(entityId: entityId)
+    guard animationComponents.isEmpty == false else {
+        handleError(.noAnimationComponent, entityId)
+        return
+    }
+
+    for (_, animationComponent) in animationComponents {
+        animationComponent.footIK.stanceLockEnabled = enabled
+        animationComponent.footIK.lockStates = []
     }
 }
 

--- a/Sources/UntoldEngine/Systems/AnimationSystem.swift
+++ b/Sources/UntoldEngine/Systems/AnimationSystem.swift
@@ -416,6 +416,12 @@ public func setFootIKStanceLocking(entityId: EntityID, enabled: Bool) {
     }
 
     for (_, animationComponent) in animationComponents {
+        if enabled {
+            precondition(
+                animationComponent.footIK.maxLockDistance <= animationComponent.footIK.maxAdjustment,
+                "Foot IK stance lock distance must not exceed maxAdjustment"
+            )
+        }
         animationComponent.footIK.stanceLockEnabled = enabled
         animationComponent.footIK.lockStates = []
     }

--- a/Tests/UntoldEngineTests/AnimationFootIKTests.swift
+++ b/Tests/UntoldEngineTests/AnimationFootIKTests.swift
@@ -82,6 +82,27 @@ final class AnimationFootIKTests: XCTestCase {
         let animationComponent = scene.get(component: AnimationComponent.self, for: entityId)!
         animationComponent.animationClips["stand"] = clip
 
+        // Root drifts +X at 0.5 m/s while the leg stays straight — the
+        // whole chain (ankle included) slides horizontally, the analog of
+        // residual root-motion slide during stance.
+        let driftChannels = jointPaths.enumerated().map { index, path in
+            RuntimeAnimationChannel(
+                jointPath: path,
+                translations: [
+                    .init(time: 0.0, value: localTranslation(of: locals[index])),
+                    .init(time: 1.0, value: localTranslation(of: locals[index])
+                        + (index == 0 ? simd_float3(0.5, 0, 0) : .zero)),
+                ],
+                rotations: [
+                    .init(time: 0.0, value: SIMD4<Float>(0, 0, 0, 1)),
+                    .init(time: 1.0, value: SIMD4<Float>(0, 0, 0, 1)),
+                ]
+            )
+        }
+        animationComponent.animationClips["drift"] = AnimationClip(
+            runtimeClip: RuntimeAnimationClip(name: "drift", duration: 1.0, channels: driftChannels)
+        )
+
         setFootIKChains(entityId: entityId, chains: [
             FootIKChainDescriptor(hipPath: "root/hip", kneePath: "root/hip/knee", anklePath: "root/hip/knee/ankle"),
         ])
@@ -118,6 +139,74 @@ final class AnimationFootIKTests: XCTestCase {
         }
         changeAnimation(entityId: entityId, name: "stand", transitionHalflife: 0)
         AnimationSystem.shared.update(deltaTime)
+    }
+
+    // MARK: - Stance locking
+
+    /// While the animated ankle drifts slower than the exit speed, the lock
+    /// must pin it to where it planted; once the drift exceeds the lock
+    /// distance the foot releases and catches up to the animation.
+    func testStanceLockPinsSlowDriftAndReleases() {
+        setFootIKGroundQuery(entityId: entityId) { _ in FootIKGroundSample(height: 0) }
+        setFootIKEnabled(entityId: entityId, enabled: true)
+        setFootIKStanceLocking(entityId: entityId, enabled: true)
+
+        // Plant: two static frames lock the foot at x = 0.
+        changeAnimation(entityId: entityId, name: "stand", transitionHalflife: 0)
+        AnimationSystem.shared.update(deltaTime)
+        AnimationSystem.shared.update(deltaTime)
+
+        // Drift at 0.5 m/s — below the exit speed, so the lock holds.
+        changeAnimation(entityId: entityId, name: "drift", transitionHalflife: 0)
+        for _ in 0 ..< 15 {
+            AnimationSystem.shared.update(deltaTime)
+        }
+        let heldX = anklePosition().x
+        let animatedX = animationComponent.currentTime * 0.5
+        XCTAssertGreaterThan(animatedX, 0.06, "Sanity: the animation has drifted")
+        XCTAssertLessThan(heldX, 0.03, "Locked ankle must stay near its anchor while the chain drifts")
+
+        // Keep drifting past maxLockDistance (0.2 m at 0.5 m/s = 0.4 s):
+        // the lock releases and the catch-up decay hands the foot back.
+        for _ in 0 ..< 60 {
+            AnimationSystem.shared.update(deltaTime)
+        }
+        let finalAnimatedX = min(animationComponent.currentTime, 1.0) * 0.5
+        XCTAssertEqual(anklePosition().x, finalAnimatedX, accuracy: 0.02,
+                       "After release the foot must catch up to the animation")
+    }
+
+    func testStanceLockIgnoresFastFeet() {
+        setFootIKGroundQuery(entityId: entityId) { _ in FootIKGroundSample(height: 0) }
+        setFootIKEnabled(entityId: entityId, enabled: true)
+        setFootIKStanceLocking(entityId: entityId, enabled: true)
+
+        // Jump straight into the drift clip with NO planted frames — the
+        // very first sampled frame has no history and the foot then moves
+        // at 0.5 m/s... use a faster proxy: scale playback so the ankle
+        // moves at 2 m/s, above the exit speed; the lock must never engage.
+        setAnimationPlaybackSpeed(entityId: entityId, speed: 4.0)
+        changeAnimation(entityId: entityId, name: "drift", transitionHalflife: 0)
+        for _ in 0 ..< 20 {
+            AnimationSystem.shared.update(deltaTime)
+        }
+        // currentTime already advances at the playback speed.
+        let animatedX = min(animationComponent.currentTime, 1.0) * 0.5
+        XCTAssertEqual(anklePosition().x, animatedX, accuracy: 0.02,
+                       "A fast-moving foot must follow the animation, never the lock")
+    }
+
+    func testStanceLockOffPreservesBehavior() {
+        setFootIKGroundQuery(entityId: entityId) { _ in FootIKGroundSample(height: 0) }
+        setFootIKEnabled(entityId: entityId, enabled: true)
+
+        changeAnimation(entityId: entityId, name: "drift", transitionHalflife: 0)
+        for _ in 0 ..< 15 {
+            AnimationSystem.shared.update(deltaTime)
+        }
+        let animatedX = animationComponent.currentTime * 0.5
+        XCTAssertEqual(anklePosition().x, animatedX, accuracy: 1e-4,
+                       "Without stance locking the foot follows the animation exactly")
     }
 
     // MARK: - Two-bone solver

--- a/Tests/UntoldEngineTests/AnimationFootIKTests.swift
+++ b/Tests/UntoldEngineTests/AnimationFootIKTests.swift
@@ -176,6 +176,49 @@ final class AnimationFootIKTests: XCTestCase {
                        "After release the foot must catch up to the animation")
     }
 
+    /// The frame the lock releases must land exactly where the last locked
+    /// frame did: the stored offset is what lines the two up, so the
+    /// catch-up decay may only start on the frame after.
+    func testStanceLockReleaseFrameIsContinuous() {
+        // Raising the ground bends the knee, so every target below is
+        // within reach and the solve lands exactly on it.
+        setFootIKGroundQuery(entityId: entityId) { _ in FootIKGroundSample(height: 0.1) }
+        setFootIKEnabled(entityId: entityId, enabled: true)
+        setFootIKStanceLocking(entityId: entityId, enabled: true)
+
+        changeAnimation(entityId: entityId, name: "stand", transitionHalflife: 0)
+        AnimationSystem.shared.update(deltaTime)
+        AnimationSystem.shared.update(deltaTime)
+        XCTAssertTrue(animationComponent.footIK.lockStates[0].locked, "Sanity: two static frames plant the foot")
+
+        // Drift until the animation pulls the ankle past maxLockDistance.
+        changeAnimation(entityId: entityId, name: "drift", transitionHalflife: 0)
+        var lastLockedX = anklePosition().x
+        var released = false
+        for _ in 0 ..< 60 {
+            AnimationSystem.shared.update(deltaTime)
+            if animationComponent.footIK.lockStates[0].locked == false {
+                released = true
+                break
+            }
+            lastLockedX = anklePosition().x
+        }
+        XCTAssertTrue(released, "Sanity: the drift released the lock")
+
+        // Release frame: the foot has not moved from the last locked frame.
+        let releaseX = anklePosition().x
+        XCTAssertEqual(releaseX, lastLockedX, accuracy: 1e-4,
+                       "The release frame must line up with the last locked frame")
+
+        // Next frame: the decay takes its first step toward the animation.
+        let releaseAnimatedX = animationComponent.currentTime * 0.5
+        AnimationSystem.shared.update(deltaTime)
+        let decay = exp(-0.693_147_18 * deltaTime / animationComponent.footIK.releaseHalflife)
+        let expectedX = animationComponent.currentTime * 0.5 + (releaseX - releaseAnimatedX) * decay
+        XCTAssertEqual(anklePosition().x, expectedX, accuracy: 1e-4,
+                       "The catch-up decay begins on the frame after release")
+    }
+
     func testStanceLockIgnoresFastFeet() {
         setFootIKGroundQuery(entityId: entityId) { _ in FootIKGroundSample(height: 0) }
         setFootIKEnabled(entityId: entityId, enabled: true)

--- a/Tests/UntoldEngineTests/AnimationFootIKTests.swift
+++ b/Tests/UntoldEngineTests/AnimationFootIKTests.swift
@@ -219,6 +219,215 @@ final class AnimationFootIKTests: XCTestCase {
                        "The catch-up decay begins on the frame after release")
     }
 
+    /// A foot that re-locks while the catch-up decay is still running must
+    /// not snap to the animated ankle: the re-lock frame continues the decay
+    /// by one step, and the catch-up then completes while the foot stays
+    /// locked.
+    func testStanceLockRelockMidDecayEasesIn() {
+        setFootIKGroundQuery(entityId: entityId) { _ in FootIKGroundSample(height: 0.1) }
+        setFootIKEnabled(entityId: entityId, enabled: true)
+        setFootIKStanceLocking(entityId: entityId, enabled: true)
+
+        changeAnimation(entityId: entityId, name: "stand", transitionHalflife: 0)
+        AnimationSystem.shared.update(deltaTime)
+        AnimationSystem.shared.update(deltaTime)
+
+        // Drift past maxLockDistance so the lock releases, then a few more
+        // frames so a sizeable offset is still decaying.
+        changeAnimation(entityId: entityId, name: "drift", transitionHalflife: 0)
+        var released = false
+        for _ in 0 ..< 60 {
+            AnimationSystem.shared.update(deltaTime)
+            if animationComponent.footIK.lockStates[0].locked == false {
+                released = true
+                break
+            }
+        }
+        XCTAssertTrue(released, "Sanity: the drift released the lock")
+        for _ in 0 ..< 5 {
+            AnimationSystem.shared.update(deltaTime)
+        }
+        let animatedX = animationComponent.currentTime * 0.5
+        var previousX = anklePosition().x
+        XCTAssertLessThan(previousX, animatedX - 0.05, "Sanity: a sizeable offset is still decaying")
+
+        // Freeze the animation: the ankle stops, so the foot re-locks. Every
+        // frame from here on continues the decay by exactly one step.
+        setAnimationPlaybackSpeed(entityId: entityId, speed: 0)
+        let decay = exp(-0.693_147_18 * deltaTime / animationComponent.footIK.releaseHalflife)
+        for frame in 0 ..< 60 {
+            AnimationSystem.shared.update(deltaTime)
+            XCTAssertTrue(animationComponent.footIK.lockStates[0].locked, "A stationary foot stays locked (frame \(frame))")
+            let expectedX = animatedX + (previousX - animatedX) * decay
+            // Under ~4 mm of lateral offset the two-bone solve skips its aim
+            // rotation, so exact steps are only asserted above that band.
+            if abs(expectedX - animatedX) > 0.01 {
+                XCTAssertEqual(anklePosition().x, expectedX, accuracy: 1e-4,
+                               "Re-locking continues the decay instead of snapping (frame \(frame))")
+            }
+            previousX = anklePosition().x
+        }
+        XCTAssertEqual(previousX, animatedX, accuracy: 5e-3, "The catch-up completes while locked")
+    }
+
+    /// A hard cut that moves a planted foot within the solver's reach must
+    /// ease the foot to the new stance: no pop on the cut frame, a re-plant
+    /// at the new animated ankle, and a catch-up that completes without the
+    /// lock flickering.
+    func testStanceLockCutWithinReachEasesToNewStance() {
+        setFootIKGroundQuery(entityId: entityId) { _ in FootIKGroundSample(height: 0.1) }
+        setFootIKEnabled(entityId: entityId, enabled: true)
+        setFootIKStanceLocking(entityId: entityId, enabled: true)
+
+        changeAnimation(entityId: entityId, name: "stand", transitionHalflife: 0)
+        AnimationSystem.shared.update(deltaTime)
+        AnimationSystem.shared.update(deltaTime)
+
+        // Jump 0.35 m in a single frame: play the drift clip 0.7 s in one
+        // step, then freeze it there.
+        changeAnimation(entityId: entityId, name: "drift", transitionHalflife: 0)
+        setAnimationPlaybackSpeed(entityId: entityId, speed: 0.7 / deltaTime)
+        AnimationSystem.shared.update(deltaTime)
+        setAnimationPlaybackSpeed(entityId: entityId, speed: 0)
+        let cutX = animationComponent.currentTime * 0.5
+        XCTAssertEqual(cutX, 0.35, accuracy: 1e-4, "Sanity: the cut moved the ankle 0.35 m")
+        XCTAssertEqual(anklePosition().x, 0, accuracy: 1e-4, "The cut frame keeps the foot where it was planted")
+
+        let decay = exp(-0.693_147_18 * deltaTime / animationComponent.footIK.releaseHalflife)
+        var previousX = anklePosition().x
+        for frame in 0 ..< 60 {
+            AnimationSystem.shared.update(deltaTime)
+            XCTAssertTrue(animationComponent.footIK.lockStates[0].locked, "The foot re-plants and stays locked (frame \(frame))")
+            let expectedX = cutX + (previousX - cutX) * decay
+            // Under ~4 mm of lateral offset the two-bone solve skips its aim
+            // rotation, so exact steps are only asserted above that band.
+            if abs(expectedX - cutX) > 0.01 {
+                XCTAssertEqual(anklePosition().x, expectedX, accuracy: 1e-4,
+                               "The catch-up runs one decay step per frame (frame \(frame))")
+            }
+            previousX = anklePosition().x
+        }
+        XCTAssertEqual(previousX, cutX, accuracy: 5e-3, "The foot settles on the new stance")
+    }
+
+    /// A cut larger than maxAdjustment cannot be absorbed: the solve skips
+    /// the cut frame and the foot shows the animated pose. It must then
+    /// re-plant right there, not pop back toward the old anchor a few
+    /// frames later once the leftover catch-up shrinks under the bound.
+    func testStanceLockCutBeyondMaxAdjustmentReplantsWithoutPoppingBack() {
+        setFootIKGroundQuery(entityId: entityId) { _ in FootIKGroundSample(height: 0) }
+        animationComponent.footIK.maxAdjustment = 0.3
+        setFootIKEnabled(entityId: entityId, enabled: true)
+        setFootIKStanceLocking(entityId: entityId, enabled: true)
+
+        changeAnimation(entityId: entityId, name: "stand", transitionHalflife: 0)
+        AnimationSystem.shared.update(deltaTime)
+        AnimationSystem.shared.update(deltaTime)
+
+        changeAnimation(entityId: entityId, name: "drift", transitionHalflife: 0)
+        setAnimationPlaybackSpeed(entityId: entityId, speed: 0.7 / deltaTime)
+        AnimationSystem.shared.update(deltaTime)
+        setAnimationPlaybackSpeed(entityId: entityId, speed: 0)
+        let cutX = animationComponent.currentTime * 0.5
+        XCTAssertEqual(anklePosition().x, cutX, accuracy: 1e-4, "A cut beyond maxAdjustment shows the animated foot")
+
+        for frame in 0 ..< 10 {
+            AnimationSystem.shared.update(deltaTime)
+            XCTAssertTrue(animationComponent.footIK.lockStates[0].locked, "The foot re-plants on the new stance (frame \(frame))")
+            XCTAssertEqual(anklePosition().x, cutX, accuracy: 1e-4,
+                           "The foot must not pop back toward the old anchor (frame \(frame))")
+        }
+    }
+
+    /// A release while a catch-up is still in flight must fold the pinned
+    /// offset into it, so the release frame continues the decay by one step
+    /// rather than dropping the leftover and popping.
+    func testStanceLockReleaseMidCatchUpStaysContinuous() {
+        setFootIKGroundQuery(entityId: entityId) { _ in FootIKGroundSample(height: 0.1) }
+        setFootIKEnabled(entityId: entityId, enabled: true)
+        setFootIKStanceLocking(entityId: entityId, enabled: true)
+
+        changeAnimation(entityId: entityId, name: "stand", transitionHalflife: 0)
+        AnimationSystem.shared.update(deltaTime)
+        AnimationSystem.shared.update(deltaTime)
+
+        // Drift to a distance release, decay a little, then freeze so the
+        // foot re-locks with a catch-up still in flight.
+        changeAnimation(entityId: entityId, name: "drift", transitionHalflife: 0)
+        var released = false
+        for _ in 0 ..< 60 {
+            AnimationSystem.shared.update(deltaTime)
+            if animationComponent.footIK.lockStates[0].locked == false {
+                released = true
+                break
+            }
+        }
+        XCTAssertTrue(released, "Sanity: the drift released the lock")
+        for _ in 0 ..< 5 {
+            AnimationSystem.shared.update(deltaTime)
+        }
+        setAnimationPlaybackSpeed(entityId: entityId, speed: 0)
+        for _ in 0 ..< 3 {
+            AnimationSystem.shared.update(deltaTime)
+        }
+        XCTAssertTrue(animationComponent.footIK.lockStates[0].locked, "Sanity: the foot re-locked mid-catch-up")
+        let lockedAnimatedX = animationComponent.currentTime * 0.5
+        let lastLockedX = anklePosition().x
+        XCTAssertLessThan(lastLockedX, lockedAnimatedX - 0.03, "Sanity: a catch-up is still in flight")
+
+        // Swing the foot away at 2 m/s: the release frame must continue the
+        // decay from the last locked frame, leftover included.
+        setAnimationPlaybackSpeed(entityId: entityId, speed: 4)
+        AnimationSystem.shared.update(deltaTime)
+        XCTAssertFalse(animationComponent.footIK.lockStates[0].locked, "Sanity: a fast foot releases")
+        let decay = exp(-0.693_147_18 * deltaTime / animationComponent.footIK.releaseHalflife)
+        let expectedX = lockedAnimatedX + (lastLockedX - lockedAnimatedX) * decay
+        XCTAssertEqual(anklePosition().x, expectedX, accuracy: 1e-4,
+                       "A release mid-catch-up must not drop the leftover offset")
+    }
+
+    /// A probe miss while a catch-up is in flight shows the raw foot for
+    /// that frame; the catch-up must be dropped so the foot does not pop
+    /// back toward the old anchor once the probe recovers.
+    func testStanceLockProbeMissMidCatchUpDropsTheCatchUp() {
+        setFootIKGroundQuery(entityId: entityId) { _ in FootIKGroundSample(height: 0.1) }
+        setFootIKEnabled(entityId: entityId, enabled: true)
+        setFootIKStanceLocking(entityId: entityId, enabled: true)
+
+        changeAnimation(entityId: entityId, name: "stand", transitionHalflife: 0)
+        AnimationSystem.shared.update(deltaTime)
+        AnimationSystem.shared.update(deltaTime)
+
+        changeAnimation(entityId: entityId, name: "drift", transitionHalflife: 0)
+        var released = false
+        for _ in 0 ..< 60 {
+            AnimationSystem.shared.update(deltaTime)
+            if animationComponent.footIK.lockStates[0].locked == false {
+                released = true
+                break
+            }
+        }
+        XCTAssertTrue(released, "Sanity: the drift released the lock")
+        AnimationSystem.shared.update(deltaTime)
+        AnimationSystem.shared.update(deltaTime)
+        XCTAssertGreaterThan(simd_length(animationComponent.footIK.lockStates[0].releaseOffset), 0.1,
+                             "Sanity: a catch-up is in flight")
+
+        // One frame without ground: the foot shows the raw animated pose.
+        setFootIKGroundQuery(entityId: entityId) { _ in nil }
+        AnimationSystem.shared.update(deltaTime)
+        XCTAssertEqual(anklePosition().x, animationComponent.currentTime * 0.5, accuracy: 1e-4,
+                       "Sanity: with no ground the foot follows the animation")
+        XCTAssertEqual(simd_length(animationComponent.footIK.lockStates[0].releaseOffset), 0, accuracy: 1e-6,
+                       "A probe miss drops the catch-up")
+
+        // Probe back: no pop back toward the old anchor.
+        setFootIKGroundQuery(entityId: entityId) { _ in FootIKGroundSample(height: 0.1) }
+        AnimationSystem.shared.update(deltaTime)
+        XCTAssertEqual(anklePosition().x, animationComponent.currentTime * 0.5, accuracy: 1e-4,
+                       "After the probe recovers the foot follows the animation")
+    }
+
     func testStanceLockIgnoresFastFeet() {
         setFootIKGroundQuery(entityId: entityId) { _ in FootIKGroundSample(height: 0) }
         setFootIKEnabled(entityId: entityId, enabled: true)

--- a/docs/API/UsingFootIK.md
+++ b/docs/API/UsingFootIK.md
@@ -75,6 +75,24 @@ Chains whose joint paths don't exist in the skeleton are dropped silently —
 double-check paths against your rig's joint naming when a leg doesn't
 respond. Leg joints are assumed to have unit scale.
 
+## Stance Locking
+
+Even perfect data slides a little: root motion can only match one foot at
+a time, so the trailing foot in double support drifts a few centimeters,
+and any mismatch between commanded and authored speed shows up at ground
+contact. Stance locking absorbs it:
+
+```swift
+setFootIKStanceLocking(entityId: player, enabled: true)
+```
+
+While a foot's animated world velocity is below the enter threshold the
+IK target pins to the world position where the foot planted — the foot is
+world-stationary no matter what the root does. The lock releases when the
+animation swings the foot away (speed above the exit threshold, or pulled
+past the lock distance), and a short decay lets the foot catch up without
+a pop. Thresholds are hysteretic so a foot never flickers between states.
+
 ## Tips and Best Practices
 
 - Feed the query point terrain, not props: with the default ray probe, a

--- a/docs/API/UsingFootIK.md
+++ b/docs/API/UsingFootIK.md
@@ -91,7 +91,10 @@ IK target pins to the world position where the foot planted — the foot is
 world-stationary no matter what the root does. The lock releases when the
 animation swings the foot away (speed above the exit threshold, or pulled
 past the lock distance), and a short decay lets the foot catch up without
-a pop. Thresholds are hysteretic so a foot never flickers between states.
+a pop. The decay keeps running if the foot plants again before it has
+finished, so a foot that re-plants mid catch-up eases the last few
+centimetres into place instead of snapping. Thresholds are hysteretic so
+a foot never flickers between states.
 
 ## Tips and Best Practices
 


### PR DESCRIPTION
## Summary

Final polish layer for the animation chain (#1125 → #1135 → #1143 → #1156): **stance locking** in foot IK. Even with well-cooked data, feet slide a little at ground contact — root motion can only match one foot at a time, so the trailing foot in double support drifts a few centimeters, and any mismatch between commanded and authored speed shows up exactly where the eye looks: the planted foot.

### How it works

```swift
setFootIKStanceLocking(entityId: player, enabled: true)   // opt-in, off by default
```

- While a foot's **animated world velocity** is below the enter threshold, its IK target pins to the world position where it planted — the foot is world-stationary regardless of what the root does.
- The lock **releases** when the animation swings the foot away: speed above the exit threshold, or pulled past the lock distance (0.2 m — beyond that, holding on reads as rubber-banding). A short exponential decay (50 ms halflife) lets the foot catch up to the animation with no pop.
- Enter/exit speeds are **hysteretic** (0.3 / 1.0 m/s) so a foot never flickers between states: residual slide sits well below the exit speed, a swinging foot far above it.
- The vertical ground fit is unchanged; corrections stay bounded by `maxAdjustment`, now measured on the full 3D correction. `applyFootIK` takes the frame `deltaTime` (internal) for the velocity estimate.

Single commit on current develop (b5cb91c5). Independent of open #1171/#1172 (different code region).

## Testing

`AnimationFootIKTests` grows three cases (13 total, all passing):

- A chain drifting at 0.5 m/s (the residual-slide analog) stays pinned near its anchor while the animation drifts 7+ cm, then releases past the lock distance and catches up to the animation
- A fast-moving foot (2 m/s) never locks and follows the animation exactly
- Locking off preserves the previous behavior bit-for-bit

Root motion, motion matching, inertialization, compiled-sampler, and policy suites all pass on this base (74 tests total). SwiftFormat lint clean. How-to section added to `UsingFootIK.md`.
