### PR TITLE
Add .untoldpack and .untoldanim exports; fix stale re-export artifacts

### DIFF
--- a/Sources/Demos/ExporterPipelineDemo/GameScene.swift
+++ b/Sources/Demos/ExporterPipelineDemo/GameScene.swift
@@ -155,7 +155,7 @@
             setEntityAnimations(
                 entityId: loadedEntity,
                 filename: option.rawValue,
-                withExtension: "untold",
+                withExtension: "untoldanim",
                 name: option.rawValue
             )
             changeAnimation(entityId: loadedEntity, name: option.rawValue)

--- a/Sources/Demos/ExporterPipelineDemo/README.md
+++ b/Sources/Demos/ExporterPipelineDemo/README.md
@@ -12,7 +12,7 @@ What it demonstrates:
 
 - setting the asset base path with `setEngine(.assetBasePath(...))`
 - loading exported `.untold` models with `setEntityMeshAsync`
-- loading exported `.untold` animation clips with `setEntityAnimations`
+- loading exported `.untoldanim` animation clips with `setEntityAnimations`
 - switching animation clips with `changeAnimation`
 - checking whether sibling `*.validation.json` files exist
 - showing basic validation metadata: asset name, mesh count, vertex totals, and index totals

--- a/Sources/Sandbox/GameScene.swift
+++ b/Sources/Sandbox/GameScene.swift
@@ -25,14 +25,15 @@
             // Make sure to convert your usdz files to .untold format as explained in docs/API/UsingTheExporter
 
             // Uncomment to render a simple mesh.
+
             /*
              let entity = createEntity()
              setEntityMeshAsync(entityId: entity, filename: "/path/to/file", withExtension: "untold") { success in
-                 setEntityName(entityId: entity, name: "redplayer")
-                 if success {
-                     loadSceneAuthored(filename: "/path/to/file", withExtension: "untold")
-                 }
-                 setSceneReady(success)
+              setEntityName(entityId: entity, name: "redplayer")
+              if success {
+                  loadSceneAuthored(filename: "/path/to/file", withExtension: "untold")
+              }
+              setSceneReady(success)
              }
              */
 
@@ -55,9 +56,9 @@
             setCamera(.active(camera))
             setOrbitOffset(entityId: camera, uTargetOffset: Constants.orbitTargetOffset)
 
