### PR TITLE
[Patch] Strip root yaw on the left so rest-rotated roots stay upright

### DIFF
--- a/Sources/UntoldEngine/Animation/RootMotion.swift
+++ b/Sources/UntoldEngine/Animation/RootMotion.swift
@@ -111,9 +111,11 @@ func wrapAngle(_ angle: Float) -> Float {
 }
 
 /// Swing–twist decomposition about the +Y axis: returns the yaw angle and
-/// the twist quaternion, with the remainder (`q * twist⁻¹`) carrying pitch
-/// and roll. The twist is normalized to the shortest arc so yaw is always
-/// in (-π, π].
+/// the twist quaternion. Root yaw is a model-space rotation applied on the
+/// left of the joint's rest (`q = twist * rest * …`), so the remainder that
+/// carries pitch, roll, and the rest orientation is `twist⁻¹ * q` — see
+/// `stripRootMotion`. The twist is normalized to the shortest arc so yaw
+/// is always in (-π, π].
 @inline(__always)
 func yawTwist(_ q: simd_quatf) -> (yaw: Float, twist: simd_quatf) {
     let projected = simd_float4(0, q.imag.y, 0, q.real)
@@ -131,14 +133,22 @@ func yawTwist(_ q: simd_quatf) -> (yaw: Float, twist: simd_quatf) {
 
 /// Grounds the root joint of a local pose: horizontal translation is zeroed
 /// and yaw removed (the entity transform owns both once root motion is on);
-/// vertical translation, pitch, and roll remain.
+/// vertical translation, pitch, roll, and the root's rest orientation
+/// remain.
+///
+/// The yaw is removed on the LEFT. Rigs whose root bone has a rest rotation
+/// (the UE mannequin's root is rotated 90° about X) author turns as a
+/// model-space yaw on top of that rest, `q = R_y(θ) * rest`; removing the
+/// twist on the right would give `R_y(θ) * rest * R_y(-θ)` — the rest
+/// rotation conjugated by the turn, which rolls the whole body onto its
+/// side by θ. Only for an identity rest are the two sides the same.
 @inline(__always)
 func stripRootMotion(from pose: inout PoseBuffer, rootIndex: Int) {
     guard rootIndex >= 0, rootIndex < pose.jointCount else { return }
     pose.translations[rootIndex].x = 0
     pose.translations[rootIndex].z = 0
     let (_, twist) = yawTwist(pose.rotations[rootIndex])
-    pose.rotations[rootIndex] = simd_normalize(pose.rotations[rootIndex] * twist.inverse)
+    pose.rotations[rootIndex] = simd_normalize(twist.inverse * pose.rotations[rootIndex])
 }
 
 // MARK: - Per-frame extraction

--- a/Tests/UntoldEngineTests/AnimationRootMotionTests.swift
+++ b/Tests/UntoldEngineTests/AnimationRootMotionTests.swift
@@ -267,10 +267,11 @@ final class AnimationRootMotionTests: XCTestCase {
 
     // MARK: - Pitch and roll preservation
 
-    /// The swing–twist split must remove only yaw. Pure pitch (and pure
-    /// roll) composed with yaw decomposes exactly — the twist is the yaw
-    /// factor — so grounding must return the authored lean untouched; a
-    /// sign error or axis mixup in the twist projection would break this.
+    /// The swing–twist split must remove only yaw. A body-frame lean —
+    /// pure pitch (and pure roll) applied after the model-space yaw,
+    /// `yaw * lean` — decomposes exactly: the twist is the yaw factor, so
+    /// grounding must return the authored lean untouched; a sign error,
+    /// axis mixup, or stripping on the wrong side would break this.
     func testPitchAndRollSurviveGrounding() {
         let yaw = simd_quatf(angle: 0.7, axis: simd_float3(0, 1, 0))
         let leans: [(name: String, swing: simd_quatf)] = [
@@ -282,7 +283,7 @@ final class AnimationRootMotionTests: XCTestCase {
             var pose = PoseBuffer()
             pose.resize(jointCount: 1)
             pose.translations[0] = simd_float3(0.3, 0.9, 1.2)
-            pose.rotations[0] = simd_normalize(swing * yaw)
+            pose.rotations[0] = simd_normalize(yaw * swing)
 
             stripRootMotion(from: &pose, rootIndex: 0)
 
@@ -405,6 +406,72 @@ final class AnimationRootMotionTests: XCTestCase {
         let settledSpeed = (getLocalPosition(entityId: entityId).z - zSettled) / deltaTime
         XCTAssertLessThan(abs(settledSpeed), 0.05,
                           "The crossfade must settle to the incoming clip's travel")
+    }
+
+    // MARK: - Rest-rotated root
+
+    /// Rigs like the UE mannequin carry a rest rotation on the root bone
+    /// (90° about X) and author turns as a model-space yaw on top of it.
+    /// Grounding must remove only that yaw and leave the rest orientation
+    /// intact — removing the twist on the wrong side rolls the body onto
+    /// its side by the turn angle.
+    func testTurnOnRestRotatedRootKeepsBodyUpright() throws {
+        let rest = simd_quatf(angle: .pi / 2, axis: simd_float3(1, 0, 0))
+        let rigged = createEntity()
+        registerComponent(entityId: rigged, componentType: SkeletonComponent.self)
+        registerComponent(entityId: rigged, componentType: AnimationComponent.self)
+        registerComponent(entityId: rigged, componentType: RenderComponent.self)
+        registerComponent(entityId: rigged, componentType: ScenegraphComponent.self)
+        registerComponent(entityId: rigged, componentType: LocalTransformComponent.self)
+        registerComponent(entityId: rigged, componentType: WorldTransformComponent.self)
+        defer { destroyEntity(entityId: rigged) }
+
+        let restMatrix = simd_float4x4(rest)
+        let runtimeSkeleton = RuntimeSkeleton(
+            jointPaths: ["root", "root/hips"],
+            parentIndices: [nil, 0],
+            bindTransforms: [restMatrix, restMatrix * simd_float4x4(translation: simd_float3(0, 1, 0))],
+            restTransforms: [restMatrix, simd_float4x4(translation: simd_float3(0, 1, 0))]
+        )
+        let skeletonComponent = try XCTUnwrap(scene.get(component: SkeletonComponent.self, for: rigged))
+        skeletonComponent.skeleton = Skeleton(runtimeSkeleton: runtimeSkeleton)
+
+        // Turn: model-space yaw applied on the left of the rest, 90° per loop.
+        func key(_ yaw: Float) -> SIMD4<Float> {
+            let q = simd_quatf(angle: yaw, axis: simd_float3(0, 1, 0)) * rest
+            return SIMD4<Float>(q.imag.x, q.imag.y, q.imag.z, q.real)
+        }
+        let rootChannel = RuntimeAnimationChannel(
+            jointPath: "root",
+            translations: [
+                .init(time: 0.0, value: simd_float3(0, 0.9, 0)),
+                .init(time: 2.0, value: simd_float3(0, 0.9, 0)),
+            ],
+            rotations: [
+                .init(time: 0.0, value: key(0)),
+                .init(time: 1.0, value: key(.pi / 4)),
+                .init(time: 2.0, value: key(.pi / 2)),
+            ]
+        )
+        let clip = AnimationClip(runtimeClip: RuntimeAnimationClip(name: "turn", duration: 2.0, channels: [rootChannel]))
+        let component = try XCTUnwrap(scene.get(component: AnimationComponent.self, for: rigged))
+        component.animationClips["turn"] = clip
+
+        setRootMotionEnabled(entityId: rigged, enabled: true)
+        changeAnimation(entityId: rigged, name: "turn", transitionHalflife: 0)
+        for _ in 0 ..< 90 { // 1 s: 45° of turn
+            AnimationSystem.shared.update(deltaTime)
+        }
+
+        // The entity turned...
+        let (entityYaw, _) = yawTwist(getRotationQuaternion(entityId: rigged))
+        XCTAssertEqual(entityYaw, .pi / 4 - (.pi / 4) * deltaTime, accuracy: 0.02, "Entity must accumulate the clip's yaw")
+
+        // ...and the grounded pose root is exactly the rest orientation —
+        // upright, not rolled onto its side.
+        let rootPose = component.localPose.rotations[0]
+        let alignment = abs(simd_dot(rootPose.vector, rest.vector))
+        XCTAssertEqual(alignment, 1.0, accuracy: 1e-3, "Grounded root must keep its rest orientation (body upright)")
     }
 
     // MARK: - Root joint override


### PR DESCRIPTION
## Summary

Bug fix in root motion (#1135) that only real rigs can trigger. Rigs like the UE4 Mannequin carry a **rest rotation on the root bone** (90° about X) and author turns as a model-space yaw stacked on top of it, `q = R_y(θ) · rest`. `stripRootMotion` removed the extracted yaw on the **right**, `q · twist⁻¹ = R_y(θ) · rest · R_y(−θ)` — the rest rotation *conjugated by the turn angle*, which rolls the whole body onto its side by θ. A 90° turn laid the character flat on the floor; partial turns read as leaning.

Yaw *extraction* was already correct (the twist projection of `R_y(θ) · R_x(90°)` is exactly `R_y(θ)`, and `rootYawPerLoop` reported the right value) — only the removal side was wrong. Only an identity rest makes the two sides equal, which is why every synthetic fixture passed.

### Fix

Remove the yaw on the left, `twist⁻¹ · q`, which restores the rest orientation and preserves any body-frame lean (pitch/roll applied after the yaw, `yaw · lean` — the convention real data uses). Doc comments on `yawTwist`/`stripRootMotion` now state the convention. Every other `yawTwist` call site uses the angle only and is unaffected.

Single commit on current develop (b5cb91c5). Independent of open #1171/#1172/#1173 — different function.

## Testing

- New regression test drives a turn on a root with a 90° rest rotation and asserts the entity accumulates the clip's yaw while the grounded root keeps its rest orientation (body upright).
- The pitch/roll preservation test now authors its lean in the body frame (`yaw * lean`) — with the previous `lean * yaw` composition it was only passing because both stripping sides coincide for an identity rest.
- Root motion, motion matching, inertialization, and foot IK suites pass on this base (56 tests). SwiftFormat lint clean.