-//            let light = createEntity()
-//            setEntityName(entityId: light, name: "Directional Light")
-            // createDirLight(entityId: light)
+            let light = createEntity()
+            setEntityName(entityId: light, name: "Directional Light")
+            createDirLight(entityId: light)
         }
 
         func update(deltaTime _: Float) {

--- a/Sources/UntoldEngine/RuntimeAssets/RuntimeAssetSource.swift
+++ b/Sources/UntoldEngine/RuntimeAssets/RuntimeAssetSource.swift
@@ -26,7 +26,10 @@ public struct RuntimeAssetSource: Sendable, Equatable {
     public static func infer(from url: URL) -> RuntimeAssetSource {
         let ext = url.pathExtension.lowercased()
         let kind: RuntimeAssetSourceKind = switch ext {
-        case "untold":
+        case "untold", "untoldanim":
+            // .untoldanim is byte-identical to .untold (same "UNTOLD" binary container,
+            // same reader) -- it's a distinct extension purely so animation-only exports
+            // are identifiable without opening the file, not a different format.
             .untold
         case "usd", "usda", "usdc", "usdz":
             .usd

--- a/Sources/UntoldEngine/Scenes/SceneSerializer.swift
+++ b/Sources/UntoldEngine/Scenes/SceneSerializer.swift
@@ -380,7 +380,7 @@ private func animationURLs(for entityData: EntityData) -> [URL] {
         return animationAssets.compactMap { resolvedSceneAssetURL($0) }
     }
 
-    return entityData.animations.filter { $0.pathExtension.lowercased() == "untold" }
+    return entityData.animations.filter { ["untold", "untoldanim"].contains($0.pathExtension.lowercased()) }
 }
 
 private func applyDeserializedAnimations(entityId: EntityID, entityData: EntityData) {

--- a/Sources/UntoldEngine/Systems/ErrorHandlingSystem.swift
+++ b/Sources/UntoldEngine/Systems/ErrorHandlingSystem.swift
@@ -96,6 +96,7 @@ public enum ErrorHandlingSystem: Int, Error, CustomStringConvertible {
     case assetAdmissionRejected = 1084
     case manifestNotFound = 1085
     case manifestDecodeFailed = 1086
+    case assetIsAnimationOnly = 1087
 
     public var description: String {
         switch self {
@@ -269,6 +270,8 @@ public enum ErrorHandlingSystem: Int, Error, CustomStringConvertible {
             return "Scene manifest not found"
         case .manifestDecodeFailed:
             return "Failed to decode scene manifest — check JSON format"
+        case .assetIsAnimationOnly:
+            return "This is a .untoldanim animation clip, not a mesh — use setEntityAnimations instead of setEntityMeshAsync"
         }
     }
 }

--- a/Sources/UntoldEngine/Systems/LoadingSystem.swift
+++ b/Sources/UntoldEngine/Systems/LoadingSystem.swift
@@ -50,13 +50,24 @@ public func getResourceURL(resourceName: String, ext: String, subName: String?) 
         let expandedPath = NSString(string: resourceName).expandingTildeInPath
         let absoluteURL = URL(fileURLWithPath: expandedPath)
 
-        // If extension is provided in the path, use it directly
-        if fm.fileExists(atPath: absoluteURL.path) {
+        // If extension is provided in the path, use it directly -- but only when it's
+        // actually a file. A same-named directory can legitimately sit beside it (e.g.
+        // a stale per-model subfolder from an older .untoldpack export at this same
+        // base name), and fileExists(atPath:) alone can't tell the two apart, so an
+        // ext-less lookup would silently resolve to the directory and never even try
+        // the extension the caller actually asked for.
+        var isDirectory: ObjCBool = false
+        if fm.fileExists(atPath: absoluteURL.path, isDirectory: &isDirectory), !isDirectory.boolValue {
             return absoluteURL
         }
 
-        // Otherwise, try appending the extension
-        let urlWithExt = absoluteURL.appendingPathExtension(ext)
+        // Otherwise, try appending the extension. Built from the path string rather
+        // than absoluteURL.appendingPathExtension(ext) -- URL(fileURLWithPath:) stats
+        // the filesystem to set hasDirectoryPath when the bare path exists (as it does
+        // here, since absoluteURL just failed the file check above by being a
+        // directory), and appendingPathExtension would carry that stale directory
+        // flag onto a URL that actually names a regular file.
+        let urlWithExt = URL(fileURLWithPath: "\(absoluteURL.path).\(ext)")
         if fm.fileExists(atPath: urlWithExt.path) {
             return urlWithExt
         }

--- a/Sources/UntoldEngine/Systems/RegistrationSystem.swift
+++ b/Sources/UntoldEngine/Systems/RegistrationSystem.swift
@@ -1232,6 +1232,37 @@ private func loadAndInstallColorGradeLUT(
     }
 }
 
+/// Splits `filename` and an optional explicit `withExtension` into the resource name
+/// and extension actually used to resolve an asset.
+///
+/// When `withExtension` is given, `filename` is returned untouched -- this preserves
+/// every existing two-argument call site's exact behavior, including ones whose
+/// resource name happens to contain a dot (e.g. "level.01"). Only when
+/// `withExtension` is nil is an extension parsed off the end of `filename` itself
+/// (e.g. "model.untold" -> ("model", "untold")), so callers can fold the extension
+/// into a single path string instead of passing it separately. Pure string
+/// splitting (NSString.pathExtension/.deletingPathExtension), not URL(fileURLWithPath:)
+/// -- the latter silently absolutizes a bare relative name against the current
+/// working directory, which would break LoadingSystem's own bare-name-vs-absolute-path
+/// branch.
+///
+/// `fallbackExtension` covers call sites (like setColorGradeLUT) that historically
+/// defaulted to a fixed extension when none was given at all.
+private func resolveAssetFilenameExtension(
+    _ filename: String,
+    _ withExtension: String?,
+    fallbackExtension: String = ""
+) -> (filename: String, withExtension: String) {
+    if let withExtension {
+        return (filename, withExtension)
+    }
+    let embeddedExtension = (filename as NSString).pathExtension
+    guard !embeddedExtension.isEmpty else {
+        return (filename, fallbackExtension)
+    }
+    return ((filename as NSString).deletingPathExtension, embeddedExtension)
+}
+
 /// Loads a standalone .cube color-grade LUT and applies it immediately, fully
 /// independent of any scene/manifest -- unlike the colorGradeLUT reference
 /// installed by loadSceneAuthored, this can point at any .cube file (hand
@@ -1242,7 +1273,11 @@ private func loadAndInstallColorGradeLUT(
 /// LoadingSystem.getResourceURL): a bare name searches the standard
 /// structured folders (a new "LUT" folder alongside Models/Textures/etc.),
 /// while an absolute path is used directly.
-public func setColorGradeLUT(filename: String, withExtension: String = "cube") {
+///
+/// `withExtension` may be omitted if `filename` already carries the extension
+/// (e.g. "grade.cube"); it otherwise defaults to "cube" as before.
+public func setColorGradeLUT(filename: String, withExtension: String? = nil) {
+    let (filename, withExtension) = resolveAssetFilenameExtension(filename, withExtension, fallbackExtension: "cube")
     guard let url = LoadingSystem.shared.resourceURL(
         forResource: filename,
         withExtension: withExtension,
@@ -1374,9 +1409,10 @@ private func registerUntoldCamera(_ camera: RuntimeCameraSource) {
 public func setEntityMesh(
     entityId: EntityID,
     filename: String,
-    withExtension: String,
+    withExtension: String? = nil,
     assetName: String? = nil
 ) {
+    let (filename, withExtension) = resolveAssetFilenameExtension(filename, withExtension)
     guard let url = LoadingSystem.shared.resourceURL(
         forResource: filename,
         withExtension: withExtension,
@@ -1418,7 +1454,7 @@ public func setEntityMesh(
 public func setEntityMeshAsync(
     entityId: EntityID,
     filename: String,
-    withExtension: String,
+    withExtension: String? = nil,
     assetName: String? = nil,
     flip _: Bool = true,
     coordinateConversion _: CoordinateSystemConversion = .autoDetect,
@@ -1426,6 +1462,7 @@ public func setEntityMeshAsync(
     blockRenderLoop: Bool = true,
     completion: ((Bool) -> Void)? = nil
 ) {
+    let (filename, withExtension) = resolveAssetFilenameExtension(filename, withExtension)
     let completionBox = completion.map { BoolCompletionBox(callback: $0) }
 
     Task {
@@ -1452,6 +1489,34 @@ public func setEntityMeshAsync(
             }
             await AssetLoadingState.shared.finishLoading(entityId: entityId)
             completionBox?.call(false)
+            return
+        }
+
+        // .untoldanim is a byte-identical .untold container, but the file has no
+        // renderable primitives (see scripts/untoldexplorer.py's --animation export
+        // mode) -- loading it as a mesh here would just produce an empty entity.
+        // Fail clearly and point at the dedicated animation entry point instead.
+        if url.pathExtension.lowercased() == "untoldanim" {
+            handleError(.assetIsAnimationOnly, filename)
+            withWorldMutationGate {
+                loadFallbackMesh(entityId: entityId, filename: filename)
+            }
+            await AssetLoadingState.shared.finishLoading(entityId: entityId)
+            completionBox?.call(false)
+            return
+        }
+
+        // A .untoldpack is not a single mesh -- it's a manifest referencing several
+        // models, each with its own placement (see scripts/untoldexplorer.py). Route
+        // it through the same entry point as .untold so callers never have to know
+        // ahead of time whether a given asset is one model or many.
+        if url.pathExtension.lowercased() == "untoldpack" {
+            loadEntityFromPack(entityId: entityId, packURL: url) { success in
+                Task {
+                    await AssetLoadingState.shared.finishLoading(entityId: entityId)
+                    completionBox?.call(success)
+                }
+            }
             return
         }
 
@@ -1562,9 +1627,10 @@ public func setEntityMeshAsync(
 /// them to the mesh entity's transform.
 public func loadSceneAuthored(
     filename: String,
-    withExtension ext: String,
+    withExtension ext: String? = nil,
     completion: (@Sendable (Bool) -> Void)? = nil
 ) {
+    let (filename, ext) = resolveAssetFilenameExtension(filename, ext)
     Task {
         guard let url = LoadingSystem.shared.resourceURL(
             forResource: filename, withExtension: ext, subResource: nil
@@ -2103,6 +2169,280 @@ private func decodeMatrix4x4Rows(
         simd_float4(rows[0][2], rows[1][2], rows[2][2], rows[3][2]),
         simd_float4(rows[0][3], rows[1][3], rows[2][3], rows[3][3])
     )
+}
+
+// MARK: - Untold Pack Manifest (multi-model .blend exports)
+
+/// One model referenced by a `.untoldpack` manifest: a self-contained `.untold`
+/// file (see scripts/untoldexplorer.py) plus the placement it had in the source
+/// Blender scene, relative to the manifest's own directory.
+public struct UntoldPackModelEntry: Decodable {
+    public let displayName: String?
+    public let path: String
+    public let transform: simd_float4x4
+
+    enum CodingKeys: String, CodingKey {
+        case displayName
+        case path
+        case transform
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        displayName = try container.decodeIfPresent(String.self, forKey: .displayName)
+        path = try container.decode(String.self, forKey: .path)
+        let rows = try container.decodeIfPresent([[Float]].self, forKey: .transform)
+        transform = decodeMatrix4x4Rows(rows)
+    }
+}
+
+/// Decoded contents of a `.untoldpack` manifest: written by the exporter whenever a
+/// source Blender scene contains more than one independent model, so each model stays
+/// its own reusable `.untold` file instead of being fused into a single asset.
+public struct UntoldPackData: Decodable {
+    public let formatVersion: Int
+    public let sourceAsset: String?
+    public let models: [UntoldPackModelEntry]
+}
+
+/// Reads and decodes a `.untoldpack` manifest from a local file URL.
+public func loadUntoldPack(url: URL) -> UntoldPackData? {
+    guard let data = try? Data(contentsOf: url) else {
+        Logger.logWarning(message: "[loadUntoldPack] Could not read file: \(url.lastPathComponent)")
+        return nil
+    }
+    guard let pack = try? JSONDecoder().decode(UntoldPackData.self, from: data) else {
+        Logger.logWarning(message: "[loadUntoldPack] Could not decode pack manifest: \(url.lastPathComponent)")
+        return nil
+    }
+    return pack
+}
+
+private func decomposeTRS(_ matrix: simd_float4x4) -> (position: simd_float3, rotation: simd_quatf, scale: simd_float3) {
+    let position = simd_make_float3(matrix.columns.3)
+    var col0 = simd_make_float3(matrix.columns.0)
+    let col1 = simd_make_float3(matrix.columns.1)
+    let col2 = simd_make_float3(matrix.columns.2)
+    var scale = simd_float3(simd_length(col0), simd_length(col1), simd_length(col2))
+
+    // Column length alone can't represent a mirrored/reflected transform (e.g. a
+    // Blender object with a negative scale axis) since length is always positive
+    // -- a plain decompose silently turns the mirror into an ordinary positive
+    // scale. A negative determinant is the tell; fold the reflection into the X
+    // scale (and its basis column) so what's left for the rotation matrix below
+    // is a proper (determinant +1) rotation.
+    let determinant = simd_dot(col0, simd_cross(col1, col2))
+    if determinant < 0 {
+        scale.x = -scale.x
+        col0 = -col0
+    }
+
+    let rotationMatrix = simd_float3x3(
+        scale.x != 0 ? col0 / abs(scale.x) : simd_float3(1, 0, 0),
+        scale.y > 0 ? col1 / scale.y : simd_float3(0, 1, 0),
+        scale.z > 0 ? col2 / scale.z : simd_float3(0, 0, 1)
+    )
+    let rotation = simd_normalize(simd_quatf(rotationMatrix))
+    return (position, rotation, scale)
+}
+
+/// Reads a `.untoldpack` manifest and writes a brand-new `.untoldscene` seeded with
+/// one entity per model, each referencing its own `.untold` file and placed using
+/// the manifest's per-model transform.
+///
+/// This is a one-time conversion, not a live link. The resulting `.untoldscene`
+/// is a normal, freely-editable scene file from this point on: re-running the
+/// exporter regenerates the pack and its `.untold` models but never touches
+/// scenes already created from it. This is what keeps `.untoldpack` (exporter-owned,
+/// regenerated every export) and `.untoldscene` (editor-owned, hand-edited) from
+/// fighting over the same file, which is what mixing them into one format used to do.
+@discardableResult
+public func createUntoldScene(fromPackAt packURL: URL, savingTo sceneURL: URL) -> Bool {
+    guard assetBasePath != nil else {
+        Logger.log(message: "❌ createUntoldScene: assetBasePath is not configured. Call setupAssetPaths() first.")
+        return false
+    }
+    guard let pack = loadUntoldPack(url: packURL) else {
+        return false
+    }
+
+    let packDir = packURL.deletingLastPathComponent()
+    var sceneData = SceneData()
+    for model in pack.models {
+        let modelURL = packDir.appendingPathComponent(model.path)
+        let displayName = model.displayName ?? modelURL.deletingPathExtension().lastPathComponent
+
+        var entity = EntityData()
+        entity.name = displayName
+        entity.assetName = displayName
+        entity.hasLocalTransformComponent = true
+        entity.hasRenderingComponent = true
+        entity.assetURL = modelURL
+        entity.asset = sceneAssetReference(kind: .model, url: modelURL, displayName: displayName)
+
+        let (position, rotation, scale) = decomposeTRS(model.transform)
+        entity.position = position
+        entity.rotation = simd_float4(rotation.vector)
+        entity.scale = scale
+
+        sceneData.entities.append(entity)
+    }
+
+    guard let encoded = try? JSONEncoder().encode(sceneData) else {
+        Logger.logWarning(message: "[createUntoldScene] Failed to encode scene for pack: \(packURL.lastPathComponent)")
+        return false
+    }
+
+    do {
+        try encoded.write(to: sceneURL, options: .atomic)
+        return true
+    } catch {
+        Logger.logWarning(message: "[createUntoldScene] Failed to write scene file \(sceneURL.lastPathComponent): \(error.localizedDescription)")
+        return false
+    }
+}
+
+/// Drives loadEntityFromPack's model loads through a bounded concurrency window
+/// instead of firing every model's setEntityMeshAsync at once.
+///
+/// setEntityMeshAsync's Task body eventually takes withWorldMutationGate's
+/// thread-blocking NSRecursiveLock (see AssetLoadingState.swift). Swift's
+/// cooperative thread pool has a fixed size; firing dozens of these Tasks
+/// simultaneously can leave every pool thread parked on that lock with none
+/// free to run the continuation that would release it -- a genuine deadlock,
+/// reproducible even with plain setEntityMeshAsync calls in a tight loop,
+/// independent of anything pack-specific. Keeping at most `maxConcurrentLoads`
+/// in flight at a time keeps this entry point far under that ceiling without
+/// having to change the shared locking primitive itself.
+private final class PackLoadDispatcher: @unchecked Sendable {
+    private let lock = NSLock()
+    private let models: [UntoldPackModelEntry]
+    private let packDir: URL
+    private let rootEntityId: EntityID
+    private let completionBox: BoolCompletionBox?
+    private var nextIndex = 0
+    private var remaining: Int
+    private var overallSuccess = true
+
+    private static let maxConcurrentLoads = 8
+
+    init(models: [UntoldPackModelEntry], packDir: URL, rootEntityId: EntityID, completionBox: BoolCompletionBox?) {
+        self.models = models
+        self.packDir = packDir
+        self.rootEntityId = rootEntityId
+        self.completionBox = completionBox
+        remaining = models.count
+    }
+
+    func start() {
+        let initialCount = min(Self.maxConcurrentLoads, models.count)
+        for _ in 0 ..< initialCount {
+            startNext()
+        }
+    }
+
+    private func startNext() {
+        lock.lock()
+        let index = nextIndex
+        guard index < models.count else {
+            lock.unlock()
+            return
+        }
+        nextIndex += 1
+        lock.unlock()
+
+        let model = models[index]
+        let modelURL = packDir.appendingPathComponent(model.path)
+        let displayName = model.displayName ?? modelURL.deletingPathExtension().lastPathComponent
+        let modelPath = modelURL.deletingPathExtension().path
+        let withExtension = modelURL.pathExtension
+        let (position, rotation, scale) = decomposeTRS(model.transform)
+        let rootEntityId = rootEntityId
+
+        withWorldMutationGate {
+            let childId = createEntity()
+            registerTransformComponent(entityId: childId)
+            registerSceneGraphComponent(entityId: childId)
+            setEntityName(entityId: childId, name: displayName)
+            setParent(childId: childId, parentId: rootEntityId)
+
+            setEntityMeshAsync(entityId: childId, filename: modelPath, withExtension: withExtension) { success in
+                withWorldMutationGate {
+                    translateTo(entityId: childId, position: position)
+                    scaleTo(entityId: childId, scale: scale)
+                    rotateTo(entityId: childId, rotation: rotation)
+                    // Single-node .untold assets rename the entity to the mesh's own internal
+                    // node name on load (see registerUntoldRuntimeAsset), which would otherwise
+                    // stomp the pack's displayName -- most visibly when two pack entries share
+                    // the same underlying .untold (e.g. an instanced prop), which would
+                    // otherwise leave both children with identical, non-descriptive names.
+                    // Failed child loads also keep this placement so fallback cubes mark the
+                    // broken pack model's intended location.
+                    setEntityName(entityId: childId, name: displayName)
+                }
+                self.recordCompletionAndAdvance(success)
+            }
+        }
+    }
+
+    private func recordCompletionAndAdvance(_ success: Bool) {
+        lock.lock()
+        overallSuccess = overallSuccess && success
+        remaining -= 1
+        let isDone = remaining <= 0
+        let result = overallSuccess
+        lock.unlock()
+
+        if isDone {
+            completionBox?.call(result)
+        } else {
+            startNext()
+        }
+    }
+}
+
+/// Loads every model referenced by a `.untoldpack` manifest as a child entity under
+/// `rootEntityId`, placed using each model's manifest transform. Called from
+/// `setEntityMeshAsync` when it resolves a `.untoldpack` path, so callers never have
+/// to know ahead of time whether a given asset is one model (`.untold`) or many
+/// (`.untoldpack`) -- both load through the same entry point.
+///
+/// This is the live, in-scene counterpart to `createUntoldScene(fromPackAt:savingTo:)`,
+/// which instead seeds a new `.untoldscene` file for later editing rather than
+/// populating the running world directly.
+///
+/// Models load through a bounded concurrency window (see `PackLoadDispatcher`) rather
+/// than all at once, since firing dozens of simultaneous loads can exhaust Swift's
+/// cooperative thread pool against `setEntityMeshAsync`'s internal locking.
+private func loadEntityFromPack(
+    entityId rootEntityId: EntityID,
+    packURL: URL,
+    completion: (@Sendable (Bool) -> Void)? = nil
+) {
+    let completionBox = completion.map { BoolCompletionBox(callback: $0) }
+
+    guard let pack = loadUntoldPack(url: packURL) else {
+        completionBox?.call(false)
+        return
+    }
+
+    withWorldMutationGate {
+        if hasComponent(entityId: rootEntityId, componentType: LocalTransformComponent.self) == false {
+            registerTransformComponent(entityId: rootEntityId)
+        }
+        if hasComponent(entityId: rootEntityId, componentType: ScenegraphComponent.self) == false {
+            registerSceneGraphComponent(entityId: rootEntityId)
+        }
+    }
+
+    guard pack.models.isEmpty == false else {
+        completionBox?.call(true)
+        return
+    }
+
+    let packDir = packURL.deletingLastPathComponent()
+    let dispatcher = PackLoadDispatcher(models: pack.models, packDir: packDir, rootEntityId: rootEntityId, completionBox: completionBox)
+    dispatcher.start()
 }
 
 private func registerManifestScenePayload(_ manifest: TileManifest) {
@@ -2925,7 +3265,8 @@ func removeEntityMesh(entityId: EntityID) {
     }
 }
 
-public func setEntityAnimations(entityId: EntityID, filename: String, withExtension: String, name: String) {
+public func setEntityAnimations(entityId: EntityID, filename: String, withExtension: String? = nil, name: String) {
+    let (filename, withExtension) = resolveAssetFilenameExtension(filename, withExtension)
     let targetEntityIds = resolveAnimationBindingTargetEntities(entityId: entityId)
     guard targetEntityIds.contains(where: { scene.get(component: SkeletonComponent.self, for: $0) != nil }) else {
         handleError(.noSkeletonComponent, entityId)
@@ -3809,7 +4150,8 @@ public enum GaussianSource {
 
 public typealias GaussianStreamingSource = GaussianSource
 
-public func setEntityGaussian(entityId: EntityID, filename: String, withExtension: String) {
+public func setEntityGaussian(entityId: EntityID, filename: String, withExtension: String? = nil) {
+    let (filename, withExtension) = resolveAssetFilenameExtension(filename, withExtension)
     guard let result = buildGaussianLoadResult(filename: filename, withExtension: withExtension) else {
         return
     }

--- a/Tests/UntoldEngineRenderTests/UntoldAnimExtensionRenderTests.swift
+++ b/Tests/UntoldEngineRenderTests/UntoldAnimExtensionRenderTests.swift
@@ -1,0 +1,94 @@
+//
+//  UntoldAnimExtensionRenderTests.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+@testable import UntoldEngine
+import XCTest
+
+final class UntoldAnimExtensionRenderTests: BaseRenderSetup {
+    private var tempRoot: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        LoadingSystem.shared.resourceURLFn = getResourceURL
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("UntoldAnimExtensionRenderTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        LoadingSystem.shared.resourceURLFn = getResourceURL
+        destroyAllEntities()
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try await super.tearDown()
+    }
+
+    override func initializeAssets() {}
+
+    /// Copies a bundled .untold test fixture to a temp path with a `.untoldanim`
+    /// extension, so tests can exercise the new extension without needing a
+    /// checked-in duplicate binary fixture.
+    private func copyFixture(named name: String, to newName: String) throws -> URL {
+        guard let sourceURL = LoadingSystem.shared.resourceURL(forResource: name, withExtension: "untold") else {
+            XCTFail("bundled \(name).untold test asset not found")
+            throw CocoaError(.fileNoSuchFile)
+        }
+        let destination = tempRoot.appendingPathComponent(newName).appendingPathExtension("untoldanim")
+        try FileManager.default.copyItem(at: sourceURL, to: destination)
+        return destination
+    }
+
+    func testSetEntityMeshAsyncRejectsUntoldanim() async throws {
+        let untoldanimURL = try copyFixture(named: "ball", to: "ball")
+
+        let entityId = createEntity()
+        let expectation = expectation(description: "mesh load completes")
+        setEntityMeshAsync(entityId: entityId, filename: untoldanimURL.deletingPathExtension().path, withExtension: "untoldanim") { success in
+            XCTAssertFalse(success, "setEntityMeshAsync should reject .untoldanim files")
+            expectation.fulfill()
+        }
+        await fulfillment(of: [expectation], timeout: 5.0)
+    }
+
+    func testSetEntityAnimationsAcceptsUntoldanim() async throws {
+        guard let redplayerURL = LoadingSystem.shared.resourceURL(forResource: "redplayer", withExtension: "untold") else {
+            XCTFail("bundled redplayer.untold test asset not found")
+            return
+        }
+        let runningUntoldanimURL = try copyFixture(named: "running", to: "running")
+
+        let entityId = createEntity()
+        setEntityName(entityId: entityId, name: "player")
+        let meshExpectation = expectation(description: "redplayer loaded")
+        setEntityMeshAsync(entityId: entityId, filename: redplayerURL.deletingPathExtension().path, withExtension: "untold") { _ in
+            meshExpectation.fulfill()
+        }
+        await fulfillment(of: [meshExpectation], timeout: 10.0)
+
+        setEntityAnimations(
+            entityId: entityId,
+            filename: runningUntoldanimURL.deletingPathExtension().path,
+            withExtension: "untoldanim",
+            name: "running"
+        )
+
+        // The skeleton (and so the AnimationComponent) may land on a child entity
+        // rather than the root for multi-node assets -- resolve the same way
+        // setEntityAnimations itself does rather than assuming it's on entityId.
+        let targetEntityIds = resolveAnimationBindingTargetEntities(entityId: entityId)
+        guard let animationComponent = targetEntityIds.compactMap({ scene.get(component: AnimationComponent.self, for: $0) }).first else {
+            XCTFail("AnimationComponent was not registered after loading a .untoldanim clip")
+            return
+        }
+        XCTAssertNotNil(animationComponent.animationClips["running"], "the .untoldanim clip should have registered under its requested name")
+    }
+}

--- a/Tests/UntoldEngineRenderTests/UntoldPackRenderTests.swift
+++ b/Tests/UntoldEngineRenderTests/UntoldPackRenderTests.swift
@@ -1,0 +1,101 @@
+//
+//  UntoldPackRenderTests.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+@testable import UntoldEngine
+import XCTest
+
+final class UntoldPackRenderTests: BaseRenderSetup {
+    private var tempRoot: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        LoadingSystem.shared.resourceURLFn = getResourceURL
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("UntoldPackRenderTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() async throws {
+        LoadingSystem.shared.resourceURLFn = getResourceURL
+        destroyAllEntities()
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try await super.tearDown()
+    }
+
+    override func initializeAssets() {}
+
+    /// Copies the bundled "ball" test asset to `path` under tempRoot so a real .untold
+    /// binary backs each pack model, and writes a .untoldpack manifest referencing them.
+    private func writePack(models: [(displayName: String, path: String, translationX: Float)]) throws -> URL {
+        guard let ballURL = LoadingSystem.shared.resourceURL(forResource: "ball", withExtension: "untold") else {
+            XCTFail("bundled ball.untold test asset not found")
+            throw CocoaError(.fileNoSuchFile)
+        }
+
+        let modelsJSON = models.map { model in
+            let destination = tempRoot.appendingPathComponent(model.path)
+            try? FileManager.default.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try? FileManager.default.removeItem(at: destination)
+            try? FileManager.default.copyItem(at: ballURL, to: destination)
+
+            return """
+            {
+              "displayName": "\(model.displayName)",
+              "path": "\(model.path)",
+              "transform": [
+                [1.0, 0.0, 0.0, \(model.translationX)],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0]
+              ]
+            }
+            """
+        }.joined(separator: ",\n")
+
+        let json = """
+        {
+          "formatVersion": 1,
+          "sourceAsset": "Robot.blend",
+          "models": [\(modelsJSON)]
+        }
+        """
+        let packURL = tempRoot.appendingPathComponent("Robot").appendingPathExtension("untoldpack")
+        try Data(json.utf8).write(to: packURL)
+        return packURL
+    }
+
+    func testSetEntityMeshAsyncRoutesUntoldpackToOneChildEntityPerModelWithTransform() async throws {
+        let packURL = try writePack(models: [
+            (displayName: "Body", path: "Body/Body.untold", translationX: 0.0),
+            (displayName: "Arm", path: "Arm/Arm.untold", translationX: 2.5),
+        ])
+
+        let rootId = createEntity()
+        let expectation = expectation(description: "pack load completes")
+        setEntityMeshAsync(entityId: rootId, filename: packURL.deletingPathExtension().path, withExtension: "untoldpack") { success in
+            XCTAssertTrue(success)
+            expectation.fulfill()
+        }
+        await fulfillment(of: [expectation], timeout: 5.0)
+
+        guard let scenegraph = scene.get(component: ScenegraphComponent.self, for: rootId) else {
+            XCTFail("root entity missing ScenegraphComponent")
+            return
+        }
+        XCTAssertEqual(scenegraph.children.count, 2)
+
+        let armId = try XCTUnwrap(scenegraph.children.first { getEntityName(entityId: $0) == "Arm" })
+        XCTAssertEqual(getPosition(entityId: armId).x, 2.5, accuracy: 0.0001)
+        XCTAssertTrue(hasComponent(entityId: armId, componentType: RenderComponent.self))
+    }
+}

--- a/Tests/UntoldEngineTests/LoadingSystemPathResolutionTests.swift
+++ b/Tests/UntoldEngineTests/LoadingSystemPathResolutionTests.swift
@@ -104,6 +104,23 @@ final class LoadingSystemPathResolutionTests: XCTestCase {
         XCTAssertEqual(resolved?.standardizedFileURL, currentResource.standardizedFileURL)
     }
 
+    func testAbsolutePathSkipsSameNamedDirectoryAndResolvesExtensionedFile() throws {
+        // A stale per-model subfolder from an older .untoldpack export can share its
+        // parent directory's base name with a newer pack manifest at that same stem
+        // (e.g. Assets/model/ left over beside a fresh Assets/model.untoldpack).
+        // FileManager.fileExists(atPath:) alone can't tell a directory from a file,
+        // so resolution must reject the directory match and keep looking for the
+        // extensioned file instead of silently returning the directory.
+        let baseName = tempRoot.appendingPathComponent("model")
+        try FileManager.default.createDirectory(at: baseName, withIntermediateDirectories: true)
+        let packFile = tempRoot.appendingPathComponent("model").appendingPathExtension("untoldpack")
+        try Data().write(to: packFile)
+
+        let resolved = getResourceURL(resourceName: baseName.path, ext: "untoldpack", subName: nil)
+
+        XCTAssertEqual(resolved?.standardizedFileURL, packFile.standardizedFileURL)
+    }
+
     func testBareResourceNameResolvesUnderTexturesDirectory() throws {
         // GameData/Textures is a canonical asset directory created by the project
         // scaffolding (see createGameDataDirectories()), but standalone texture

--- a/Tests/UntoldEngineTests/UntoldAnimExtensionTests.swift
+++ b/Tests/UntoldEngineTests/UntoldAnimExtensionTests.swift
@@ -1,0 +1,25 @@
+//
+//  UntoldAnimExtensionTests.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+
+@testable import UntoldEngine
+import XCTest
+
+final class UntoldAnimExtensionTests: XCTestCase {
+    func testRuntimeAssetSourceInfersUntoldAnimAsUntoldKind() {
+        let url = URL(fileURLWithPath: "/tmp/walk.untoldanim")
+        XCTAssertEqual(RuntimeAssetSource.infer(from: url).kind, .untold)
+    }
+
+    func testRuntimeAssetSourceStillInfersPlainUntold() {
+        let url = URL(fileURLWithPath: "/tmp/Robot.untold")
+        XCTAssertEqual(RuntimeAssetSource.infer(from: url).kind, .untold)
+    }
+}

--- a/Tests/UntoldEngineTests/UntoldPackTests.swift
+++ b/Tests/UntoldEngineTests/UntoldPackTests.swift
@@ -1,0 +1,152 @@
+//
+//  UntoldPackTests.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+
+import simd
+@testable import UntoldEngine
+import XCTest
+
+final class UntoldPackTests: XCTestCase {
+    private var previousAssetBasePath: URL?
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        previousAssetBasePath = assetBasePath
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("UntoldPackTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        assetBasePath = tempRoot
+    }
+
+    override func tearDownWithError() throws {
+        assetBasePath = previousAssetBasePath
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        try super.tearDownWithError()
+    }
+
+    /// Mirrors the exact JSON shape scripts/untoldexplorer.py's
+    /// write_untoldpack_manifest() emits: row-major nested arrays for `transform`,
+    /// matching the same convention as .untold's own local_transform_rows.
+    private func writePack(named name: String, models: [(displayName: String, path: String, translationX: Float)]) throws -> URL {
+        let modelsJSON = models.map { model in
+            """
+            {
+              "displayName": "\(model.displayName)",
+              "path": "\(model.path)",
+              "transform": [
+                [1.0, 0.0, 0.0, \(model.translationX)],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0]
+              ]
+            }
+            """
+        }.joined(separator: ",\n")
+
+        let json = """
+        {
+          "formatVersion": 1,
+          "sourceAsset": "Robot.blend",
+          "models": [\(modelsJSON)]
+        }
+        """
+        let packURL = tempRoot.appendingPathComponent(name).appendingPathExtension("untoldpack")
+        try Data(json.utf8).write(to: packURL)
+        return packURL
+    }
+
+    func testLoadUntoldPackDecodesModelsAndTransform() throws {
+        let packURL = try writePack(named: "Robot", models: [
+            (displayName: "Body", path: "Body/Body.untold", translationX: 0.0),
+            (displayName: "Arm", path: "Arm/Arm.untold", translationX: 2.5),
+        ])
+
+        let pack = try XCTUnwrap(loadUntoldPack(url: packURL))
+        XCTAssertEqual(pack.formatVersion, 1)
+        XCTAssertEqual(pack.sourceAsset, "Robot.blend")
+        XCTAssertEqual(pack.models.count, 2)
+        XCTAssertEqual(pack.models[0].displayName, "Body")
+        XCTAssertEqual(pack.models[1].path, "Arm/Arm.untold")
+        // Row 0, column 3 of the source JSON (translation.x) must land in the
+        // decoded matrix's translation column, matching the .untold binary's
+        // own row-major-JSON / column-major-simd convention.
+        XCTAssertEqual(pack.models[1].transform.columns.3.x, 2.5, accuracy: 0.0001)
+    }
+
+    func testCreateUntoldSceneWritesOneEntityPerModelWithResolvedTransform() throws {
+        let packURL = try writePack(named: "Robot", models: [
+            (displayName: "Body", path: "Body/Body.untold", translationX: 0.0),
+            (displayName: "Arm", path: "Arm/Arm.untold", translationX: 2.5),
+        ])
+        let sceneURL = tempRoot.appendingPathComponent("Robot.untoldscene")
+
+        XCTAssertTrue(createUntoldScene(fromPackAt: packURL, savingTo: sceneURL))
+
+        let sceneData = try JSONDecoder().decode(SceneData.self, from: Data(contentsOf: sceneURL))
+        XCTAssertEqual(sceneData.entities.count, 2)
+
+        let arm = try XCTUnwrap(sceneData.entities.first { $0.name == "Arm" })
+        XCTAssertEqual(arm.position.x, 2.5, accuracy: 0.0001)
+        XCTAssertEqual(arm.asset?.kind, .model)
+        XCTAssertEqual(arm.asset?.path, "Arm/Arm.untold")
+        XCTAssertTrue(arm.hasRenderingComponent)
+        XCTAssertTrue(arm.hasLocalTransformComponent)
+    }
+
+    func testCreateUntoldSceneDecomposesMirroredScale() throws {
+        // A negative-X-scale linear part, as Blender emits for a mirrored object.
+        let json = """
+        {
+          "formatVersion": 1,
+          "sourceAsset": "Mirror.blend",
+          "models": [
+            {
+              "displayName": "MirroredProp",
+              "path": "MirroredProp/MirroredProp.untold",
+              "transform": [
+                [-1.0, 0.0, 0.0, 3.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0]
+              ]
+            }
+          ]
+        }
+        """
+        let packURL = tempRoot.appendingPathComponent("Mirror").appendingPathExtension("untoldpack")
+        try Data(json.utf8).write(to: packURL)
+        let sceneURL = tempRoot.appendingPathComponent("Mirror.untoldscene")
+
+        XCTAssertTrue(createUntoldScene(fromPackAt: packURL, savingTo: sceneURL))
+
+        let sceneData = try JSONDecoder().decode(SceneData.self, from: Data(contentsOf: sceneURL))
+        let entity = try XCTUnwrap(sceneData.entities.first)
+        // decomposeTRS must preserve the reflection as a negative scale rather than
+        // collapsing it to a positive one (column length is always positive on its
+        // own) -- otherwise mirrored Blender objects silently un-mirror on load.
+        XCTAssertEqual(entity.scale.x, -1.0, accuracy: 0.0001)
+        XCTAssertEqual(entity.scale.y, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(entity.scale.z, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(entity.position.x, 3.0, accuracy: 0.0001)
+    }
+
+    func testCreateUntoldSceneFailsWithoutAssetBasePath() throws {
+        let packURL = try writePack(named: "Robot", models: [
+            (displayName: "Body", path: "Body/Body.untold", translationX: 0.0),
+        ])
+        assetBasePath = nil
+        let sceneURL = tempRoot.appendingPathComponent("Robot.untoldscene")
+
+        XCTAssertFalse(createUntoldScene(fromPackAt: packURL, savingTo: sceneURL))
+    }
+}

--- a/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/ExportCommand.swift
+++ b/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/ExportCommand.swift
@@ -33,9 +33,22 @@ struct ExportCommand: ParsableCommand {
         spherical-harmonics degree and chunk size. Values that start with a
         minus sign must use the --option=value form.
 
+        --animation exports clip data only (no mesh) to a `.untoldanim` file --
+        a plain `.untold` container under the hood, but named distinctly so it's
+        never mistaken for a mesh (setEntityMeshAsync rejects it; use
+        setEntityAnimations instead).
+
+        If the source .blend scene contains more than one independent model
+        (more than one object with no parent among the exported objects), the
+        exporter writes a <name>.untoldpack manifest next to --output instead
+        of a single .untold file, plus one self-contained .untold per model
+        under its own subfolder. --optimize bakes textures for every model
+        in the pack.
+
         Example:
           untoldengine export --input model.usdz --output model.untold --convert-orientation --optimize
           untoldengine export --input model.blend --output model.untold --convert-orientation --optimize
+          untoldengine export --input model.blend --output walk.untoldanim --animation
           untoldengine export --input splats.ply --output splats.untoldgs
           untoldengine export --input splats.ply --output splats.untoldgs --lod-levels 4
           untoldengine export --input sofa.ply --output sofa.untoldgs --splat-up-axis z \\
@@ -46,7 +59,7 @@ struct ExportCommand: ParsableCommand {
     @Option(name: .long, help: "Source .usd, .usda, .usdc, .usdz, .blend, or Gaussian .ply asset")
     var input: String
 
-    @Option(name: .long, help: "Destination .untold or .untoldgs file")
+    @Option(name: .long, help: "Destination .untold, .untoldanim (with --animation), or .untoldgs file")
     var output: String
 
     @Option(name: .long, help: "Override the Blender executable path")
@@ -70,7 +83,7 @@ struct ExportCommand: ParsableCommand {
     @Flag(name: .long, help: "LZ4-compress vertex and index chunks")
     var compressGeometry = false
 
-    @Flag(name: .long, help: "Export animation clips without mesh geometry")
+    @Flag(name: .long, help: "Export animation clips without mesh geometry; requires a .untoldanim --output path")
     var animation = false
 
     @Flag(name: .long, help: "Compress geometry and bake/patch textures after export (implies --compress-geometry)")
@@ -140,6 +153,12 @@ struct ExportCommand: ParsableCommand {
             return
         }
 
+        if animation {
+            guard outputURL.pathExtension.lowercased() == "untoldanim" else {
+                throw ExportError.unsupportedAnimationExportOutput(outputURL.pathExtension)
+            }
+        }
+
         let blenderURL = try resolveBlender()
         let exporterURL = try resolveExporter()
 
@@ -165,6 +184,17 @@ struct ExportCommand: ParsableCommand {
         printInfo("Using Blender: \(blenderURL.path)")
         printInfo("Exporting \(inputURL.path)")
 
+        // If the source scene contained more than one independent model, the
+        // exporter writes a .untoldpack manifest plus one self-contained
+        // .untold per model under --output's directory instead of a single
+        // file at --output itself (see group_export_nodes_by_root in
+        // scripts/untoldexplorer.py). Snapshot both possible outputs' mtimes
+        // before running so we can tell which one THIS run actually wrote,
+        // rather than trusting file existence alone (see below).
+        let packURL = outputURL.deletingPathExtension().appendingPathExtension("untoldpack")
+        let outputMTimeBefore = modificationDate(at: outputURL)
+        let packMTimeBefore = modificationDate(at: packURL)
+
         let process = Process()
         process.executableURL = blenderURL
         process.arguments = [
@@ -186,11 +216,76 @@ struct ExportCommand: ParsableCommand {
         guard process.terminationStatus == 0 else {
             throw ExportError.exportFailed(process.terminationStatus)
         }
-        printSuccess("Exported: \(outputURL.path)")
 
-        if optimize {
-            try optimizeTextures(outputURL: outputURL)
+        // A file existing post-export isn't proof THIS run produced it: the
+        // exporter script the CLI just ran may predate the exporter-side stale
+        // cleanup (untoldengine export runs whatever copy `untoldengine install`
+        // last placed, not the live repo), which can leave last run's leftover
+        // pack/single-file artifact sitting beside this run's real output. Compare
+        // mtimes from before/after the process instead of just checking existence,
+        // so a leftover from an older export -- of either kind -- doesn't get
+        // mistaken for this run's output, or worse, cause this run's real output
+        // to be deleted as "stale".
+        let packWrittenThisRun = FileManager.default.fileExists(atPath: packURL.path)
+            && modificationDate(at: packURL) != packMTimeBefore
+        let outputWrittenThisRun = FileManager.default.fileExists(atPath: outputURL.path)
+            && modificationDate(at: outputURL) != outputMTimeBefore
+
+        if packWrittenThisRun {
+            guard let pack = loadUntoldPack(url: packURL) else {
+                throw ExportError.packManifestUnreadable(packURL.path)
+            }
+
+            // The exporter itself removes a stale single-file export when it detects
+            // a scene has moved from one model to several (see the cleanup after
+            // write_untoldpack_manifest() in scripts/untoldexplorer.py). This is a
+            // belt-and-suspenders repeat of that same check for an installed exporter
+            // that predates it -- only when outputURL wasn't written by this run,
+            // since a leftover from an older export is the only thing safe to remove.
+            if FileManager.default.fileExists(atPath: outputURL.path), !outputWrittenThisRun {
+                try? FileManager.default.removeItem(at: outputURL)
+                printInfo("Removed stale single-file export: \(outputURL.path)")
+            }
+
+            printSuccess("Exported pack: \(packURL.path) (\(pack.models.count) model(s))")
+            for model in pack.models {
+                printInfo("  \(model.displayName ?? model.path) -> \(model.path)")
+            }
+            if optimize {
+                for model in pack.models {
+                    let modelURL = packURL.deletingLastPathComponent().appendingPathComponent(model.path)
+                    try optimizeTextures(outputURL: modelURL)
+                }
+            }
+        } else {
+            // Mirror image of the above: an old pack manifest from a previous
+            // multi-model export at this stem may still be sitting here, left by
+            // an installed exporter that predates write_single_untold_from_nodes()'s
+            // own pack cleanup. Only clean it up when this run didn't touch it, so a
+            // caller still loading `withExtension: "untoldpack"` can't silently pick
+            // up a now-outdated model set.
+            if FileManager.default.fileExists(atPath: packURL.path), !packWrittenThisRun {
+                if let stalePack = loadUntoldPack(url: packURL) {
+                    for model in stalePack.models {
+                        let modelDir = packURL.deletingLastPathComponent()
+                            .appendingPathComponent(model.path)
+                            .deletingLastPathComponent()
+                        try? FileManager.default.removeItem(at: modelDir)
+                    }
+                }
+                try? FileManager.default.removeItem(at: packURL)
+                printInfo("Removed stale pack manifest: \(packURL.path)")
+            }
+
+            printSuccess("Exported: \(outputURL.path)")
+            if optimize {
+                try optimizeTextures(outputURL: outputURL)
+            }
         }
+    }
+
+    private func modificationDate(at url: URL) -> Date? {
+        (try? FileManager.default.attributesOfItem(atPath: url.path))?[.modificationDate] as? Date
     }
 
     private func runGaussianSplatExport(inputURL: URL, outputURL: URL, cookOptions: UntoldGSCookOptions) throws {
@@ -335,6 +430,8 @@ enum ExportError: LocalizedError {
     case splatCookFailed(String)
     case invalidSplatUpAxis(String)
     case invalidSplatFlag(String)
+    case packManifestUnreadable(String)
+    case unsupportedAnimationExportOutput(String)
 
     var errorDescription: String? {
         switch self {
@@ -359,6 +456,11 @@ enum ExportError: LocalizedError {
             return "--splat-up-axis must be y, z or -y, got \(value)"
         case let .invalidSplatFlag(reason):
             return reason
+        case let .packManifestUnreadable(path):
+            return "Exporter wrote a .untoldpack manifest but it could not be read back: \(path)"
+        case let .unsupportedAnimationExportOutput(pathExtension):
+            let suffix = pathExtension.isEmpty ? "<none>" : ".\(pathExtension)"
+            return "--animation export supports only .untoldanim output, got \(suffix)"
         }
     }
 }

--- a/docs/API/GettingStarted.md
+++ b/docs/API/GettingStarted.md
@@ -341,7 +341,7 @@ For animation assets, use the `--animation` flag:
 ```bash
 untoldengine export \
   --input /path/to/your/animation/robot/robot.usdz \
-  --output /path/to/your/project/GameData/Animations/robot/robot.untold \
+  --output /path/to/your/project/GameData/Animations/robot/robot.untoldanim \
   --convert-orientation \
   --animation
 ```

--- a/docs/API/UsingAnimationSystem.md
+++ b/docs/API/UsingAnimationSystem.md
@@ -26,10 +26,10 @@ setEntityMesh(entityId: redPlayer, filename: "redplayer", withExtension: "untold
 ---
 
 ### Step 3: Load the Animation
-Load the animation data for your model by providing the exported animation `.untold` file and a name to reference the animation later.
+Load the animation data for your model by providing the exported animation `.untoldanim` file and a name to reference the animation later.
 
 ```swift
-setEntityAnimations(entityId: redPlayer, filename: "running", withExtension: "untold", name: "running")
+setEntityAnimations(entityId: redPlayer, filename: "running", withExtension: "untoldanim", name: "running")
 ```
 
 For hierarchical or multi-mesh `.untold` assets, call animation APIs on the asset root. The engine resolves the root to every skinned render descendant and installs the clip on each target that has both a `SkeletonComponent` and a `RenderComponent`. This keeps split characters or multi-part rigged models animated as one actor.

--- a/docs/API/UsingAssetPaths.md
+++ b/docs/API/UsingAssetPaths.md
@@ -30,7 +30,7 @@ Where each asset type belongs:
 | `Scripts/` | scripting-system script files |
 | `Models/` | `.untold` meshes, one subfolder per asset (e.g. `Models/robot/robot.untold`) |
 | `StreamModels/` | tile-streamed geometry (`export-untold-tiles` output) |
-| `Animations/` | `.untold` animation clips |
+| `Animations/` | `.untoldanim` animation clips |
 | `Gaussians/` | Gaussian splat assets |
 | `Textures/` | standalone textures loaded by name, outside of a material |
 | `Shaders/` | custom shader source |

--- a/docs/API/UsingAsyncLoading.md
+++ b/docs/API/UsingAsyncLoading.md
@@ -186,5 +186,5 @@ Task {
 
 - `.untold` is the runtime format for mesh loading and streaming.
 - USD/USDZ assets should be converted to `.untold` before runtime use.
-- Animation clips exported with `--animation` can be loaded as `.untold` assets.
+- Animation clips exported with `--animation` are written as `.untoldanim` assets and loaded via `setEntityAnimations(...)`, not `setEntityMeshAsync(...)`.
 - `setEntityStreamScene(...)` automatically aligns texture streaming distances to the manifest radii and enables the full tile/HLOD/LOD/OCC streaming pipeline.

--- a/docs/API/UsingRegistrationSystem.md
+++ b/docs/API/UsingRegistrationSystem.md
@@ -44,6 +44,14 @@ This function:
 - Registers default components like RenderComponent and TransformComponent.
 - Calls the completion handler when the mesh has been registered.
 
+`withExtension` is optional — fold the extension into `filename` instead if you prefer:
+
+```swift
+setEntityMeshAsync(entityId: entity, filename: "model.untold") { success in ... }
+```
+
+Passing `withExtension` explicitly (as above) still works exactly as before and takes priority if both are given; this applies to every `filename`/`withExtension` pair in the engine (`setEntityMesh`, `setEntityMeshAsync`, `setEntityAnimations`, `setEntityGaussian`, `loadSceneAuthored`, `setColorGradeLUT`).
+
 For immediate loading, use:
 
 ```swift

--- a/docs/API/UsingTheExporter.md
+++ b/docs/API/UsingTheExporter.md
@@ -73,7 +73,7 @@ untoldengine export \
 Common options:
 
 - `--input <path>`: required source `.usd`, `.usda`, `.usdc`, `.usdz`, or `.blend`
-- `--output <path>`: required destination `.untold`
+- `--output <path>`: required destination `.untold` (or `.untoldanim` with `--animation`)
 - `--file-type <tile|lod|hlod|shared|animation>`: optional, defaults to `tile`
 - `--mesh-name <name>`: optional, export only one mesh from a multi-mesh asset
 - `--convert-orientation`: optional, convert the export into engine space
@@ -82,7 +82,7 @@ Common options:
 - `--compress-geometry`: optional, LZ4-compress vertex and index chunks (requires `pip install lz4`)
 - `--optimize`: optional, compress geometry and bake/patch textures after export (implies `--compress-geometry`)
 - `--color-grade-lut <path>`: optional, stage an externally-authored standard `.cube` 3D LUT and apply it as a post-tonemap creative grade — composes with (does not replace) the default tonemap. No Blender render, no conversion. See [Using Color Management](UsingColorManagement.md)
-- `--animation`: optional, export animation clips only — no mesh geometry is written
+- `--animation`: optional, export animation clips only — no mesh geometry is written; requires a `.untoldanim` `--output` path
 - `--blender <path>`: optional Blender executable override
 
 Example using absolute paths and geometry compression:

--- a/docs/API/UsingUntoldEngineCLI.md
+++ b/docs/API/UsingUntoldEngineCLI.md
@@ -130,7 +130,7 @@ and installs the `Pillow`/`lz4` Python packages, so `untoldengine export
 ## Exporting Assets
 
 Run the exporter from the game project or any other directory. Input can be a
-USD/USDZ asset or a `.blend` file:
+USD/USDZ asset, a `.blend` file, or a Gaussian `.ply` splat capture:
 
 ```bash
 untoldengine export \
@@ -147,6 +147,76 @@ followed by `untoldengine texbake --dir` and `--patch-refs`. See
 
 Use `--blender /path/to/Blender` when Blender is not installed in its standard
 macOS location and is not available on `PATH`.
+
+### Multi-model `.blend` scenes → `.untoldpack`
+
+If the source `.blend` scene contains more than one independent model (more
+than one object with no parent among the exported objects), the exporter
+writes a `<name>.untoldpack` manifest next to `--output` instead of a single
+`.untold` file, plus one self-contained `.untold` per model under its own
+subfolder:
+
+```bash
+untoldengine export \
+  --input warehouse.blend \
+  --output warehouse.untold \
+  --convert-orientation --optimize
+# → warehouse.untoldpack, Shelf/Shelf.untold, Forklift/Forklift.untold, ...
+```
+
+`--optimize` bakes textures for every model in the pack. Load the result with
+`setEntityMeshAsync(entityId:filename:withExtension:)` using `"untoldpack"` —
+the engine loads a pack the same way it loads a single `.untold`, placing
+each model as a child entity. See [Using the Registration
+System](UsingRegistrationSystem.md).
+
+Re-exporting the same `--output` path after the scene's model count changes
+(single ↔ multiple) automatically removes the previous run's now-stale
+`.untold`/`.untoldpack` output, and any model subfolders a shrunk pack no
+longer references, so a caller never picks up a leftover file from an older
+export by accident.
+
+### Animation-only exports → `.untoldanim`
+
+`--animation` exports clip data only (no mesh geometry) and requires a
+`.untoldanim` `--output` path:
+
+```bash
+untoldengine export \
+  --input running.usdz \
+  --output running.untoldanim \
+  --convert-orientation --animation
+```
+
+`.untoldanim` is a plain `.untold` container under the hood, named distinctly
+so it's never mistaken for a mesh — `setEntityMeshAsync` rejects it; load it
+with `setEntityAnimations(entityId:filename:withExtension:name:)` instead.
+
+### Gaussian splats → `.untoldgs`
+
+Gaussian `.ply` inputs skip Blender entirely and export straight to
+`.untoldgs`:
+
+```bash
+# Single tier
+untoldengine export --input splats.ply --output splats.untoldgs
+
+# Progressive LOD tiers (splats_lod0.untoldgs, splats_lod1.untoldgs, ...)
+untoldengine export --input splats.ply --output splats.untoldgs --lod-levels 4
+```
+
+### Other export flags
+
+| Flag | Description |
+|---|---|
+| `--mesh-name <name>` | Export only one mesh from a multi-mesh asset |
+| `--file-type <tile\|lod\|hlod\|shared\|animation>` | Untold file type (default `tile`) |
+| `--source-orientation <blender-native\|engine-oriented>` | Input orientation |
+| `--compress-geometry` | LZ4-compress vertex/index chunks |
+| `--validate` | Write a companion validation JSON file |
+| `--color-grade-lut <path>` | Stage an externally-authored `.cube` 3D LUT and apply it as a post-tonemap creative grade (no Blender render, no conversion) — see [Using Color Management](UsingColorManagement.md) |
+
+Run `untoldengine export --help` for the full, current flag list.
 
 ---
 

--- a/docs/Tutorials/CLIExporterTutorial.md
+++ b/docs/Tutorials/CLIExporterTutorial.md
@@ -137,12 +137,12 @@ export so the imported result matches what you see in Blender.
 
 ## Export Animation Clips
 
-Export animation-only `.untold` files with `--animation`:
+Export animation-only `.untoldanim` files with `--animation`:
 
 ```bash
 untoldengine export \
   --input /path/to/running.usdz \
-  --output ~/Projects/MyGame/Sources/MyGame/GameData/Animations/running/running.untold \
+  --output ~/Projects/MyGame/Sources/MyGame/GameData/Animations/running/running.untoldanim \
   --convert-orientation \
   --animation
 ```
@@ -150,8 +150,8 @@ untoldengine export \
 Register clips on the loaded character:
 
 ```swift
-setEntityAnimations(entityId: character, filename: "idle", withExtension: "untold", name: "idle")
-setEntityAnimations(entityId: character, filename: "running", withExtension: "untold", name: "running")
+setEntityAnimations(entityId: character, filename: "idle", withExtension: "untoldanim", name: "idle")
+setEntityAnimations(entityId: character, filename: "running", withExtension: "untoldanim", name: "running")
 changeAnimation(entityId: character, name: "idle")
 ```
 

--- a/scripts/tests/test_untoldexplorer.py
+++ b/scripts/tests/test_untoldexplorer.py
@@ -232,6 +232,23 @@ class UntoldExplorerTests(unittest.TestCase):
         self.assertEqual(u.pack_normal((0.0, 0.0, 0.0)), u.pack_normal((0.0, 0.0, 1.0)))
         self.assertEqual(u.pack_tangent((0.0, 0.0, 0.0), -1.0), u.pack_tangent((1.0, 0.0, 0.0), -1.0))
 
+    def test_unique_pack_model_dir_name_disambiguates_sanitize_collisions(self) -> None:
+        used_names: set[str] = set()
+
+        first = u.unique_pack_model_dir_name("Chair.1", used_names)
+        second = u.unique_pack_model_dir_name("Chair 1", used_names)
+        third = u.unique_pack_model_dir_name("???", used_names)
+        fourth = u.unique_pack_model_dir_name("!!!", used_names)
+
+        # "Chair.1" and "Chair 1" both sanitize down to "Chair_1"; "???" and "!!!"
+        # both fall back to "model". Without disambiguation the second write of
+        # each pair would land in the first's folder and overwrite its .untold.
+        self.assertEqual(first, "Chair_1")
+        self.assertNotEqual(second, first)
+        self.assertEqual(third, "model")
+        self.assertNotEqual(fourth, third)
+        self.assertEqual(len({first, second, third, fourth}), 4)
+
     def test_binary_writer_alignment_and_string_table_dedup(self) -> None:
         writer = u.BinaryWriter()
         writer.write_u8(7)

--- a/scripts/untold-blender-addon/README.md
+++ b/scripts/untold-blender-addon/README.md
@@ -54,7 +54,7 @@ then set `ASTCENC_BIN=/full/path/to/astcenc` before launching Blender.
 Ensure the downloaded binary is executable with
 `chmod +x /full/path/to/astcenc`.
 
-Use `File > Export > Untold Animation (.untold)` for animation clips.
+Use `File > Export > Untold Animation (.untoldanim)` for animation clips.
 
 Animation options:
 

--- a/scripts/untold-blender-addon/untold_exporter/__init__.py
+++ b/scripts/untold-blender-addon/untold_exporter/__init__.py
@@ -213,9 +213,16 @@ class UNTOLD_OT_export_asset(bpy.types.Operator, ExportHelper):
             wm.progress_end()
             workspace.status_text_set(None)
 
+        if result.get("is_pack"):
+            # The scene had more than one independent model (see
+            # group_export_nodes_by_root), so a <name>.untoldpack manifest plus one
+            # .untold per model were written instead of a single output_path.
+            destination = f"{result['pack_path'].name} ({result['model_count']} model(s))"
+        else:
+            destination = output_path.name
         message = (
             f"Exported {result['mesh_count']} mesh(es), "
-            f"{result['vertex_count']} vertices to {output_path.name}"
+            f"{result['vertex_count']} vertices to {destination}"
         )
         if compression_summary["detail"]:
             message += f" | Geometry: {compression_summary['detail']}"
@@ -235,9 +242,9 @@ class UNTOLD_OT_export_animation(bpy.types.Operator, ExportHelper):
     bl_label = "Export Untold Animation"
     bl_options = {"REGISTER"}
 
-    filename_ext = ".untold"
+    filename_ext = ".untoldanim"
     filter_glob: bpy.props.StringProperty(
-        default="*.untold",
+        default="*.untoldanim",
         options={"HIDDEN"},
     )
 
@@ -281,7 +288,7 @@ class UNTOLD_OT_export_animation(bpy.types.Operator, ExportHelper):
     def _animation_output_path(filepath: str) -> Path:
         selected_path = Path(filepath).expanduser().resolve()
         clip_name = selected_path.stem or "animation"
-        return selected_path.parent / clip_name / f"{clip_name}.untold"
+        return selected_path.parent / clip_name / f"{clip_name}.untoldanim"
 
     def execute(self, context: bpy.types.Context) -> set[str]:
         output_path = self._animation_output_path(self.filepath)
@@ -597,7 +604,7 @@ class UNTOLD_OT_export_tiled_scene(bpy.types.Operator):
 
 def menu_func_export(self: bpy.types.Menu, context: bpy.types.Context) -> None:
     self.layout.operator(UNTOLD_OT_export_asset.bl_idname, text="Untold (.untold)")
-    self.layout.operator(UNTOLD_OT_export_animation.bl_idname, text="Untold Animation (.untold)")
+    self.layout.operator(UNTOLD_OT_export_animation.bl_idname, text="Untold Animation (.untoldanim)")
     self.layout.operator(UNTOLD_OT_export_tiled_scene.bl_idname, text="Untold Tiled Scene")
 
 

--- a/scripts/untold-blender-addon/untold_exporter/bridge.py
+++ b/scripts/untold-blender-addon/untold_exporter/bridge.py
@@ -176,7 +176,11 @@ def export_asset(
     source_asset_path = source_asset_path_for_export(output_path)
     export_objects = module.prepare_export_objects_from_blender_objects(objects)
     export_objects = append_unique_objects(export_objects, scene_payload_candidates(context, scope))
-    result = module.export_objects_to_untold(
+    # export_objects_to_untold_or_pack (rather than export_objects_to_untold) so a
+    # scene with more than one independent model writes a .untoldpack the same
+    # way the untoldengine CLI's `export` command does -- both share the same
+    # single-vs-pack decision, so they can't drift out of sync.
+    result = module.export_objects_to_untold_or_pack(
         export_objects,
         source_asset_path=source_asset_path,
         output_path=output_path,
@@ -197,36 +201,45 @@ def export_asset(
     result["texture_bake_status"] = "skipped"
 
     if bake_textures:
-        textures_dir = output_path.parent / "Textures"
-        if not textures_dir.is_dir():
-            result["texture_bake_status"] = "no textures"
-            if progress_callback is not None:
-                progress_callback("Bake textures", 0, 1, "No Textures directory was generated")
-            return result
-
+        # A pack model's textures are staged relative to its own subfolder, not
+        # output_path's directory (see write_untold_pack_from_groups) -- bake and
+        # patch each model independently, same as ExportCommand.swift's --optimize.
+        untold_paths = result["model_paths"] if result.get("is_pack") else [output_path]
         texbake = texbake_module()
-        if progress_callback is not None:
-            progress_callback("Bake textures", 0, 1, textures_dir.name)
+        baked_any = False
 
         def texture_bake_progress(done: int, total: int, detail: str) -> None:
             if progress_callback is not None:
                 progress_callback("Bake textures", done, total, detail)
 
-        try:
-            texbake.bake_directory(
-                textures_dir,
-                texture_quality,
-                keep_texture_temp,
-                progress_callback=texture_bake_progress,
-            )
-            texbake.patch_refs(output_path)
-        except SystemExit as exc:
-            code = exc.code if isinstance(exc.code, int) else 1
-            if code != 0:
-                raise RuntimeError(f"Texture bake failed with exit code {code}") from exc
-        result["texture_bake_status"] = "baked"
-        if progress_callback is not None:
-            progress_callback("Bake textures", 1, 1, "Baked .utex files and patched .untold references")
+        for untold_path in untold_paths:
+            textures_dir = untold_path.parent / "Textures"
+            if not textures_dir.is_dir():
+                continue
+            if progress_callback is not None:
+                progress_callback("Bake textures", 0, 1, textures_dir.name)
+            try:
+                texbake.bake_directory(
+                    textures_dir,
+                    texture_quality,
+                    keep_texture_temp,
+                    progress_callback=texture_bake_progress,
+                )
+                texbake.patch_refs(untold_path)
+            except SystemExit as exc:
+                code = exc.code if isinstance(exc.code, int) else 1
+                if code != 0:
+                    raise RuntimeError(f"Texture bake failed with exit code {code}") from exc
+            baked_any = True
+
+        if not baked_any:
+            result["texture_bake_status"] = "no textures"
+            if progress_callback is not None:
+                progress_callback("Bake textures", 0, 1, "No Textures directory was generated")
+        else:
+            result["texture_bake_status"] = "baked"
+            if progress_callback is not None:
+                progress_callback("Bake textures", 1, 1, "Baked .utex files and patched .untold references")
 
     return result
 

--- a/scripts/untoldexplorer.py
+++ b/scripts/untoldexplorer.py
@@ -117,6 +117,11 @@ TEXTURE_CHANNEL_G = 1
 TEXTURE_CHANNEL_B = 2
 TEXTURE_CHANNEL_A = 3
 UNTOLD_EXPORT_TEMP_OBJECT_PROP = "_untold_export_temp_object"
+# Records the pre-split object's name on each single-material fragment produced by
+# split_blender_objects_by_material(), so multi-model .untoldpack grouping (see
+# group_export_nodes_by_root) can reunite fragments of one multi-material object
+# into a single model instead of treating each material fragment as its own model.
+UNTOLD_MATERIAL_SPLIT_SOURCE_PROP = "_untold_material_split_source"
 
 ProgressCallback = Callable[[str, int, int, str], None]
 
@@ -727,6 +732,10 @@ class ExportedNode:
     world_bounds: AABB
     skeleton: Optional[ExportedSkeleton] = None
     mesh: Optional[ExportedMesh] = None
+    # Name of the object this node was split from by split_blender_objects_by_material(),
+    # if any (see UNTOLD_MATERIAL_SPLIT_SOURCE_PROP). None for nodes that were never
+    # material-split.
+    material_split_root_name: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -1013,7 +1022,31 @@ def bake_skeleton_to_world(skeleton: ExportedSkeleton, world_transform_rows: lis
     return replace(skeleton, joints=baked_joints)
 
 
+def pack_model_group_key(node: ExportedNode) -> str:
+    """The .untoldpack model identity a root node resolves to.
+
+    Ordinarily this is just the node's own entity_name. But a multi-material
+    object with no real Blender parent gets replaced by several parentless
+    material-split fragments (see split_blender_objects_by_material) that
+    aren't parented to each other, so plain parent-chain walking can't reunite
+    them -- material_split_root_name (the pre-split object's name) is used
+    instead so they still collapse into one pack model.
+    """
+    return node.material_split_root_name if node.material_split_root_name is not None else node.entity_name
+
+
 def normalize_export_nodes(nodes: list[ExportedNode]) -> list[ExportedNode]:
+    """Bake every node's mesh vertices into its export-set root's local space.
+
+    Each root's own local_transform_rows is folded into its (and its
+    descendants') baked vertex data, and reset to identity afterward. Callers
+    that need a model to be re-placeable after baking (e.g. a .untoldpack
+    model, one of several sharing one manifest) must zero the root's
+    local_transform_rows *before* calling this -- see zero_root_transform --
+    otherwise the root's absolute placement in the source scene ends up baked
+    into the geometry, and applying it again as an entity transform on load
+    doubles it up.
+    """
     if not nodes:
         return nodes
 
@@ -1105,6 +1138,22 @@ def normalize_export_nodes(nodes: list[ExportedNode]) -> list[ExportedNode]:
         )
 
     return normalized_nodes
+
+
+def zero_root_transform(nodes: list[ExportedNode]) -> list[ExportedNode]:
+    """Reset every root node's (parent_entity_name is None) local_transform_rows
+    to identity, leaving descendant transforms untouched.
+
+    Used before normalize_export_nodes() when building one .untoldpack model's
+    own .untold file, so that model's geometry gets baked relative to its own
+    root instead of the source scene's absolute world space -- the root's real
+    placement is carried separately in the manifest and applied once, at load
+    time, as that model's entity transform.
+    """
+    return [
+        replace(node, local_transform_rows=identity_matrix_rows()) if node.parent_entity_name is None else node
+        for node in nodes
+    ]
 
 
 def write_header(
@@ -4225,8 +4274,18 @@ def split_blender_objects_by_material(objects: list[object]) -> list[object]:
                     for p in new_mesh.polygons:
                         p.material_index = 0
                 new_obj = bpy.data.objects.new(f"{obj.name}_mat{mat_idx}", new_mesh)
+                # Preserve the source object's parent link (if any) so nodes that
+                # already sit under a real Blender hierarchy still group correctly;
+                # UNTOLD_MATERIAL_SPLIT_SOURCE_PROP below is what reunites fragments
+                # of a *parentless* multi-material object, which parent-chain
+                # walking alone can't do since these fragments aren't parented to
+                # each other.
+                new_obj.parent = obj.parent
+                if obj.parent is not None:
+                    new_obj.matrix_parent_inverse = obj.matrix_parent_inverse.copy()
                 new_obj.matrix_world = obj.matrix_world.copy()
                 new_obj[UNTOLD_EXPORT_TEMP_OBJECT_PROP] = True
+                new_obj[UNTOLD_MATERIAL_SPLIT_SOURCE_PROP] = obj.name
                 bpy.context.scene.collection.objects.link(new_obj)
                 result.append(new_obj)
             finally:
@@ -4414,10 +4473,11 @@ def extract_nodes_from_objects(
                 world_bounds=world_bounds,
                 skeleton=skeleton,
                 mesh=mesh,
+                material_split_root_name=obj.get(UNTOLD_MATERIAL_SPLIT_SOURCE_PROP),
             )
         )
 
-    return normalize_export_nodes(nodes)
+    return nodes
 
 
 def _blender_python_packages_dir() -> Path:
@@ -5085,6 +5145,8 @@ def export_animation_clips_to_untold(
     output_path: Path,
     progress_callback: Optional[ProgressCallback] = None,
 ) -> dict[str, object]:
+    if output_path.suffix.lower() != ".untoldanim":
+        raise RuntimeError(f"Animation export requires a .untoldanim output path, got: {output_path.suffix or '<none>'}")
     if progress_callback is not None:
         progress_callback("Build animation", 0, 1, output_path.name)
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -5252,6 +5314,7 @@ def export_objects_to_untold(
         )
     finally:
         cleanup_temporary_export_objects(export_objects)
+    exported_nodes = normalize_export_nodes(exported_nodes)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     if clean_sidecars:
         clean_generated_sidecar_dirs(output_path)
@@ -5305,6 +5368,384 @@ def export_objects_to_untold(
     }
 
 
+UNTOLDPACK_FORMAT_VERSION = 1
+
+
+def group_export_nodes_by_root(nodes: list[ExportedNode]) -> dict[str, list[ExportedNode]]:
+    """Bucket nodes by the export-set root they descend from.
+
+    A root is any node with parent_entity_name is None. A .blend scene with
+    exactly one root is "one model" (current single-.untold behavior); more
+    than one root means the scene contains multiple independent models that
+    should become separate .untold files referenced by a .untoldpack
+    manifest, rather than being fused into a single file.
+
+    Uses pack_model_group_key() to resolve each root's identity so that
+    material-split fragments of one parentless multi-material object collapse
+    back into a single model instead of becoming separate ones.
+    """
+    nodes_by_name = {node.entity_name: node for node in nodes}
+
+    def find_root_name(name: str) -> str:
+        node = nodes_by_name[name]
+        while node.parent_entity_name is not None:
+            node = nodes_by_name[node.parent_entity_name]
+        return pack_model_group_key(node)
+
+    groups: dict[str, list[ExportedNode]] = {}
+    for node in nodes:
+        groups.setdefault(find_root_name(node.entity_name), []).append(node)
+    return groups
+
+
+def sanitize_pack_model_name(name: str) -> str:
+    safe = "".join(char if char.isalnum() or char in "_-" else "_" for char in name)
+    return safe.strip("_") or "model"
+
+
+def unique_pack_model_dir_name(root_name: str, used_names: set[str]) -> str:
+    """Sanitizes root_name for use as a pack model's subfolder, disambiguating
+    collisions from sanitize_pack_model_name() collapsing distinct root names
+    (e.g. "Chair.1" and "Chair 1", or two names that both sanitize down to the
+    "model" fallback) -- without this, the second model would silently write
+    into the first's folder and overwrite its .untold file.
+    """
+    candidate = sanitize_pack_model_name(root_name)
+    if candidate not in used_names:
+        used_names.add(candidate)
+        return candidate
+
+    fingerprint = hashlib.sha1(root_name.encode("utf-8")).hexdigest()[:8]
+    candidate = f"{sanitize_pack_model_name(root_name)}_{fingerprint}"
+    if candidate not in used_names:
+        used_names.add(candidate)
+        return candidate
+
+    counter = 1
+    while True:
+        candidate = f"{sanitize_pack_model_name(root_name)}_{fingerprint}_{counter}"
+        if candidate not in used_names:
+            used_names.add(candidate)
+            return candidate
+        counter += 1
+
+
+def write_untoldpack_manifest(
+    pack_path: Path,
+    source_asset_name: str,
+    models: list[dict[str, object]],
+) -> None:
+    pack_data = {
+        "formatVersion": UNTOLDPACK_FORMAT_VERSION,
+        "sourceAsset": source_asset_name,
+        "models": models,
+    }
+    pack_path.write_text(json.dumps(pack_data, indent=2), encoding="utf-8")
+
+
+def read_pack_model_dir_names(pack_path: Path) -> list[str]:
+    """Best-effort read of an existing .untoldpack manifest's per-model directory names.
+
+    Used only for stale-file cleanup bookkeeping when a re-export changes a scene's
+    model topology (see the two call sites in main()) -- a missing or unreadable
+    manifest just yields no names to clean up rather than failing the export.
+    """
+    if not pack_path.is_file():
+        return []
+    try:
+        pack_data = json.loads(pack_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    dir_names = []
+    for model in pack_data.get("models", []):
+        path = model.get("path")
+        if path:
+            dir_names.append(Path(path).parent.name)
+    return dir_names
+
+
+def remove_pack_model_dirs(models_root: Path, dir_names: Iterable[str]) -> None:
+    """Delete the given per-model subfolders under models_root, if present."""
+    for dir_name in dir_names:
+        model_dir = models_root / dir_name
+        if model_dir.is_dir():
+            shutil.rmtree(model_dir)
+
+
+def write_single_untold_from_nodes(
+    exported_nodes: list[ExportedNode],
+    *,
+    exported_lights: list[ExportedLight],
+    exported_cameras: list[ExportedCamera],
+    output_path: Path,
+    file_type_name: str,
+    compress_geometry: bool,
+    color_grade_lut_path: Optional[Path],
+    validate: bool,
+    progress_callback: Optional[ProgressCallback],
+) -> dict[str, object]:
+    """Builds and writes a single `.untold` file from already-extracted nodes.
+
+    Shares its stale-artifact cleanup with write_untold_pack_from_groups() (see
+    export_objects_to_untold_or_pack) so both the CLI's `export` command and the
+    Blender add-on's "Export Untold Asset" operator behave identically when a
+    scene's model topology changes between runs at the same --output stem.
+    """
+    exported_nodes = normalize_export_nodes(exported_nodes)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    color_grade_lut: Optional[ColorGradeLUT] = None
+    if color_grade_lut_path is not None:
+        if progress_callback is not None:
+            progress_callback("Stage color grade LUT", 0, 1, color_grade_lut_path.name)
+        color_grade_lut = stage_color_grade_lut_for_output(color_grade_lut_path, output_path.parent)
+
+    exported_nodes = stage_nodes_for_output(exported_nodes, output_path, progress_callback=progress_callback)
+    untold_bytes = build_untold_file(
+        exported_nodes,
+        output_path,
+        file_type_name,
+        exported_lights=exported_lights,
+        exported_cameras=exported_cameras,
+        compress_geometry=compress_geometry,
+        color_grade_lut=color_grade_lut,
+        progress_callback=progress_callback,
+    )
+    if progress_callback is not None:
+        progress_callback("Write file", 0, 1, output_path.name)
+    output_path.write_bytes(untold_bytes)
+
+    exported_meshes = [node.mesh for node in exported_nodes if node.mesh is not None]
+
+    validation_path: Optional[Path] = None
+    if validate:
+        validation_path = write_validation_file(
+            output_path,
+            output_path.stem,
+            [mesh.validation_mesh for mesh in exported_meshes],
+        )
+
+    # A previous export at this same --output stem may have been a multi-model
+    # .untoldpack; it no longer is, so the old manifest and its per-model .untold
+    # subfolders are now stale. Removed only now that the new single .untold has
+    # written successfully, so a caller still loading `withExtension:
+    # "untoldpack"` can't silently pick up an outdated model set.
+    removed_stale_pack_path: Optional[Path] = None
+    pack_path = output_path.with_suffix(".untoldpack")
+    if pack_path.is_file():
+        remove_pack_model_dirs(output_path.parent, read_pack_model_dir_names(pack_path))
+        pack_path.unlink()
+        removed_stale_pack_path = pack_path
+
+    return {
+        "is_pack": False,
+        "output_path": output_path,
+        "validation_path": validation_path,
+        "bytes_written": len(untold_bytes),
+        "node_count": len(exported_nodes),
+        "mesh_count": len(exported_meshes),
+        "light_count": len(exported_lights),
+        "camera_count": len(exported_cameras),
+        "vertex_count": sum(mesh.vertex_count for mesh in exported_meshes),
+        "index_count": sum(mesh.index_count for mesh in exported_meshes),
+        "color_grade_lut_staged": color_grade_lut is not None,
+        "color_grade_lut_uri": color_grade_lut.uri if color_grade_lut is not None else None,
+        "removed_stale_pack_path": removed_stale_pack_path,
+    }
+
+
+def write_untold_pack_from_groups(
+    model_groups: dict[str, list[ExportedNode]],
+    *,
+    source_asset_name: str,
+    output_path: Path,
+    file_type_name: str,
+    compress_geometry: bool,
+    validate: bool,
+    progress_callback: Optional[ProgressCallback],
+) -> dict[str, object]:
+    """Builds and writes one self-contained `.untold` per model plus a
+    `.untoldpack` manifest referencing them, instead of fusing unrelated models
+    into one file. See write_single_untold_from_nodes() for the single-model
+    counterpart and its matching stale-artifact cleanup.
+    """
+    pack_path = output_path.with_suffix(".untoldpack")
+    # Captured before write_untoldpack_manifest() overwrites pack_path below, so
+    # any model directories from a previous pack export that the new manifest no
+    # longer references can be pruned as orphans once the new pack has written
+    # successfully (see the orphan cleanup below).
+    old_model_dir_names = read_pack_model_dir_names(pack_path)
+    new_model_dir_names: list[str] = []
+
+    manifest_models: list[dict[str, object]] = []
+    model_paths: list[Path] = []
+    total_meshes = 0
+    total_vertices = 0
+    total_indices = 0
+    total_bytes = 0
+    used_model_dir_names: set[str] = set()
+    for root_name, raw_group_nodes in model_groups.items():
+        # The root's own placement is captured here, from the un-baked node, and
+        # carried in the manifest instead of being baked into the geometry
+        # (zero_root_transform below) -- otherwise applying this same transform
+        # again as the model's entity transform on load would double it up.
+        original_root_transform = next(
+            node.local_transform_rows for node in raw_group_nodes if node.parent_entity_name is None
+        )
+        group_nodes = normalize_export_nodes(zero_root_transform(raw_group_nodes))
+
+        model_dir_name = unique_pack_model_dir_name(root_name, used_model_dir_names)
+        model_output_path = output_path.parent / model_dir_name / f"{model_dir_name}.untold"
+        model_output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        staged_group_nodes = stage_nodes_for_output(group_nodes, model_output_path, progress_callback=progress_callback)
+        model_bytes = build_untold_file(
+            staged_group_nodes,
+            model_output_path,
+            file_type_name,
+            compress_geometry=compress_geometry,
+            progress_callback=progress_callback,
+        )
+        model_output_path.write_bytes(model_bytes)
+        group_meshes = [node.mesh for node in staged_group_nodes if node.mesh is not None]
+        total_meshes += len(group_meshes)
+        total_vertices += sum(mesh.vertex_count for mesh in group_meshes)
+        total_indices += sum(mesh.index_count for mesh in group_meshes)
+        total_bytes += len(model_bytes)
+        model_paths.append(model_output_path)
+
+        if validate:
+            write_validation_file(
+                model_output_path,
+                model_output_path.stem,
+                [mesh.validation_mesh for mesh in group_meshes],
+            )
+
+        manifest_models.append(
+            {
+                "displayName": root_name,
+                "path": f"{model_dir_name}/{model_dir_name}.untold",
+                "transform": original_root_transform,
+            }
+        )
+        new_model_dir_names.append(model_dir_name)
+
+    write_untoldpack_manifest(pack_path, source_asset_name, manifest_models)
+
+    # A previous export at this same --output stem may have been a single
+    # .untold; it no longer is, so the old file is now stale and would shadow
+    # the pack for a caller still loading it `withExtension: "untold"`. Only
+    # removed after the new pack has written successfully.
+    removed_stale_single_path: Optional[Path] = None
+    if output_path.is_file():
+        output_path.unlink()
+        removed_stale_single_path = output_path
+
+    # A previous pack export at this stem may have included models that no
+    # longer exist in the source scene (renamed/deleted objects) -- their
+    # subfolders are now orphaned since the new manifest doesn't reference them.
+    orphaned_dir_names = [name for name in old_model_dir_names if name not in new_model_dir_names]
+    if orphaned_dir_names:
+        remove_pack_model_dirs(output_path.parent, orphaned_dir_names)
+
+    return {
+        "is_pack": True,
+        "pack_path": pack_path,
+        "models": manifest_models,
+        "model_paths": model_paths,
+        "model_count": len(manifest_models),
+        "mesh_count": total_meshes,
+        "vertex_count": total_vertices,
+        "index_count": total_indices,
+        "bytes_written": total_bytes,
+        "removed_stale_single_path": removed_stale_single_path,
+        "removed_orphan_dir_names": orphaned_dir_names,
+    }
+
+
+def export_objects_to_untold_or_pack(
+    export_objects: list[object],
+    *,
+    source_asset_path: Path,
+    output_path: Path,
+    file_type_name: str = "tile",
+    convert_orientation: bool = False,
+    source_orientation: str = "blender-native",
+    validate: bool = False,
+    compress_geometry: bool = False,
+    color_grade_lut_path: Optional[Path] = None,
+    clean_sidecars: bool = False,
+    progress_callback: Optional[ProgressCallback] = None,
+) -> dict[str, object]:
+    """Like export_objects_to_untold(), but writes a `.untoldpack` manifest plus
+    one self-contained `.untold` per model instead of fusing everything into a
+    single file when `export_objects` spans more than one independent root
+    model (see group_export_nodes_by_root).
+
+    This is the single source of truth for the single-vs-pack decision, shared
+    by the untoldengine CLI's `export` command (main(), below) and the Blender
+    add-on's "Export Untold Asset" operator (untold_exporter/bridge.py) so the
+    two can't drift out of sync the way they did before this function existed
+    -- the add-on called export_objects_to_untold() directly and so never
+    produced a pack no matter how many independent models a scene had.
+
+    Callers that must always fuse everything into one file regardless of root
+    count -- e.g. scripts/tilestreamingpartition.py, where a tile is expected
+    to intentionally bundle many independent props into one payload -- should
+    keep calling export_objects_to_untold() directly instead of this function.
+    """
+    exported_lights, exported_cameras = extract_scene_payload_from_objects(
+        export_objects,
+        convert_orientation=convert_orientation,
+        source_orientation=source_orientation,
+        include_scene_payload=True,
+    )
+    try:
+        exported_nodes = extract_nodes_from_objects(
+            export_objects,
+            source_asset_path,
+            convert_orientation=convert_orientation,
+            source_orientation=source_orientation,
+            validate=validate,
+            progress_callback=progress_callback,
+        )
+    finally:
+        cleanup_temporary_export_objects(export_objects)
+
+    if clean_sidecars:
+        clean_generated_sidecar_dirs(output_path)
+
+    model_groups = group_export_nodes_by_root(exported_nodes)
+    if len(model_groups) <= 1:
+        result = write_single_untold_from_nodes(
+            exported_nodes,
+            exported_lights=exported_lights,
+            exported_cameras=exported_cameras,
+            output_path=output_path,
+            file_type_name=file_type_name,
+            compress_geometry=compress_geometry,
+            color_grade_lut_path=color_grade_lut_path,
+            validate=validate,
+            progress_callback=progress_callback,
+        )
+        return result
+
+    result = write_untold_pack_from_groups(
+        model_groups,
+        source_asset_name=source_asset_path.name,
+        output_path=output_path,
+        file_type_name=file_type_name,
+        compress_geometry=compress_geometry,
+        validate=validate,
+        progress_callback=progress_callback,
+    )
+    result["node_count"] = len(exported_nodes)
+    result["light_count"] = len(exported_lights)
+    result["camera_count"] = len(exported_cameras)
+    result["dropped_scene_payload"] = bool(exported_lights or exported_cameras or color_grade_lut_path is not None)
+    return result
+
+
 def parse_args(argv: list[str]) -> argparse.Namespace:
     if "--" in argv:
         argv = argv[argv.index("--") + 1 :]
@@ -5312,7 +5753,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         argv = argv[1:]
     parser = argparse.ArgumentParser(description="Cook USD scene or animation data into UntoldEngine's .untold format.")
     parser.add_argument("--input", required=True, help="Path to a source USD/USDZ asset or a .blend file.")
-    parser.add_argument("--output", required=True, help="Path to the output .untold file.")
+    parser.add_argument("--output", required=True, help="Path to the output .untold file (or .untoldanim with --animation).")
     parser.add_argument("--file-type", default="tile", choices=sorted(FILE_TYPES.keys()), help="Untold file type to emit.")
     parser.add_argument("--mesh-name", default=None, help="Optional mesh object name when the USD asset imports multiple meshes.")
     parser.add_argument(
@@ -5363,6 +5804,8 @@ def main(argv: list[str]) -> int:
     print(f"{'Opening' if input_path.suffix.lower() == '.blend' else 'Importing'} {input_path.name} ...", flush=True)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     if args.animation:
+        if output_path.suffix.lower() != ".untoldanim":
+            raise RuntimeError(f"--animation requires a .untoldanim --output path, got: {output_path.suffix or '<none>'}")
         progress = ProgressReporter("animation export", 4)
         progress.stage("Open .blend" if input_path.suffix.lower() == ".blend" else "Import USD", input_path.name)
         exported_clips = extract_animation_clips(
@@ -5371,7 +5814,7 @@ def main(argv: list[str]) -> int:
             source_orientation=args.source_orientation,
         )
         progress.advance("Extract animation", f"{len(exported_clips)} clip(s)")
-        print(f"Building animation .untold file with {len(exported_clips)} clip(s) ...", flush=True)
+        print(f"Building animation .untoldanim file with {len(exported_clips)} clip(s) ...", flush=True)
         untold_bytes = build_animation_untold_file(exported_clips, output_path)
         progress.advance("Build file", output_path.name)
         output_path.write_bytes(untold_bytes)
@@ -5399,47 +5842,93 @@ def main(argv: list[str]) -> int:
             source_orientation=args.source_orientation,
         )
         clean_generated_sidecar_dirs(output_path)
-        print(f"Staging {len(exported_nodes)} node(s) ...", flush=True)
-        exported_nodes = stage_nodes_for_output(exported_nodes, output_path)
+
+        model_groups = group_export_nodes_by_root(exported_nodes)
         staged_hdr_assets = stage_hdr_assets_for_output(output_path.parent, input_path)
-        progress.advance("Stage nodes", output_path.name)
-
-        color_grade_lut: Optional[ColorGradeLUT] = None
-        if args.color_grade_lut:
-            print(f"Staging color grade LUT {args.color_grade_lut} ...", flush=True)
-            color_grade_lut = stage_color_grade_lut_for_output(Path(args.color_grade_lut), output_path.parent)
-
-        print("Building .untold file ...", flush=True)
-        untold_bytes = build_untold_file(
-            exported_nodes,
-            output_path,
-            args.file_type,
-            exported_lights=exported_lights,
-            exported_cameras=exported_cameras,
-            compress_geometry=args.compress_geometry,
-            color_grade_lut=color_grade_lut,
-            progress_callback=lambda stage, done, total, detail: progress.stage(
-                stage,
-                f"{done}/{total} {detail}" if total > 1 else detail,
-            ),
+        progress_stage_callback = lambda stage, done, total, detail: progress.stage(
+            stage,
+            f"{done}/{total} {detail}" if total > 1 else detail,
         )
-        progress.advance("Build file", output_path.name)
-        output_path.write_bytes(untold_bytes)
-        progress.advance("Write file", output_path.name)
-        exported_meshes = [exported_node.mesh for exported_node in exported_nodes if exported_node.mesh is not None]
-        print(f"Wrote {output_path} ({len(untold_bytes)} bytes)")
-        print(f"Nodes: {len(exported_nodes)}, Meshes: {len(exported_meshes)}")
-        print(f"Lights: {len(exported_lights)}, Cameras: {len(exported_cameras)}")
-        if staged_hdr_assets:
-            print(f"HDR environments: {len(staged_hdr_assets)}")
-        if color_grade_lut is not None:
-            print(f"Color grade LUT: {color_grade_lut.uri}")
-        print(f"Vertices: {sum(exported_mesh.vertex_count for exported_mesh in exported_meshes)}, indices: {sum(exported_mesh.index_count for exported_mesh in exported_meshes)}")
-        if args.validate:
-            # This sidecar is only for validation/debugging in engine-side tests.
-            validation_path = write_validation_file(output_path, output_path.stem, [exported_mesh.validation_mesh for exported_mesh in exported_meshes])
-            print(f"Wrote {validation_path}")
-        progress.advance("Complete", output_path.name)
+
+        if len(model_groups) <= 1:
+            print(f"Staging {len(exported_nodes)} node(s) ...", flush=True)
+            if args.color_grade_lut:
+                print(f"Staging color grade LUT {args.color_grade_lut} ...", flush=True)
+            print("Building .untold file ...", flush=True)
+            result = write_single_untold_from_nodes(
+                exported_nodes,
+                exported_lights=exported_lights,
+                exported_cameras=exported_cameras,
+                output_path=output_path,
+                file_type_name=args.file_type,
+                compress_geometry=args.compress_geometry,
+                color_grade_lut_path=Path(args.color_grade_lut) if args.color_grade_lut else None,
+                validate=args.validate,
+                progress_callback=progress_stage_callback,
+            )
+            progress.advance("Stage nodes", output_path.name)
+            progress.advance("Build file", output_path.name)
+            progress.advance("Write file", output_path.name)
+            print(f"Wrote {result['output_path']} ({result['bytes_written']} bytes)")
+            print(f"Nodes: {result['node_count']}, Meshes: {result['mesh_count']}")
+            print(f"Lights: {result['light_count']}, Cameras: {result['camera_count']}")
+            if staged_hdr_assets:
+                print(f"HDR environments: {len(staged_hdr_assets)}")
+            if result["color_grade_lut_uri"] is not None:
+                print(f"Color grade LUT: {result['color_grade_lut_uri']}")
+            print(f"Vertices: {result['vertex_count']}, indices: {result['index_count']}")
+            if result["validation_path"] is not None:
+                print(f"Wrote {result['validation_path']}")
+            # This scene used to export as a multi-model .untoldpack (a previous run
+            # at this same --output stem); it no longer does, so the old manifest and
+            # its per-model .untold subfolders are now stale (see
+            # write_single_untold_from_nodes), and ExportCommand.swift's post-export
+            # pack detection now reflects this run's actual output rather than
+            # leftover state from an earlier one.
+            if result["removed_stale_pack_path"] is not None:
+                print(f"Removed stale pack manifest: {result['removed_stale_pack_path']}", flush=True)
+            progress.advance("Complete", output_path.name)
+        else:
+            # Multiple independent models were found in the source scene: emit one
+            # self-contained .untold per model plus a .untoldpack manifest that
+            # references them, instead of fusing unrelated models into one file.
+            progress.advance("Stage nodes", output_path.with_suffix(".untoldpack").name)
+            if exported_lights or exported_cameras:
+                print(
+                    f"Note: {len(exported_lights)} light(s) and {len(exported_cameras)} camera(s) are scene-level "
+                    "and were not written into any individual .untold model; recreate them in the scene built from this pack.",
+                    flush=True,
+                )
+            if args.color_grade_lut:
+                print("Note: --color-grade-lut is scene-level and was not applied to individual pack models.", flush=True)
+
+            result = write_untold_pack_from_groups(
+                model_groups,
+                source_asset_name=input_path.name,
+                output_path=output_path,
+                file_type_name=args.file_type,
+                compress_geometry=args.compress_geometry,
+                validate=args.validate,
+                progress_callback=progress_stage_callback,
+            )
+            progress.advance("Build file", result["pack_path"].name)
+            print(f"Wrote {result['pack_path']} ({result['model_count']} model(s))")
+            print(f"Nodes: {len(exported_nodes)}, Meshes: {result['mesh_count']}")
+            if staged_hdr_assets:
+                print(f"HDR environments: {len(staged_hdr_assets)}")
+            # This scene used to export as a single .untold (a previous run at this
+            # same --output stem); it no longer does, so the old file was stale and
+            # would have shadowed the pack for a caller still loading it
+            # `withExtension: "untold"` (see write_untold_pack_from_groups).
+            if result["removed_stale_single_path"] is not None:
+                print(f"Removed stale single-file export: {result['removed_stale_single_path']}", flush=True)
+            # A previous pack export at this stem may have included models that no
+            # longer exist in the source scene (renamed/deleted objects); their
+            # subfolders were orphaned since the new manifest doesn't reference them.
+            if result["removed_orphan_dir_names"]:
+                print(f"Removed {len(result['removed_orphan_dir_names'])} orphaned pack model folder(s): {', '.join(result['removed_orphan_dir_names'])}", flush=True)
+            progress.advance("Write file", result["pack_path"].name)
+            progress.advance("Complete", result["pack_path"].name)
     return 0
 
 


### PR DESCRIPTION
## Summary

- Add `.untoldpack` manifest export for `.blend` scenes containing more than one independent model, with one self-contained `.untold` file per model. `setEntityMeshAsync` loads a pack transparently as child entities while preserving per-model transforms.

- Add the `.untoldanim` extension for animation-only exports. It uses the same underlying container as `.untold`, but with a distinct extension. `setEntityMeshAsync` now rejects `.untoldanim` files with a clear error directing users to `setEntityAnimations`.

- Fix a stale-file bug when re-exporting to the same `--output` path after a scene's model count changes (single ↔ multiple). The exporter now removes orphaned `.untold` / `.untoldpack` outputs and pack model subfolders that are no longer referenced. The CLI also performs this cleanup defensively.

- Fix the Blender add-on's **Export Untold Asset** operator, which previously used a different code path from the CLI and therefore never produced an `.untoldpack` for multi-model scenes. Both now share the `export_objects_to_untold_or_pack` entry point to prevent the two export paths from drifting apart.

- Make `withExtension` optional across `setEntityMesh`, `setEntityMeshAsync`, `setEntityAnimations`, `setEntityGaussian`, `loadSceneAuthored`, and `setColorGradeLUT`. Extensions can now be included directly in `filename` (for example, `"model.untold"`) instead of being passed separately. This is fully backward compatible, and an explicit `withExtension` value still takes priority when provided.

- Update the CLI (`UsingUntoldEngineCLI.md`) and Registration System (`UsingRegistrationSystem.md`) documentation to reflect these changes.