### PR TITLE
[Feature] Chunked, quantised .untoldgs version 3 payload

### DIFF
--- a/Sources/UntoldEngine/AssetFormat/UntoldGSFormat.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldGSFormat.swift
@@ -1,0 +1,555 @@
+//
+//  UntoldGSFormat.swift
+//  UntoldEngine
+//
+//  Engine-native `.untoldgs` Gaussian splat container, version 3.
+//
+//  `.untoldgs` is a regeneratable cache of a source capture (`.ply`); a version bump
+//  means "re-bake". Versions 1 and 2 stored one flat array of GPU-encoded splats and
+//  were read whole. Version 3 stores quantised splats in page-aligned chunks so any
+//  chunk can be read by byte range, memory-mapped, or loaded with Metal fast resource
+//  loading straight into a GPU page:
+//
+//    [0]                  UntoldGSHeaderV3       256 bytes, padded to 16 KB
+//    [chunkIndexOffset]   UntoldGSChunkEntry[]   64 bytes each, padded
+//    [nodeTreeOffset]     UntoldGSTreeNode[]     48 bytes each, padded
+//    [paletteOffset]      reserved (0 when absent)
+//    [payloadOffset]      chunk payloads, each padded to a 16 KB multiple:
+//                           core block  16 bytes × splatCount
+//                           SH block    higher-order SH bytes × splatCount (optional)
+//
+//  Integrity is per chunk (`UntoldGSChunkEntry.crc32`): a streamed payload is never
+//  fully resident, so there is no whole-file hash. Scene-side facts (mesh twin,
+//  budgets, portal bakes) live in the `.untold` asset that references this file.
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import CShaderTypes
+import Foundation
+import simd
+
+// MARK: - Errors
+
+public enum UntoldGSError: Error, CustomStringConvertible, Equatable {
+    case badMagic
+    case unsupportedVersion(UInt32)
+    case truncated
+    /// A header-declared size, count or offset disagrees with the file.
+    case sizeMismatch(String)
+    /// The bytes are the right size but their content is inconsistent (CRC, tree, counts).
+    case corrupt(String)
+    /// A feature flag or field value this reader does not implement.
+    case unsupported(String)
+    /// The writer was given splats it cannot encode.
+    case invalidInput(String)
+
+    public var description: String {
+        switch self {
+        case .badMagic: "Not an Untold Gaussian splat file"
+        case let .unsupportedVersion(version): "Unsupported Untold Gaussian splat version \(version)"
+        case .truncated: "Untold Gaussian splat file is truncated"
+        case let .sizeMismatch(reason): "Untold Gaussian splat size mismatch: \(reason)"
+        case let .corrupt(reason): "Untold Gaussian splat file is corrupt: \(reason)"
+        case let .unsupported(reason): "Untold Gaussian splat feature is not supported: \(reason)"
+        case let .invalidInput(reason): "Untold Gaussian splat input is invalid: \(reason)"
+        }
+    }
+}
+
+// MARK: - Decoded asset (what the runtime consumes)
+
+public struct UntoldGSAsset {
+    public let encodedSplats: [EncodedGaussianSplat]
+    public let shCoefficients: [UInt8]
+    public let shMetadata: GaussianSHMetadata?
+    /// Mean of this tier's splats' squared major-axis extent, baked in by
+    /// `bakeGaussianSplatProgressiveTiers` — see `estimatedGaussianOverdraw`. 0 for files
+    /// baked without the statistic (indistinguishable from a real 0, but a real 0 can only
+    /// happen for a tier with no splats, which never gets written).
+    public let meanSquaredSplatExtent: Float
+    /// Asset-level local-space bounding box (shared by every tier of the same bake, not
+    /// per-tier — see `bakeGaussianSplatProgressiveTiers`). Lets any registration path —
+    /// including streaming, which needs a real box before it can decide whether to load
+    /// anything — read a real box via `UntoldGSFormat.readHeader` without a caller-supplied value.
+    public let boundingBoxMin: simd_float3
+    public let boundingBoxMax: simd_float3
+
+    public init(
+        encodedSplats: [EncodedGaussianSplat],
+        shCoefficients: [UInt8],
+        shMetadata: GaussianSHMetadata?,
+        meanSquaredSplatExtent: Float,
+        boundingBoxMin: simd_float3,
+        boundingBoxMax: simd_float3
+    ) {
+        self.encodedSplats = encodedSplats
+        self.shCoefficients = shCoefficients
+        self.shMetadata = shMetadata
+        self.meanSquaredSplatExtent = meanSquaredSplatExtent
+        self.boundingBoxMin = boundingBoxMin
+        self.boundingBoxMax = boundingBoxMax
+    }
+
+    public var splatCount: Int {
+        encodedSplats.count
+    }
+}
+
+// MARK: - Constants
+
+public enum UntoldGSFormat {
+    /// "UTGS" as a little-endian UInt32; unchanged since version 1 so older files are
+    /// recognised and rejected with `.unsupportedVersion` rather than `.badMagic`.
+    public static let magic: UInt32 = 0x5347_5455
+    public static let magicBytes: [UInt8] = [0x55, 0x54, 0x47, 0x53]
+    public static let version: UInt32 = 3
+
+    /// Section and chunk payload alignment. Matches the VM page size on current Apple
+    /// devices, which `MTLDevice.makeBuffer(bytesNoCopy:)` requires and Metal fast resource
+    /// loading works best with.
+    public static let pageAlignment: Int = 16384
+
+    public static let headerSize: Int = 256
+    public static let chunkEntrySize: Int = 64
+    public static let treeNodeSize: Int = 48
+    /// Bytes per splat in the core block: packed position, rotation, scale, RGBA.
+    public static let coreRecordSize: Int = 16
+
+    public static let defaultLog2ChunkSplats: UInt8 = 10 // 1024 splats, 16 KB core
+    public static let maxLog2ChunkSplats: UInt8 = 14 // 16384 splats
+    public static let maxSHDegree: UInt8 = 3
+    public static let invalidNode: UInt32 = 0xFFFF_FFFF
+
+    /// Higher-order SH bytes stored per splat for a degree (DC excluded, three channels):
+    /// 0, 9, 24, 45. Same contract as `GaussianSHMetadata.higherOrderCoefficientsPerSplat`.
+    public static func shCoefficientCount(degree: UInt8) -> Int {
+        let perChannel = Int(degree + 1) * Int(degree + 1) - 1
+        return perChannel * 3
+    }
+
+    public static func alignedToPage(_ value: Int) -> Int {
+        let remainder = value % pageAlignment
+        return remainder == 0 ? value : value + (pageAlignment - remainder)
+    }
+}
+
+public enum UntoldGSFlags {
+    /// A spherical-harmonics block follows each chunk's core block.
+    public static let hasSphericalHarmonics: UInt32 = 1 << 0
+    /// SH block stores 16-bit palette indices instead of direct coefficients. Reserved.
+    public static let sphericalHarmonicsPalette: UInt32 = 1 << 1
+    /// Splats were cooked with the anti-aliasing (3D smoothing) convention.
+    public static let antialiased: UInt32 = 1 << 2
+    /// Payload was produced for an environment (large chunks, LOD tree, visibility table).
+    public static let environment: UInt32 = 1 << 3
+}
+
+/// Coordinate-system convention of the stored positions and rotations.
+public enum UntoldGSCoordinateSystem: UInt8, Sendable {
+    /// Right-handed, +X right, +Y up, −Z forward. Matches the engine.
+    case rightUpBack = 0
+    /// Right-handed, +X right, −Y up, +Z forward. The 3DGS training convention.
+    case rightDownFront = 1
+}
+
+/// How the stored colour values are meant to be interpreted.
+public enum UntoldGSColorSpace: UInt8, Sendable {
+    /// sRGB-encoded, display-referred values. Decoded to linear by the shader.
+    case sRGBDisplayReferred = 0
+    /// Linear, scene-referred values.
+    case linearSceneReferred = 1
+}
+
+// MARK: - Header
+
+/// 256-byte version-3 file header.
+public struct UntoldGSHeaderV3: Sendable, Equatable {
+    public var magic: [UInt8]
+    public var version: UInt32
+    /// See `UntoldGSFlags`.
+    public var flags: UInt32
+    /// Spherical-harmonics degree stored in the SH block, 0...3.
+    public var shDegree: UInt8
+    public var coordinateSystem: UInt8
+    public var colorSpace: UInt8
+    /// log2 of the maximum splat count per chunk.
+    public var log2ChunkSplats: UInt8
+    /// Total splat count across all LOD levels.
+    public var splatCount: UInt32
+    public var chunkCount: UInt32
+    public var nodeCount: UInt32
+    public var lodLevels: UInt8
+    /// 3-byte pad. Write as zero.
+    public var reserved0: [UInt8]
+    /// Bounds of the stored splat centres.
+    public var boundsMin: SIMD3<Float>
+    public var boundsMax: SIMD3<Float>
+    /// Asset-level local-space bounding box, expanded by splat extent and shared by every tier
+    /// of a bake. What `UntoldGSFormat.readHeader` returns.
+    public var boundingBoxMin: SIMD3<Float>
+    public var boundingBoxMax: SIMD3<Float>
+    /// Mean squared major-axis extent of this tier's splats — see `estimatedGaussianOverdraw`.
+    public var meanSquaredSplatExtent: Float
+    /// Exposure the colours were captured at, in EV. Zero when unknown.
+    public var captureExposureEV: Float
+    /// Per-channel tint that neutralises the capture white balance. Ones when unknown.
+    public var captureWhiteBalance: SIMD3<Float>
+    /// Registers splat space onto the mesh twin. Identity for worlds.
+    public var splatToMesh: simd_float4x4
+    public var chunkIndexOffset: UInt64
+    public var nodeTreeOffset: UInt64
+    /// Zero when the file carries no palette.
+    public var paletteOffset: UInt64
+    public var payloadOffset: UInt64
+    /// Byte size of the whole file, so a reader can bounds-check ranges before opening the payload.
+    public var fileSize: UInt64
+    /// Reserved tail bringing the header to 256 bytes. Write as zero.
+    public var reserved1: [UInt8]
+
+    public static let reserved1Size = 256 - 204
+
+    public init(
+        flags: UInt32 = 0,
+        shDegree: UInt8 = 0,
+        coordinateSystem: UntoldGSCoordinateSystem = .rightUpBack,
+        colorSpace: UntoldGSColorSpace = .sRGBDisplayReferred,
+        log2ChunkSplats: UInt8 = UntoldGSFormat.defaultLog2ChunkSplats,
+        splatCount: UInt32,
+        chunkCount: UInt32,
+        nodeCount: UInt32,
+        lodLevels: UInt8 = 1,
+        boundsMin: SIMD3<Float>,
+        boundsMax: SIMD3<Float>,
+        boundingBoxMin: SIMD3<Float>,
+        boundingBoxMax: SIMD3<Float>,
+        meanSquaredSplatExtent: Float = 0,
+        captureExposureEV: Float = 0,
+        captureWhiteBalance: SIMD3<Float> = SIMD3<Float>(repeating: 1),
+        splatToMesh: simd_float4x4 = matrix_identity_float4x4,
+        chunkIndexOffset: UInt64,
+        nodeTreeOffset: UInt64,
+        paletteOffset: UInt64 = 0,
+        payloadOffset: UInt64,
+        fileSize: UInt64
+    ) {
+        magic = UntoldGSFormat.magicBytes
+        version = UntoldGSFormat.version
+        self.flags = flags
+        self.shDegree = shDegree
+        self.coordinateSystem = coordinateSystem.rawValue
+        self.colorSpace = colorSpace.rawValue
+        self.log2ChunkSplats = log2ChunkSplats
+        self.splatCount = splatCount
+        self.chunkCount = chunkCount
+        self.nodeCount = nodeCount
+        self.lodLevels = lodLevels
+        reserved0 = [0, 0, 0]
+        self.boundsMin = boundsMin
+        self.boundsMax = boundsMax
+        self.boundingBoxMin = boundingBoxMin
+        self.boundingBoxMax = boundingBoxMax
+        self.meanSquaredSplatExtent = meanSquaredSplatExtent
+        self.captureExposureEV = captureExposureEV
+        self.captureWhiteBalance = captureWhiteBalance
+        self.splatToMesh = splatToMesh
+        self.chunkIndexOffset = chunkIndexOffset
+        self.nodeTreeOffset = nodeTreeOffset
+        self.paletteOffset = paletteOffset
+        self.payloadOffset = payloadOffset
+        self.fileSize = fileSize
+        reserved1 = Array(repeating: 0, count: UntoldGSHeaderV3.reserved1Size)
+    }
+
+    public var splatsPerChunk: Int {
+        1 << Int(log2ChunkSplats)
+    }
+
+    public var hasSphericalHarmonics: Bool {
+        flags & UntoldGSFlags.hasSphericalHarmonics != 0
+    }
+
+    /// Higher-order SH bytes stored per splat; zero without an SH block.
+    public var shBytesPerSplat: Int {
+        hasSphericalHarmonics ? UntoldGSFormat.shCoefficientCount(degree: shDegree) : 0
+    }
+
+    /// The GPU SH contract for this file, or nil without an SH block.
+    public var shMetadata: GaussianSHMetadata? {
+        guard hasSphericalHarmonics, shDegree > 0 else { return nil }
+        let perChannel = UInt32(shDegree + 1) * UInt32(shDegree + 1)
+        return GaussianSHMetadata(
+            degree: UInt32(shDegree),
+            coefficientsPerChannel: perChannel,
+            higherOrderCoefficientsPerSplat: UInt32(shBytesPerSplat),
+            _pad0: 0
+        )
+    }
+}
+
+// MARK: - Chunk index entry
+
+/// 64-byte entry: everything needed to serve and decode one chunk by byte range.
+public struct UntoldGSChunkEntry: Sendable, Equatable {
+    /// Absolute file offset of the chunk payload. Multiple of `pageAlignment`.
+    public var payloadOffset: UInt64
+    /// Padded payload size (core + SH, rounded up to the page).
+    public var payloadBytes: UInt32
+    /// Unpadded core block size: `coreRecordSize × splatCount`.
+    public var coreBytes: UInt32
+    public var splatCount: UInt32
+    /// 0 is the coarsest (root) level.
+    public var lodLevel: UInt16
+    /// Owning tree node.
+    public var nodeId: UInt16
+    /// Decode constants for the 11/10/11 packed positions.
+    public var aabbMin: SIMD3<Float>
+    public var aabbMax: SIMD3<Float>
+    /// Decode constants for the 11/10/11 packed log-scales.
+    public var logScaleMin: Float
+    public var logScaleMax: Float
+    /// Write as zero.
+    public var reserved0: UInt32
+    /// CRC-32 (IEEE) over the unpadded payload: core block followed by SH block.
+    public var crc32: UInt32
+
+    public init(
+        payloadOffset: UInt64,
+        payloadBytes: UInt32,
+        coreBytes: UInt32,
+        splatCount: UInt32,
+        lodLevel: UInt16 = 0,
+        nodeId: UInt16 = 0,
+        aabbMin: SIMD3<Float>,
+        aabbMax: SIMD3<Float>,
+        logScaleMin: Float,
+        logScaleMax: Float,
+        reserved0: UInt32 = 0,
+        crc32: UInt32
+    ) {
+        self.payloadOffset = payloadOffset
+        self.payloadBytes = payloadBytes
+        self.coreBytes = coreBytes
+        self.splatCount = splatCount
+        self.lodLevel = lodLevel
+        self.nodeId = nodeId
+        self.aabbMin = aabbMin
+        self.aabbMax = aabbMax
+        self.logScaleMin = logScaleMin
+        self.logScaleMax = logScaleMax
+        self.reserved0 = reserved0
+        self.crc32 = crc32
+    }
+}
+
+// MARK: - Tree node
+
+/// 48-byte node of the binary tree over the Morton-ordered chunk array.
+/// Chunks under a node are contiguous in the index, so a node maps to one byte range per LOD.
+public struct UntoldGSTreeNode: Sendable, Equatable {
+    public var aabbMin: SIMD3<Float>
+    public var aabbMax: SIMD3<Float>
+    /// Child node indices; `UntoldGSFormat.invalidNode` on leaves.
+    public var child0: UInt32
+    public var child1: UInt32
+    public var firstChunk: UInt32
+    public var chunkCount: UInt32
+    /// World-space error of this node's coarsest representation. Zero for single-level files.
+    public var geometricError: Float
+    /// Environments only: offset into the visibility table. Zero when absent.
+    public var visibilityMaskOffset: UInt32
+
+    public init(
+        aabbMin: SIMD3<Float>,
+        aabbMax: SIMD3<Float>,
+        child0: UInt32 = UntoldGSFormat.invalidNode,
+        child1: UInt32 = UntoldGSFormat.invalidNode,
+        firstChunk: UInt32,
+        chunkCount: UInt32,
+        geometricError: Float = 0,
+        visibilityMaskOffset: UInt32 = 0
+    ) {
+        self.aabbMin = aabbMin
+        self.aabbMax = aabbMax
+        self.child0 = child0
+        self.child1 = child1
+        self.firstChunk = firstChunk
+        self.chunkCount = chunkCount
+        self.geometricError = geometricError
+        self.visibilityMaskOffset = visibilityMaskOffset
+    }
+
+    public var isLeaf: Bool {
+        child0 == UntoldGSFormat.invalidNode && child1 == UntoldGSFormat.invalidNode
+    }
+}
+
+// MARK: - Binary encode / decode
+
+extension UntoldGSHeaderV3: UntoldBinaryEncodable, UntoldBinaryDecodable {
+    public func encode(to writer: UntoldBinaryWriter) {
+        writer.writeBytes(magic) // 0 – 3
+        writer.writeUInt32LE(version) // 4 – 7
+        writer.writeUInt32LE(flags) // 8 – 11
+        writer.writeUInt8(shDegree) // 12
+        writer.writeUInt8(coordinateSystem) // 13
+        writer.writeUInt8(colorSpace) // 14
+        writer.writeUInt8(log2ChunkSplats) // 15
+        writer.writeUInt32LE(splatCount) // 16 – 19
+        writer.writeUInt32LE(chunkCount) // 20 – 23
+        writer.writeUInt32LE(nodeCount) // 24 – 27
+        writer.writeUInt8(lodLevels) // 28
+        writer.writeBytes(reserved0) // 29 – 31
+        writer.writeFloat3LE(boundsMin) // 32 – 43
+        writer.writeFloat3LE(boundsMax) // 44 – 55
+        writer.writeFloat3LE(boundingBoxMin) // 56 – 67
+        writer.writeFloat3LE(boundingBoxMax) // 68 – 79
+        writer.writeFloat32LE(meanSquaredSplatExtent) // 80 – 83
+        writer.writeFloat32LE(captureExposureEV) // 84 – 87
+        writer.writeFloat3LE(captureWhiteBalance) // 88 – 99
+        writer.writeMatrix4x4LE(splatToMesh) // 100 – 163
+        writer.writeUInt64LE(chunkIndexOffset) // 164 – 171
+        writer.writeUInt64LE(nodeTreeOffset) // 172 – 179
+        writer.writeUInt64LE(paletteOffset) // 180 – 187
+        writer.writeUInt64LE(payloadOffset) // 188 – 195
+        writer.writeUInt64LE(fileSize) // 196 – 203
+        writer.writeBytes(reserved1) // 204 – 255
+    }
+
+    public static func decode(from reader: UntoldBinaryReader) throws -> UntoldGSHeaderV3 {
+        let magic = try Array(reader.readBytes(count: 4))
+        let version = try reader.readUInt32LE()
+        let flags = try reader.readUInt32LE()
+        let shDegree = try reader.readUInt8()
+        let coordinateSystem = try reader.readUInt8()
+        let colorSpace = try reader.readUInt8()
+        let log2ChunkSplats = try reader.readUInt8()
+        let splatCount = try reader.readUInt32LE()
+        let chunkCount = try reader.readUInt32LE()
+        let nodeCount = try reader.readUInt32LE()
+        let lodLevels = try reader.readUInt8()
+        let reserved0 = try Array(reader.readBytes(count: 3))
+        let boundsMin = try reader.readFloat3LE()
+        let boundsMax = try reader.readFloat3LE()
+        let boundingBoxMin = try reader.readFloat3LE()
+        let boundingBoxMax = try reader.readFloat3LE()
+        let meanSquaredSplatExtent = try reader.readFloat32LE()
+        let captureExposureEV = try reader.readFloat32LE()
+        let captureWhiteBalance = try reader.readFloat3LE()
+        let splatToMesh = try reader.readMatrix4x4LE()
+        let chunkIndexOffset = try reader.readUInt64LE()
+        let nodeTreeOffset = try reader.readUInt64LE()
+        let paletteOffset = try reader.readUInt64LE()
+        let payloadOffset = try reader.readUInt64LE()
+        let fileSize = try reader.readUInt64LE()
+        let reserved1 = try Array(reader.readBytes(count: UntoldGSHeaderV3.reserved1Size))
+
+        var header = UntoldGSHeaderV3(
+            flags: flags,
+            shDegree: shDegree,
+            log2ChunkSplats: log2ChunkSplats,
+            splatCount: splatCount,
+            chunkCount: chunkCount,
+            nodeCount: nodeCount,
+            lodLevels: lodLevels,
+            boundsMin: boundsMin,
+            boundsMax: boundsMax,
+            boundingBoxMin: boundingBoxMin,
+            boundingBoxMax: boundingBoxMax,
+            meanSquaredSplatExtent: meanSquaredSplatExtent,
+            captureExposureEV: captureExposureEV,
+            captureWhiteBalance: captureWhiteBalance,
+            splatToMesh: splatToMesh,
+            chunkIndexOffset: chunkIndexOffset,
+            nodeTreeOffset: nodeTreeOffset,
+            paletteOffset: paletteOffset,
+            payloadOffset: payloadOffset,
+            fileSize: fileSize
+        )
+        header.magic = magic
+        header.version = version
+        header.coordinateSystem = coordinateSystem
+        header.colorSpace = colorSpace
+        header.reserved0 = reserved0
+        header.reserved1 = reserved1
+        return header
+    }
+}
+
+extension UntoldGSChunkEntry: UntoldBinaryEncodable, UntoldBinaryDecodable {
+    public func encode(to writer: UntoldBinaryWriter) {
+        writer.writeUInt64LE(payloadOffset) // 0 – 7
+        writer.writeUInt32LE(payloadBytes) // 8 – 11
+        writer.writeUInt32LE(coreBytes) // 12 – 15
+        writer.writeUInt32LE(splatCount) // 16 – 19
+        writer.writeUInt16LE(lodLevel) // 20 – 21
+        writer.writeUInt16LE(nodeId) // 22 – 23
+        writer.writeFloat3LE(aabbMin) // 24 – 35
+        writer.writeFloat3LE(aabbMax) // 36 – 47
+        writer.writeFloat32LE(logScaleMin) // 48 – 51
+        writer.writeFloat32LE(logScaleMax) // 52 – 55
+        writer.writeUInt32LE(reserved0) // 56 – 59
+        writer.writeUInt32LE(crc32) // 60 – 63
+    }
+
+    public static func decode(from reader: UntoldBinaryReader) throws -> UntoldGSChunkEntry {
+        try UntoldGSChunkEntry(
+            payloadOffset: reader.readUInt64LE(),
+            payloadBytes: reader.readUInt32LE(),
+            coreBytes: reader.readUInt32LE(),
+            splatCount: reader.readUInt32LE(),
+            lodLevel: reader.readUInt16LE(),
+            nodeId: reader.readUInt16LE(),
+            aabbMin: reader.readFloat3LE(),
+            aabbMax: reader.readFloat3LE(),
+            logScaleMin: reader.readFloat32LE(),
+            logScaleMax: reader.readFloat32LE(),
+            reserved0: reader.readUInt32LE(),
+            crc32: reader.readUInt32LE()
+        )
+    }
+}
+
+extension UntoldGSTreeNode: UntoldBinaryEncodable, UntoldBinaryDecodable {
+    public func encode(to writer: UntoldBinaryWriter) {
+        writer.writeFloat3LE(aabbMin) // 0 – 11
+        writer.writeFloat3LE(aabbMax) // 12 – 23
+        writer.writeUInt32LE(child0) // 24 – 27
+        writer.writeUInt32LE(child1) // 28 – 31
+        writer.writeUInt32LE(firstChunk) // 32 – 35
+        writer.writeUInt32LE(chunkCount) // 36 – 39
+        writer.writeFloat32LE(geometricError) // 40 – 43
+        writer.writeUInt32LE(visibilityMaskOffset) // 44 – 47
+    }
+
+    public static func decode(from reader: UntoldBinaryReader) throws -> UntoldGSTreeNode {
+        try UntoldGSTreeNode(
+            aabbMin: reader.readFloat3LE(),
+            aabbMax: reader.readFloat3LE(),
+            child0: reader.readUInt32LE(),
+            child1: reader.readUInt32LE(),
+            firstChunk: reader.readUInt32LE(),
+            chunkCount: reader.readUInt32LE(),
+            geometricError: reader.readFloat32LE(),
+            visibilityMaskOffset: reader.readUInt32LE()
+        )
+    }
+}
+
+extension UntoldBinaryWriter {
+    func writeFloat3LE(_ value: SIMD3<Float>) {
+        writeFloat32LE(value.x)
+        writeFloat32LE(value.y)
+        writeFloat32LE(value.z)
+    }
+}
+
+extension UntoldBinaryReader {
+    func readFloat3LE() throws -> SIMD3<Float> {
+        try SIMD3<Float>(readFloat32LE(), readFloat32LE(), readFloat32LE())
+    }
+}

--- a/Sources/UntoldEngine/AssetFormat/UntoldGSPacking.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldGSPacking.swift
@@ -60,15 +60,38 @@ public struct UntoldGSSplat: Sendable, Equatable {
     }
 
     /// The GPU layout the renderer consumes: covariance from rotation and scale, half precision.
+    /// The raw `.ply` load path (`encodeGaussianSplatForTBDR`) converts through this same
+    /// initialiser and call, so the rotation-to-covariance math lives here only.
     public func encodedForTBDR() -> EncodedGaussianSplat {
-        let transform = simd_float3x3(simd_normalize(rotation)) * simd_float3x3(diagonal: scale)
-        let covariance = transform * transform.transpose
+        let covariance = Self.covariance(rotation: rotation, scale: scale)
         return EncodedGaussianSplat(
             position: position,
             covA: simd_half3(Float16(covariance[0, 0]), Float16(covariance[0, 1]), Float16(covariance[0, 2])),
             covB: simd_half3(Float16(covariance[1, 1]), Float16(covariance[1, 2]), Float16(covariance[2, 2])),
             colorAndOpacity: simd_half4(Float16(color.x), Float16(color.y), Float16(color.z), Float16(opacity))
         )
+    }
+
+    /// The 3D covariance of a Gaussian with the given unit rotation and per-axis scale:
+    /// `(R S)(R S)ᵀ`. A zero-length rotation is treated as the identity.
+    public static func covariance(rotation: simd_quatf, scale: SIMD3<Float>) -> simd_float3x3 {
+        let unit = simd_length_squared(rotation.vector) > 0 ? simd_normalize(rotation) : simd_quatf(ix: 0, iy: 0, iz: 0, r: 1)
+        let transform = simd_float3x3(unit) * simd_float3x3(diagonal: scale)
+        return transform * transform.transpose
+    }
+
+    /// Every number the writer packs is finite and the scale is strictly positive (its log is
+    /// stored): the packers convert to integers, which traps on NaN, so this is checked before
+    /// any of them run.
+    public var isFinite: Bool {
+        position.x.isFinite && position.y.isFinite && position.z.isFinite
+            && scale.x.isFinite && scale.y.isFinite && scale.z.isFinite
+            && scale.x > 0 && scale.y > 0 && scale.z > 0
+            && rotation.vector.x.isFinite && rotation.vector.y.isFinite
+            && rotation.vector.z.isFinite && rotation.vector.w.isFinite
+            && color.x.isFinite && color.y.isFinite && color.z.isFinite
+            && opacity.isFinite
+            && sphericalHarmonics.allSatisfy(\.isFinite)
     }
 }
 
@@ -297,8 +320,11 @@ public enum UntoldGSPacking {
 
     // MARK: Helpers
 
+    /// Clamps to 0...1; NaN clamps to 0 (Swift's `min`/`max` would propagate it into the
+    /// integer conversions of the packers, which trap on NaN).
     static func clamp01(_ value: Float) -> Float {
-        min(max(value, 0), 1)
+        guard !value.isNaN else { return 0 }
+        return min(max(value, 0), 1)
     }
 }
 

--- a/Sources/UntoldEngine/AssetFormat/UntoldGSPacking.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldGSPacking.swift
@@ -1,0 +1,324 @@
+//
+//  UntoldGSPacking.swift
+//  UntoldEngine
+//
+//  Bit-level encoding of the 16-byte `.untoldgs` core record, Morton ordering,
+//  the CRC-32 used for per-chunk integrity, and the conversions between the
+//  writer's splat representation and the importer's / GPU's structs.
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import CShaderTypes
+import Foundation
+import simd
+
+/// One splat as the writer consumes it and the decoder produces it:
+/// linear scale, unit quaternion, display-referred colour in 0...1.
+public struct UntoldGSSplat: Sendable, Equatable {
+    public var position: SIMD3<Float>
+    /// Linear per-axis scale (standard deviation), strictly positive.
+    public var scale: SIMD3<Float>
+    public var rotation: simd_quatf
+    /// SH DC colour already mapped to 0...1 (`0.5 + 0.2821 × f_dc`), not linear radiance.
+    public var color: SIMD3<Float>
+    /// Post-sigmoid opacity in 0...1.
+    public var opacity: Float
+    /// Higher-order SH coefficients, channel-major, count 0 / 9 / 24 / 45.
+    public var sphericalHarmonics: [Float]
+
+    public init(
+        position: SIMD3<Float>,
+        scale: SIMD3<Float>,
+        rotation: simd_quatf,
+        color: SIMD3<Float>,
+        opacity: Float,
+        sphericalHarmonics: [Float] = []
+    ) {
+        self.position = position
+        self.scale = scale
+        self.rotation = rotation
+        self.color = color
+        self.opacity = opacity
+        self.sphericalHarmonics = sphericalHarmonics
+    }
+
+    /// Converts an importer splat. The importer keeps the PLY order `rot_0..rot_3 = (w, x, y, z)`.
+    public init(_ splat: GaussianSplat, sphericalHarmonics: [Float] = []) {
+        self.init(
+            position: SIMD3<Float>(splat.center.x, splat.center.y, splat.center.z),
+            scale: SIMD3<Float>(splat.scale.x, splat.scale.y, splat.scale.z),
+            rotation: simd_quatf(ix: splat.quat.y, iy: splat.quat.z, iz: splat.quat.w, r: splat.quat.x),
+            color: SIMD3<Float>(splat.color.x, splat.color.y, splat.color.z),
+            opacity: splat.opacity,
+            sphericalHarmonics: sphericalHarmonics
+        )
+    }
+
+    /// The GPU layout the renderer consumes: covariance from rotation and scale, half precision.
+    public func encodedForTBDR() -> EncodedGaussianSplat {
+        let transform = simd_float3x3(simd_normalize(rotation)) * simd_float3x3(diagonal: scale)
+        let covariance = transform * transform.transpose
+        return EncodedGaussianSplat(
+            position: position,
+            covA: simd_half3(Float16(covariance[0, 0]), Float16(covariance[0, 1]), Float16(covariance[0, 2])),
+            covB: simd_half3(Float16(covariance[1, 1]), Float16(covariance[1, 2]), Float16(covariance[2, 2])),
+            colorAndOpacity: simd_half4(Float16(color.x), Float16(color.y), Float16(color.z), Float16(opacity))
+        )
+    }
+}
+
+/// The four 32-bit words of one core record.
+public struct UntoldGSCoreRecord: Sendable, Equatable {
+    /// x: bits 21–31 (11), y: bits 11–20 (10), z: bits 0–10 (11); normalised in the chunk AABB.
+    public var position: UInt32
+    /// Bits 30–31: index of the largest quaternion component; three 10-bit fields for the rest.
+    public var rotation: UInt32
+    /// 11/10/11 log-scale normalised in the chunk range.
+    public var scale: UInt32
+    /// R << 24 | G << 16 | B << 8 | A.
+    public var rgba: UInt32
+
+    public init(position: UInt32, rotation: UInt32, scale: UInt32, rgba: UInt32) {
+        self.position = position
+        self.rotation = rotation
+        self.scale = scale
+        self.rgba = rgba
+    }
+}
+
+public enum UntoldGSPacking {
+    private static let mask11: UInt32 = 0x7FF
+    private static let mask10: UInt32 = 0x3FF
+    private static let sqrt2 = Float(2).squareRoot()
+
+    // MARK: 11/10/11 triplets
+
+    /// Packs three normalised components (0...1) as 11, 10 and 11 bits.
+    public static func pack11_10_11(_ t: SIMD3<Float>) -> UInt32 {
+        let x = UInt32((clamp01(t.x) * 2047).rounded())
+        let y = UInt32((clamp01(t.y) * 1023).rounded())
+        let z = UInt32((clamp01(t.z) * 2047).rounded())
+        return (x << 21) | (y << 11) | z
+    }
+
+    public static func unpack11_10_11(_ packed: UInt32) -> SIMD3<Float> {
+        SIMD3<Float>(
+            Float((packed >> 21) & mask11) / 2047,
+            Float((packed >> 11) & mask10) / 1023,
+            Float(packed & mask11) / 2047
+        )
+    }
+
+    /// Normalises `value` into `min...max`; a zero-width range maps to 0.
+    public static func normalize(_ value: SIMD3<Float>, min: SIMD3<Float>, max: SIMD3<Float>) -> SIMD3<Float> {
+        let extent = max - min
+        var t = SIMD3<Float>(repeating: 0)
+        for axis in 0 ..< 3 where extent[axis] > 0 {
+            t[axis] = (value[axis] - min[axis]) / extent[axis]
+        }
+        return t
+    }
+
+    public static func denormalize(_ t: SIMD3<Float>, min: SIMD3<Float>, max: SIMD3<Float>) -> SIMD3<Float> {
+        min + t * (max - min)
+    }
+
+    // MARK: Rotation (smallest three)
+
+    /// Encodes a unit quaternion: the largest-magnitude component is dropped and its
+    /// index stored in the top two bits; the other three are stored as 10-bit values
+    /// in `[-1/√2, 1/√2]`. The quaternion sign is chosen so the dropped component is positive.
+    public static func packRotation(_ q: simd_quatf) -> UInt32 {
+        var v = q.vector // x, y, z, w
+        let lengthSquared = simd_length_squared(v)
+        if lengthSquared > 0 {
+            v /= lengthSquared.squareRoot()
+        } else {
+            v = SIMD4<Float>(0, 0, 0, 1)
+        }
+
+        var largest = 0
+        var largestMagnitude: Float = -1
+        for index in 0 ..< 4 {
+            let magnitude = abs(v[index])
+            if magnitude > largestMagnitude {
+                largestMagnitude = magnitude
+                largest = index
+            }
+        }
+        if v[largest] < 0 {
+            v = -v
+        }
+
+        var packed = UInt32(largest) << 30
+        var slot: UInt32 = 0
+        for index in 0 ..< 4 where index != largest {
+            let t = clamp01(v[index] / sqrt2 + 0.5)
+            packed |= UInt32((t * 1023).rounded()) << (20 - slot * 10)
+            slot += 1
+        }
+        return packed
+    }
+
+    public static func unpackRotation(_ packed: UInt32) -> simd_quatf {
+        let largest = Int(packed >> 30)
+        var components = SIMD4<Float>(repeating: 0)
+        var slot: UInt32 = 0
+        var sumSquares: Float = 0
+        for index in 0 ..< 4 where index != largest {
+            let t = Float((packed >> (20 - slot * 10)) & mask10) / 1023
+            let value = (t - 0.5) * sqrt2
+            components[index] = value
+            sumSquares += value * value
+            slot += 1
+        }
+        components[largest] = max(0, 1 - sumSquares).squareRoot()
+        return simd_quatf(vector: components)
+    }
+
+    // MARK: Colour
+
+    public static func packRGBA(color: SIMD3<Float>, opacity: Float) -> UInt32 {
+        let r = UInt32((clamp01(color.x) * 255).rounded())
+        let g = UInt32((clamp01(color.y) * 255).rounded())
+        let b = UInt32((clamp01(color.z) * 255).rounded())
+        let a = UInt32((clamp01(opacity) * 255).rounded())
+        return (r << 24) | (g << 16) | (b << 8) | a
+    }
+
+    public static func unpackRGBA(_ packed: UInt32) -> (color: SIMD3<Float>, opacity: Float) {
+        let color = SIMD3<Float>(
+            Float((packed >> 24) & 0xFF) / 255,
+            Float((packed >> 16) & 0xFF) / 255,
+            Float((packed >> 8) & 0xFF) / 255
+        )
+        return (color, Float(packed & 0xFF) / 255)
+    }
+
+    // MARK: Whole record
+
+    /// Chunk-level constants a record is encoded against.
+    public struct ChunkRanges: Sendable, Equatable {
+        public var aabbMin: SIMD3<Float>
+        public var aabbMax: SIMD3<Float>
+        public var logScaleMin: Float
+        public var logScaleMax: Float
+
+        public init(aabbMin: SIMD3<Float>, aabbMax: SIMD3<Float>, logScaleMin: Float, logScaleMax: Float) {
+            self.aabbMin = aabbMin
+            self.aabbMax = aabbMax
+            self.logScaleMin = logScaleMin
+            self.logScaleMax = logScaleMax
+        }
+
+        public init(entry: UntoldGSChunkEntry) {
+            self.init(aabbMin: entry.aabbMin, aabbMax: entry.aabbMax, logScaleMin: entry.logScaleMin, logScaleMax: entry.logScaleMax)
+        }
+
+        private var logScaleRange: Float {
+            logScaleMax - logScaleMin
+        }
+
+        func normalizeLogScale(_ scale: SIMD3<Float>) -> SIMD3<Float> {
+            let range = logScaleRange
+            guard range > 0 else { return SIMD3<Float>(repeating: 0) }
+            let logScale = SIMD3<Float>(log(max(scale.x, Float.leastNormalMagnitude)),
+                                        log(max(scale.y, Float.leastNormalMagnitude)),
+                                        log(max(scale.z, Float.leastNormalMagnitude)))
+            return (logScale - SIMD3<Float>(repeating: logScaleMin)) / range
+        }
+
+        func denormalizeLogScale(_ t: SIMD3<Float>) -> SIMD3<Float> {
+            let logScale = SIMD3<Float>(repeating: logScaleMin) + t * logScaleRange
+            return SIMD3<Float>(exp(logScale.x), exp(logScale.y), exp(logScale.z))
+        }
+    }
+
+    public static func encode(_ splat: UntoldGSSplat, ranges: ChunkRanges) -> UntoldGSCoreRecord {
+        UntoldGSCoreRecord(
+            position: pack11_10_11(normalize(splat.position, min: ranges.aabbMin, max: ranges.aabbMax)),
+            rotation: packRotation(splat.rotation),
+            scale: pack11_10_11(ranges.normalizeLogScale(splat.scale)),
+            rgba: packRGBA(color: splat.color, opacity: splat.opacity)
+        )
+    }
+
+    public static func decode(_ record: UntoldGSCoreRecord, ranges: ChunkRanges) -> UntoldGSSplat {
+        let rgba = unpackRGBA(record.rgba)
+        return UntoldGSSplat(
+            position: denormalize(unpack11_10_11(record.position), min: ranges.aabbMin, max: ranges.aabbMax),
+            scale: ranges.denormalizeLogScale(unpack11_10_11(record.scale)),
+            rotation: unpackRotation(record.rotation),
+            color: rgba.color,
+            opacity: rgba.opacity
+        )
+    }
+
+    // MARK: Spherical harmonics
+
+    /// The SH block uses the renderer's byte contract (`quantizeGaussianSHCoefficient`,
+    /// dequantised in `Gaussians.metal` as `(byte - 128) / 128`), so chunk bytes can be
+    /// bound to the GPU without conversion.
+    public static func packSHCoefficient(_ value: Float) -> UInt8 {
+        quantizeGaussianSHCoefficient(value)
+    }
+
+    public static func unpackSHCoefficient(_ byte: UInt8) -> Float {
+        (Float(byte) - 128) / 128
+    }
+
+    // MARK: Morton order
+
+    /// 63-bit Morton key: 21 bits per axis, position normalised over `bounds`.
+    public static func mortonKey(_ position: SIMD3<Float>, boundsMin: SIMD3<Float>, boundsMax: SIMD3<Float>) -> UInt64 {
+        let t = normalize(position, min: boundsMin, max: boundsMax)
+        let maxCoordinate: Float = 2_097_151 // 2^21 - 1
+        let x = UInt64((clamp01(t.x) * maxCoordinate).rounded())
+        let y = UInt64((clamp01(t.y) * maxCoordinate).rounded())
+        let z = UInt64((clamp01(t.z) * maxCoordinate).rounded())
+        return spread21(x) | (spread21(y) << 1) | (spread21(z) << 2)
+    }
+
+    /// Spreads the low 21 bits of `value` so there are two zero bits between each.
+    static func spread21(_ value: UInt64) -> UInt64 {
+        var v = value & 0x1FFFFF
+        v = (v | (v << 32)) & 0x1F_0000_0000_FFFF
+        v = (v | (v << 16)) & 0x1F_0000_FF00_00FF
+        v = (v | (v << 8)) & 0x100F_00F0_0F00_F00F
+        v = (v | (v << 4)) & 0x10C3_0C30_C30C_30C3
+        v = (v | (v << 2)) & 0x1249_2492_4924_9249
+        return v
+    }
+
+    // MARK: Helpers
+
+    static func clamp01(_ value: Float) -> Float {
+        min(max(value, 0), 1)
+    }
+}
+
+/// CRC-32 (IEEE 802.3, reflected, polynomial 0xEDB88320) for per-chunk integrity.
+public enum UntoldGSCRC32 {
+    private static let table: [UInt32] = (0 ..< 256).map { index -> UInt32 in
+        var crc = UInt32(index)
+        for _ in 0 ..< 8 {
+            crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xEDB8_8320 : crc >> 1
+        }
+        return crc
+    }
+
+    public static func checksum(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        data.withUnsafeBytes { buffer in
+            for byte in buffer {
+                crc = table[Int((crc ^ UInt32(byte)) & 0xFF)] ^ (crc >> 8)
+            }
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+}

--- a/Sources/UntoldEngine/AssetFormat/UntoldGSReader.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldGSReader.swift
@@ -1,0 +1,369 @@
+//
+//  UntoldGSReader.swift
+//  UntoldEngine
+//
+//  Parses and validates the version-3 `.untoldgs` header, chunk index and tree,
+//  serves chunk payloads by byte range, decodes chunks on the CPU, and exposes
+//  the whole-asset `read`/`readHeader` entry points the runtime already uses.
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import CShaderTypes
+import Foundation
+import simd
+
+/// Header, chunk index and tree of a `.untoldgs` file. Everything except the payloads.
+public struct UntoldGSIndex: Sendable, Equatable {
+    public var header: UntoldGSHeaderV3
+    public var chunks: [UntoldGSChunkEntry]
+    public var nodes: [UntoldGSTreeNode]
+
+    public init(header: UntoldGSHeaderV3, chunks: [UntoldGSChunkEntry], nodes: [UntoldGSTreeNode]) {
+        self.header = header
+        self.chunks = chunks
+        self.nodes = nodes
+    }
+
+    /// Byte range that must be read to parse the index: header through the end of the tree.
+    public static func prefixSize(header: UntoldGSHeaderV3) -> Int {
+        Int(header.nodeTreeOffset) + Int(header.nodeCount) * UntoldGSFormat.treeNodeSize
+    }
+}
+
+public extension UntoldGSFormat {
+    // MARK: - Runtime entry points
+
+    /// Reads only the asset-level bounding box from the fixed-size header via a bounded
+    /// `FileHandle` read — not `Data(contentsOf:)`, which would pull the whole payload into
+    /// memory to look at a few header bytes. Lets registration paths (including streaming,
+    /// which needs a real box before it can decide whether to load anything) get one
+    /// synchronously without a caller-supplied value.
+    static func readHeader(from url: URL) throws -> (boundingBoxMin: simd_float3, boundingBoxMax: simd_float3) {
+        let header = try readHeaderV3(from: url)
+        return (header.boundingBoxMin, header.boundingBoxMax)
+    }
+
+    /// Reads and validates the full header through a bounded `FileHandle` read.
+    static func readHeaderV3(from url: URL) throws -> UntoldGSHeaderV3 {
+        guard let fileHandle = FileHandle(forReadingAtPath: url.path) else {
+            throw UntoldGSError.truncated
+        }
+        defer { try? fileHandle.close() }
+        let data = try fileHandle.read(upToCount: headerSize) ?? Data()
+        return try readHeaderV3(from: data)
+    }
+
+    /// Reads the whole asset into the layout the renderer consumes. Every chunk is read,
+    /// CRC-verified and decoded on the CPU; the streaming loader reads chunks by range instead.
+    static func read(from url: URL) throws -> UntoldGSAsset {
+        let file = try UntoldGSFile(url: url)
+        let header = file.header
+        let shBytes = header.shBytesPerSplat
+
+        var encodedSplats: [EncodedGaussianSplat] = []
+        encodedSplats.reserveCapacity(Int(header.splatCount))
+        var shCoefficients: [UInt8] = []
+        shCoefficients.reserveCapacity(Int(header.splatCount) * shBytes)
+
+        for chunkIndex in file.index.chunks.indices {
+            let chunk = file.index.chunks[chunkIndex]
+            let payload = try file.chunkPayload(at: chunkIndex)
+            let decoded = try UntoldGSDecoder.decodeCore(chunk: chunk, payload: payload)
+            for splat in decoded {
+                encodedSplats.append(splat.encodedForTBDR())
+            }
+            if shBytes > 0 {
+                let start = Int(chunk.coreBytes)
+                let end = start + Int(chunk.splatCount) * shBytes
+                shCoefficients.append(contentsOf: payload[payload.startIndex + start ..< payload.startIndex + end])
+            }
+        }
+
+        return UntoldGSAsset(
+            encodedSplats: encodedSplats,
+            shCoefficients: shCoefficients,
+            shMetadata: header.shMetadata,
+            meanSquaredSplatExtent: header.meanSquaredSplatExtent,
+            boundingBoxMin: header.boundingBoxMin,
+            boundingBoxMax: header.boundingBoxMax
+        )
+    }
+
+    // MARK: - Index parsing
+
+    /// Parses the header alone from at least `headerSize` bytes. Older versions report
+    /// `.unsupportedVersion` (the file must be re-baked), not `.truncated`.
+    static func readHeaderV3(from data: Data) throws -> UntoldGSHeaderV3 {
+        guard data.count >= 8 else { throw UntoldGSError.truncated }
+        let prefix = UntoldBinaryReader(data: data)
+        let magicValue = try prefix.readUInt32LE()
+        guard magicValue == magic else { throw UntoldGSError.badMagic }
+        let versionValue = try prefix.readUInt32LE()
+        guard versionValue == version else { throw UntoldGSError.unsupportedVersion(versionValue) }
+        guard data.count >= headerSize else { throw UntoldGSError.truncated }
+
+        let header = try UntoldGSHeaderV3.decode(from: UntoldBinaryReader(data: data))
+        try validate(header: header)
+        return header
+    }
+
+    /// Parses header, chunk index and tree. `data` may be the whole file or any prefix
+    /// covering the tree section; payload ranges are validated against `header.fileSize`.
+    static func readIndex(from data: Data) throws -> UntoldGSIndex {
+        let header = try readHeaderV3(from: data)
+        let required = UntoldGSIndex.prefixSize(header: header)
+        guard data.count >= required else { throw UntoldGSError.truncated }
+
+        let reader = UntoldBinaryReader(data: data)
+        try reader.seek(to: Int(header.chunkIndexOffset))
+        var chunks: [UntoldGSChunkEntry] = []
+        chunks.reserveCapacity(Int(header.chunkCount))
+        for _ in 0 ..< header.chunkCount {
+            try chunks.append(UntoldGSChunkEntry.decode(from: reader))
+        }
+
+        try reader.seek(to: Int(header.nodeTreeOffset))
+        var nodes: [UntoldGSTreeNode] = []
+        nodes.reserveCapacity(Int(header.nodeCount))
+        for _ in 0 ..< header.nodeCount {
+            try nodes.append(UntoldGSTreeNode.decode(from: reader))
+        }
+
+        let index = UntoldGSIndex(header: header, chunks: chunks, nodes: nodes)
+        try validate(index: index)
+        return index
+    }
+
+    // MARK: - Validation
+
+    internal static func validate(header: UntoldGSHeaderV3) throws {
+        guard header.shDegree <= maxSHDegree else {
+            throw UntoldGSError.unsupported("spherical-harmonics degree \(header.shDegree)")
+        }
+        guard header.log2ChunkSplats >= 1, header.log2ChunkSplats <= maxLog2ChunkSplats else {
+            throw UntoldGSError.unsupported("log2ChunkSplats \(header.log2ChunkSplats)")
+        }
+        guard header.flags & UntoldGSFlags.sphericalHarmonicsPalette == 0 else {
+            throw UntoldGSError.unsupported("sphericalHarmonicsPalette")
+        }
+        guard header.splatCount > 0, header.chunkCount > 0, header.nodeCount > 0 else {
+            throw UntoldGSError.sizeMismatch("empty asset")
+        }
+        for offset in [header.chunkIndexOffset, header.nodeTreeOffset, header.payloadOffset] {
+            guard offset % UInt64(pageAlignment) == 0 else {
+                throw UntoldGSError.sizeMismatch("section offset \(offset) is not page aligned")
+            }
+        }
+        // Overflow-checked: a corrupt header can declare counts whose byte sizes overflow.
+        let (indexSize, indexOverflow) = UInt64(header.chunkCount).multipliedReportingOverflow(by: UInt64(chunkEntrySize))
+        let (treeSize, treeOverflow) = UInt64(header.nodeCount).multipliedReportingOverflow(by: UInt64(treeNodeSize))
+        guard !indexOverflow, !treeOverflow else {
+            throw UntoldGSError.sizeMismatch("header-declared counts overflow")
+        }
+        try requireInFile(offset: header.chunkIndexOffset, size: indexSize, fileSize: header.fileSize, what: "chunk index")
+        try requireInFile(offset: header.nodeTreeOffset, size: treeSize, fileSize: header.fileSize, what: "node tree")
+        guard header.payloadOffset <= header.fileSize else {
+            throw UntoldGSError.sizeMismatch("payload offset \(header.payloadOffset) beyond file size \(header.fileSize)")
+        }
+    }
+
+    internal static func validate(index: UntoldGSIndex) throws {
+        let header = index.header
+        guard index.chunks.count == Int(header.chunkCount) else {
+            throw UntoldGSError.sizeMismatch("chunk count \(index.chunks.count), expected \(header.chunkCount)")
+        }
+        let maxSplats = UInt32(header.splatsPerChunk)
+        let shBytes = header.shBytesPerSplat
+        var totalSplats: UInt64 = 0
+
+        for (chunkIndex, chunk) in index.chunks.enumerated() {
+            guard chunk.splatCount > 0, chunk.splatCount <= maxSplats else {
+                throw UntoldGSError.sizeMismatch("chunk \(chunkIndex) splat count \(chunk.splatCount) out of range")
+            }
+            let expectedCore = chunk.splatCount * UInt32(coreRecordSize)
+            guard chunk.coreBytes == expectedCore else {
+                throw UntoldGSError.sizeMismatch("chunk \(chunkIndex) core bytes \(chunk.coreBytes), expected \(expectedCore)")
+            }
+            let unpadded = Int(chunk.coreBytes) + Int(chunk.splatCount) * shBytes
+            guard Int(chunk.payloadBytes) >= unpadded, chunk.payloadBytes % UInt32(pageAlignment) == 0 else {
+                throw UntoldGSError.sizeMismatch("chunk \(chunkIndex) payload bytes \(chunk.payloadBytes) cannot hold \(unpadded)")
+            }
+            guard chunk.payloadOffset % UInt64(pageAlignment) == 0 else {
+                throw UntoldGSError.sizeMismatch("chunk \(chunkIndex) offset \(chunk.payloadOffset) is not page aligned")
+            }
+            try requireInFile(offset: chunk.payloadOffset, size: UInt64(chunk.payloadBytes), fileSize: header.fileSize, what: "chunk \(chunkIndex)")
+            guard Int(chunk.nodeId) < index.nodes.count else {
+                throw UntoldGSError.corrupt("chunk \(chunkIndex) references node \(chunk.nodeId) of \(index.nodes.count)")
+            }
+            totalSplats += UInt64(chunk.splatCount)
+        }
+        guard totalSplats == UInt64(header.splatCount) else {
+            throw UntoldGSError.sizeMismatch("chunks hold \(totalSplats) splats, header declares \(header.splatCount)")
+        }
+
+        for (nodeIndex, node) in index.nodes.enumerated() {
+            let end = UInt64(node.firstChunk) + UInt64(node.chunkCount)
+            guard node.chunkCount > 0, end <= UInt64(index.chunks.count) else {
+                throw UntoldGSError.corrupt("node \(nodeIndex) spans chunks \(node.firstChunk)..<\(end) of \(index.chunks.count)")
+            }
+            for child in [node.child0, node.child1] where child != invalidNode {
+                guard Int(child) < index.nodes.count, Int(child) > nodeIndex else {
+                    throw UntoldGSError.corrupt("node \(nodeIndex) has invalid child \(child)")
+                }
+            }
+        }
+        guard index.nodes[0].firstChunk == 0, index.nodes[0].chunkCount == UInt32(index.chunks.count) else {
+            throw UntoldGSError.corrupt("root does not cover every chunk")
+        }
+    }
+
+    private static func requireInFile(offset: UInt64, size: UInt64, fileSize: UInt64, what: String) throws {
+        let (end, overflow) = offset.addingReportingOverflow(size)
+        guard !overflow, end <= fileSize else {
+            throw UntoldGSError.sizeMismatch("\(what) at \(offset)+\(size) exceeds file size \(fileSize)")
+        }
+    }
+}
+
+// MARK: - Chunk decoding
+
+public enum UntoldGSDecoder {
+    /// Verifies the chunk CRC over the unpadded payload.
+    public static func verify(chunk: UntoldGSChunkEntry, chunkIndex: Int, header: UntoldGSHeaderV3, payload: Data) throws {
+        let unpadded = Int(chunk.coreBytes) + Int(chunk.splatCount) * header.shBytesPerSplat
+        guard payload.count >= unpadded else {
+            throw UntoldGSError.truncated
+        }
+        let actual = UntoldGSCRC32.checksum(payload.prefix(unpadded))
+        guard actual == chunk.crc32 else {
+            throw UntoldGSError.corrupt("chunk \(chunkIndex) CRC \(String(actual, radix: 16)) does not match \(String(chunk.crc32, radix: 16))")
+        }
+    }
+
+    /// Decodes the core block of a chunk payload (positions, scales, rotations, colour, opacity).
+    public static func decodeCore(chunk: UntoldGSChunkEntry, payload: Data) throws -> [UntoldGSSplat] {
+        let count = Int(chunk.splatCount)
+        guard payload.count >= Int(chunk.coreBytes) else {
+            throw UntoldGSError.truncated
+        }
+        let ranges = UntoldGSPacking.ChunkRanges(entry: chunk)
+        let reader = UntoldBinaryReader(data: payload)
+        var splats: [UntoldGSSplat] = []
+        splats.reserveCapacity(count)
+        for _ in 0 ..< count {
+            let record = try UntoldGSCoreRecord(
+                position: reader.readUInt32LE(),
+                rotation: reader.readUInt32LE(),
+                scale: reader.readUInt32LE(),
+                rgba: reader.readUInt32LE()
+            )
+            splats.append(UntoldGSPacking.decode(record, ranges: ranges))
+        }
+        return splats
+    }
+
+    /// Decodes a chunk payload including its SH block, dequantised to floats.
+    public static func decode(chunk: UntoldGSChunkEntry, header: UntoldGSHeaderV3, payload: Data) throws -> [UntoldGSSplat] {
+        var splats = try decodeCore(chunk: chunk, payload: payload)
+        let shBytes = header.shBytesPerSplat
+        guard shBytes > 0 else { return splats }
+        let count = Int(chunk.splatCount)
+        guard payload.count >= Int(chunk.coreBytes) + count * shBytes else {
+            throw UntoldGSError.truncated
+        }
+        let reader = UntoldBinaryReader(data: payload)
+        try reader.seek(to: Int(chunk.coreBytes))
+        for index in 0 ..< count {
+            var coefficients: [Float] = []
+            coefficients.reserveCapacity(shBytes)
+            for _ in 0 ..< shBytes {
+                try coefficients.append(UntoldGSPacking.unpackSHCoefficient(reader.readUInt8()))
+            }
+            splats[index].sphericalHarmonics = coefficients
+        }
+        return splats
+    }
+}
+
+// MARK: - Range-based file access
+
+/// Opens a `.untoldgs` on disk, parses only the index, and serves chunk payloads by
+/// byte range. The payload is never read whole.
+public final class UntoldGSFile: @unchecked Sendable {
+    public let url: URL
+    public let index: UntoldGSIndex
+    private let handle: FileHandle
+    private let lock = NSLock()
+
+    public init(url: URL) throws {
+        self.url = url
+        guard let handle = FileHandle(forReadingAtPath: url.path) else {
+            throw UntoldGSError.truncated
+        }
+        self.handle = handle
+
+        try handle.seek(toOffset: 0)
+        let headerData = try handle.read(upToCount: UntoldGSFormat.headerSize) ?? Data()
+        let header = try UntoldGSFormat.readHeaderV3(from: headerData)
+
+        let actualSize = try handle.seekToEnd()
+        guard actualSize == header.fileSize else {
+            throw UntoldGSError.sizeMismatch("file has \(actualSize) bytes, header declares \(header.fileSize)")
+        }
+
+        let prefixSize = UntoldGSIndex.prefixSize(header: header)
+        try handle.seek(toOffset: 0)
+        guard let prefix = try handle.read(upToCount: prefixSize), prefix.count == prefixSize else {
+            throw UntoldGSError.truncated
+        }
+        index = try UntoldGSFormat.readIndex(from: prefix)
+    }
+
+    deinit {
+        try? handle.close()
+    }
+
+    public var header: UntoldGSHeaderV3 {
+        index.header
+    }
+
+    /// Reads one chunk's padded payload. Verifies the CRC when `verify` is set.
+    public func chunkPayload(at chunkIndex: Int, verify: Bool = true) throws -> Data {
+        guard chunkIndex >= 0, chunkIndex < index.chunks.count else {
+            throw UntoldGSError.sizeMismatch("chunk \(chunkIndex) of \(index.chunks.count)")
+        }
+        let chunk = index.chunks[chunkIndex]
+        let payload: Data = try lock.withLock {
+            try handle.seek(toOffset: chunk.payloadOffset)
+            guard let data = try handle.read(upToCount: Int(chunk.payloadBytes)), data.count == Int(chunk.payloadBytes) else {
+                throw UntoldGSError.truncated
+            }
+            return data
+        }
+        if verify {
+            try UntoldGSDecoder.verify(chunk: chunk, chunkIndex: chunkIndex, header: index.header, payload: payload)
+        }
+        return payload
+    }
+
+    /// Reads and decodes one chunk on the CPU, SH included.
+    public func decodeChunk(at chunkIndex: Int, verify: Bool = true) throws -> [UntoldGSSplat] {
+        let payload = try chunkPayload(at: chunkIndex, verify: verify)
+        return try UntoldGSDecoder.decode(chunk: index.chunks[chunkIndex], header: index.header, payload: payload)
+    }
+
+    /// Reads and decodes every chunk in index order. Intended for tests and tooling.
+    public func decodeAll(verify: Bool = true) throws -> [UntoldGSSplat] {
+        var splats: [UntoldGSSplat] = []
+        splats.reserveCapacity(Int(index.header.splatCount))
+        for chunkIndex in index.chunks.indices {
+            try splats.append(contentsOf: decodeChunk(at: chunkIndex, verify: verify))
+        }
+        return splats
+    }
+}

--- a/Sources/UntoldEngine/AssetFormat/UntoldGSReader.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldGSReader.swift
@@ -170,6 +170,24 @@ public extension UntoldGSFormat {
         guard header.payloadOffset <= header.fileSize else {
             throw UntoldGSError.sizeMismatch("payload offset \(header.payloadOffset) beyond file size \(header.fileSize)")
         }
+        // The three sections must not share bytes: a corrupt header could otherwise have the
+        // chunk index and the tree parsed from the same range and pass every per-section check.
+        let sections: [(name: String, start: UInt64, end: UInt64)] = [
+            ("header", 0, UInt64(headerSize)),
+            ("chunk index", header.chunkIndexOffset, header.chunkIndexOffset + indexSize),
+            ("node tree", header.nodeTreeOffset, header.nodeTreeOffset + treeSize),
+            ("payload", header.payloadOffset, header.fileSize),
+        ]
+        for first in sections.indices {
+            for second in sections.indices where second > first {
+                let a = sections[first]
+                let b = sections[second]
+                let overlap = a.start < b.end && b.start < a.end
+                guard !overlap else {
+                    throw UntoldGSError.sizeMismatch("\(a.name) and \(b.name) sections overlap")
+                }
+            }
+        }
     }
 
     internal static func validate(index: UntoldGSIndex) throws {

--- a/Sources/UntoldEngine/AssetFormat/UntoldGSWriter.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldGSWriter.swift
@@ -1,0 +1,327 @@
+//
+//  UntoldGSWriter.swift
+//  UntoldEngine
+//
+//  Builds a version-3 `.untoldgs` file from an in-memory splat list: Morton
+//  ordering, chunking with per-chunk quantisation ranges, a binary tree over
+//  the chunk array, and page-aligned sections.
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import simd
+
+public struct UntoldGSWriteOptions: Sendable {
+    /// log2 of the maximum splat count per chunk. 10 (1024 splats) for objects, 12 for environments.
+    public var log2ChunkSplats: UInt8 = UntoldGSFormat.defaultLog2ChunkSplats
+    /// SH degree to store. Every splat must carry the matching coefficient count. 0 stores none.
+    public var shDegree: UInt8 = 0
+    /// Maximum chunks under a tree leaf.
+    public var leafMaxChunks: Int = 8
+    /// Within a chunk, order splats by opacity × area so partial reads keep the important ones.
+    public var sortByImportanceWithinChunk = true
+    public var coordinateSystem: UntoldGSCoordinateSystem = .rightUpBack
+    public var colorSpace: UntoldGSColorSpace = .sRGBDisplayReferred
+    public var antialiased = false
+    public var isEnvironment = false
+    /// Asset-level bounding box to bake. Defaults to the splat bounds expanded by each
+    /// splat's largest scale, like `computeGaussianSplatBoundingBox`.
+    public var boundingBoxMin: SIMD3<Float>?
+    public var boundingBoxMax: SIMD3<Float>?
+    /// Bake-time overdraw statistic for this tier — see `estimatedGaussianOverdraw`.
+    public var meanSquaredSplatExtent: Float = 0
+    public var splatToMesh: simd_float4x4 = matrix_identity_float4x4
+    public var captureExposureEV: Float = 0
+    public var captureWhiteBalance = SIMD3<Float>(repeating: 1)
+
+    public init() {}
+}
+
+public extension UntoldGSFormat {
+    /// Encodes `splats` into a complete version-3 file image.
+    static func write(splats: [UntoldGSSplat], options: UntoldGSWriteOptions = .init()) throws -> Data {
+        guard !splats.isEmpty else { throw UntoldGSError.invalidInput("no splats to write") }
+        guard options.shDegree <= maxSHDegree else {
+            throw UntoldGSError.unsupported("spherical-harmonics degree \(options.shDegree)")
+        }
+        guard options.log2ChunkSplats >= 1, options.log2ChunkSplats <= maxLog2ChunkSplats else {
+            throw UntoldGSError.unsupported("log2ChunkSplats \(options.log2ChunkSplats)")
+        }
+
+        let shCount = shCoefficientCount(degree: options.shDegree)
+        for (index, splat) in splats.enumerated() where splat.sphericalHarmonics.count != shCount {
+            throw UntoldGSError.invalidInput(
+                "splat \(index) carries \(splat.sphericalHarmonics.count) SH coefficients, expected \(shCount)"
+            )
+        }
+
+        let bounds = bounds(of: splats)
+        let order = mortonOrder(splats, boundsMin: bounds.min, boundsMax: bounds.max)
+        let splatsPerChunk = 1 << Int(options.log2ChunkSplats)
+        let chunkRanges = stride(from: 0, to: order.count, by: splatsPerChunk).map { start in
+            Array(order[start ..< min(start + splatsPerChunk, order.count)])
+        }
+
+        let headerSection = alignedToPage(headerSize)
+        let chunkIndexOffset = headerSection
+        let chunkIndexSection = alignedToPage(chunkRanges.count * chunkEntrySize)
+
+        var entries: [UntoldGSChunkEntry] = []
+        entries.reserveCapacity(chunkRanges.count)
+        var payloads: [Data] = []
+        payloads.reserveCapacity(chunkRanges.count)
+
+        for indices in chunkRanges {
+            var ordered = indices
+            if options.sortByImportanceWithinChunk {
+                ordered.sort { importance(splats[$0]) > importance(splats[$1]) }
+            }
+            let encoded = encodeChunk(ordered.map { splats[$0] }, shCount: shCount)
+            entries.append(encoded.entry)
+            payloads.append(encoded.payload)
+        }
+
+        let nodes = try buildTree(entries: &entries, leafMaxChunks: max(1, options.leafMaxChunks))
+        let nodeTreeOffset = chunkIndexOffset + chunkIndexSection
+        let nodeTreeSection = alignedToPage(nodes.count * treeNodeSize)
+        let payloadOffset = nodeTreeOffset + nodeTreeSection
+
+        var cursor = payloadOffset
+        for index in entries.indices {
+            entries[index].payloadOffset = UInt64(cursor)
+            cursor += Int(entries[index].payloadBytes)
+        }
+        let fileSize = cursor
+
+        var flags: UInt32 = 0
+        if options.shDegree > 0 {
+            flags |= UntoldGSFlags.hasSphericalHarmonics
+        }
+        if options.antialiased {
+            flags |= UntoldGSFlags.antialiased
+        }
+        if options.isEnvironment {
+            flags |= UntoldGSFlags.environment
+        }
+
+        let boundingBox = defaultBoundingBox(of: splats)
+        let header = UntoldGSHeaderV3(
+            flags: flags,
+            shDegree: options.shDegree,
+            coordinateSystem: options.coordinateSystem,
+            colorSpace: options.colorSpace,
+            log2ChunkSplats: options.log2ChunkSplats,
+            splatCount: UInt32(splats.count),
+            chunkCount: UInt32(entries.count),
+            nodeCount: UInt32(nodes.count),
+            lodLevels: 1,
+            boundsMin: bounds.min,
+            boundsMax: bounds.max,
+            boundingBoxMin: options.boundingBoxMin ?? boundingBox.min,
+            boundingBoxMax: options.boundingBoxMax ?? boundingBox.max,
+            meanSquaredSplatExtent: options.meanSquaredSplatExtent,
+            captureExposureEV: options.captureExposureEV,
+            captureWhiteBalance: options.captureWhiteBalance,
+            splatToMesh: options.splatToMesh,
+            chunkIndexOffset: UInt64(chunkIndexOffset),
+            nodeTreeOffset: UInt64(nodeTreeOffset),
+            paletteOffset: 0,
+            payloadOffset: UInt64(payloadOffset),
+            fileSize: UInt64(fileSize)
+        )
+
+        let writer = UntoldBinaryWriter()
+        header.encode(to: writer)
+        writer.align(to: pageAlignment)
+        for entry in entries {
+            entry.encode(to: writer)
+        }
+        writer.align(to: pageAlignment)
+        for node in nodes {
+            node.encode(to: writer)
+        }
+        writer.align(to: pageAlignment)
+        precondition(writer.count == payloadOffset, "section layout mismatch")
+        for payload in payloads {
+            writer.writeData(payload)
+            writer.align(to: pageAlignment)
+        }
+        precondition(writer.count == fileSize, "payload layout mismatch")
+        return writer.data
+    }
+
+    /// Encodes and writes atomically, creating the parent directory when needed.
+    static func write(splats: [UntoldGSSplat], options: UntoldGSWriteOptions = .init(), to url: URL) throws {
+        let data = try write(splats: splats, options: options)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url, options: .atomic)
+    }
+
+    // MARK: - Ordering
+
+    /// Indices of `splats` sorted by Morton key over `boundsMin...boundsMax`.
+    static func mortonOrder(_ splats: [UntoldGSSplat], boundsMin: SIMD3<Float>, boundsMax: SIMD3<Float>) -> [Int] {
+        let keys = splats.map { UntoldGSPacking.mortonKey($0.position, boundsMin: boundsMin, boundsMax: boundsMax) }
+        return splats.indices.sorted { a, b in
+            keys[a] != keys[b] ? keys[a] < keys[b] : a < b
+        }
+    }
+
+    /// Bounds of the splat centres.
+    static func bounds(of splats: [UntoldGSSplat]) -> (min: SIMD3<Float>, max: SIMD3<Float>) {
+        var minimum = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
+        var maximum = SIMD3<Float>(repeating: -.greatestFiniteMagnitude)
+        for splat in splats {
+            minimum = simd_min(minimum, splat.position)
+            maximum = simd_max(maximum, splat.position)
+        }
+        return (minimum, maximum)
+    }
+
+    /// Centre bounds expanded by each splat's largest scale, matching `computeGaussianSplatBoundingBox`.
+    static func defaultBoundingBox(of splats: [UntoldGSSplat]) -> (min: SIMD3<Float>, max: SIMD3<Float>) {
+        var minimum = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
+        var maximum = SIMD3<Float>(repeating: -.greatestFiniteMagnitude)
+        for splat in splats {
+            let extent = SIMD3<Float>(repeating: splat.scale.max())
+            minimum = simd_min(minimum, splat.position - extent)
+            maximum = simd_max(maximum, splat.position + extent)
+        }
+        return (minimum, maximum)
+    }
+
+    /// Opacity × summed pairwise scale products (proportional to surface area).
+    internal static func importance(_ splat: UntoldGSSplat) -> Float {
+        let s = splat.scale
+        return splat.opacity * (s.x * s.y + s.y * s.z + s.z * s.x)
+    }
+
+    // MARK: - Chunk encoding
+
+    internal struct EncodedChunk {
+        var entry: UntoldGSChunkEntry
+        var payload: Data
+    }
+
+    internal static func encodeChunk(_ splats: [UntoldGSSplat], shCount: Int) -> EncodedChunk {
+        var aabbMin = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
+        var aabbMax = SIMD3<Float>(repeating: -.greatestFiniteMagnitude)
+        var logScaleMin = Float.greatestFiniteMagnitude
+        var logScaleMax = -Float.greatestFiniteMagnitude
+
+        for splat in splats {
+            aabbMin = simd_min(aabbMin, splat.position)
+            aabbMax = simd_max(aabbMax, splat.position)
+            for axis in 0 ..< 3 {
+                let logScale = log(max(splat.scale[axis], Float.leastNormalMagnitude))
+                logScaleMin = min(logScaleMin, logScale)
+                logScaleMax = max(logScaleMax, logScale)
+            }
+        }
+
+        let ranges = UntoldGSPacking.ChunkRanges(
+            aabbMin: aabbMin, aabbMax: aabbMax, logScaleMin: logScaleMin, logScaleMax: logScaleMax
+        )
+
+        let coreWriter = UntoldBinaryWriter()
+        for splat in splats {
+            let record = UntoldGSPacking.encode(splat, ranges: ranges)
+            coreWriter.writeUInt32LE(record.position)
+            coreWriter.writeUInt32LE(record.rotation)
+            coreWriter.writeUInt32LE(record.scale)
+            coreWriter.writeUInt32LE(record.rgba)
+        }
+        if shCount > 0 {
+            for splat in splats {
+                for coefficient in splat.sphericalHarmonics {
+                    coreWriter.writeUInt8(UntoldGSPacking.packSHCoefficient(coefficient))
+                }
+            }
+        }
+
+        let payload = coreWriter.data
+        let entry = UntoldGSChunkEntry(
+            payloadOffset: 0,
+            payloadBytes: UInt32(alignedToPage(payload.count)),
+            coreBytes: UInt32(splats.count * coreRecordSize),
+            splatCount: UInt32(splats.count),
+            lodLevel: 0,
+            nodeId: 0,
+            aabbMin: aabbMin,
+            aabbMax: aabbMax,
+            logScaleMin: logScaleMin,
+            logScaleMax: logScaleMax,
+            crc32: UntoldGSCRC32.checksum(payload)
+        )
+        return EncodedChunk(entry: entry, payload: payload)
+    }
+
+    // MARK: - Tree
+
+    /// Binary tree over the chunk array by range halving, so every node's chunks are
+    /// contiguous. Nodes are stored in preorder; leaves stamp `nodeId` on their chunks.
+    internal static func buildTree(entries: inout [UntoldGSChunkEntry], leafMaxChunks: Int) throws -> [UntoldGSTreeNode] {
+        var nodes: [UntoldGSTreeNode] = []
+
+        func build(first: Int, count: Int) -> UInt32 {
+            let nodeIndex = UInt32(nodes.count)
+            var aabbMin = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
+            var aabbMax = SIMD3<Float>(repeating: -.greatestFiniteMagnitude)
+            for index in first ..< first + count {
+                aabbMin = simd_min(aabbMin, entries[index].aabbMin)
+                aabbMax = simd_max(aabbMax, entries[index].aabbMax)
+            }
+            nodes.append(UntoldGSTreeNode(aabbMin: aabbMin, aabbMax: aabbMax, firstChunk: UInt32(first), chunkCount: UInt32(count)))
+
+            if count <= leafMaxChunks {
+                for index in first ..< first + count {
+                    entries[index].nodeId = UInt16(truncatingIfNeeded: nodeIndex)
+                }
+                return nodeIndex
+            }
+            let half = count / 2
+            let child0 = build(first: first, count: half)
+            let child1 = build(first: first + half, count: count - half)
+            nodes[Int(nodeIndex)].child0 = child0
+            nodes[Int(nodeIndex)].child1 = child1
+            return nodeIndex
+        }
+
+        _ = build(first: 0, count: entries.count)
+        guard nodes.count <= Int(UInt16.max) else {
+            throw UntoldGSError.unsupported("tree with \(nodes.count) nodes exceeds \(UInt16.max)")
+        }
+        return nodes
+    }
+}
+
+// MARK: - Importer conversion
+
+/// Converts importer splats (plus their channel-major SH including the DC term) into
+/// writer splats carrying only the higher-order SH coefficients. `keeping` selects and
+/// orders the splats, as the progressive bake does.
+func makeUntoldGSSplats(asset: GaussianSplatAsset, keeping indices: [Int]) -> [UntoldGSSplat] {
+    let perChannel = asset.sphericalHarmonics?.coefficientsPerChannel ?? 1
+    let perSplat = perChannel * 3
+    let higherOrder = perChannel - 1
+    var splats: [UntoldGSSplat] = []
+    splats.reserveCapacity(indices.count)
+    for index in indices {
+        var coefficients: [Float] = []
+        if let harmonics = asset.sphericalHarmonics, higherOrder > 0 {
+            coefficients.reserveCapacity(higherOrder * 3)
+            let base = index * perSplat
+            for channel in 0 ..< 3 {
+                let start = base + channel * perChannel + 1
+                coefficients.append(contentsOf: harmonics.coefficients[start ..< start + higherOrder])
+            }
+        }
+        splats.append(UntoldGSSplat(asset.splats[index], sphericalHarmonics: coefficients))
+    }
+    return splats
+}

--- a/Sources/UntoldEngine/AssetFormat/UntoldGSWriter.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldGSWriter.swift
@@ -54,10 +54,17 @@ public extension UntoldGSFormat {
         }
 
         let shCount = shCoefficientCount(degree: options.shDegree)
-        for (index, splat) in splats.enumerated() where splat.sphericalHarmonics.count != shCount {
-            throw UntoldGSError.invalidInput(
-                "splat \(index) carries \(splat.sphericalHarmonics.count) SH coefficients, expected \(shCount)"
-            )
+        for (index, splat) in splats.enumerated() {
+            guard splat.sphericalHarmonics.count == shCount else {
+                throw UntoldGSError.invalidInput(
+                    "splat \(index) carries \(splat.sphericalHarmonics.count) SH coefficients, expected \(shCount)"
+                )
+            }
+            // One degenerate splat (a scale that overflowed through exp() on import, a NaN
+            // colour) must fail the bake, not trap inside an integer conversion.
+            guard splat.isFinite else {
+                throw UntoldGSError.invalidInput("splat \(index) has non-finite data or a non-positive scale")
+            }
         }
 
         let bounds = bounds(of: splats)
@@ -109,7 +116,10 @@ public extension UntoldGSFormat {
             flags |= UntoldGSFlags.environment
         }
 
-        let boundingBox = defaultBoundingBox(of: splats)
+        // Only scanned when the caller did not supply a box (the bake always does).
+        let boundingBox = (options.boundingBoxMin == nil || options.boundingBoxMax == nil)
+            ? defaultBoundingBox(of: splats)
+            : (min: options.boundingBoxMin!, max: options.boundingBoxMax!)
         let header = UntoldGSHeaderV3(
             flags: flags,
             shDegree: options.shDegree,
@@ -183,14 +193,26 @@ public extension UntoldGSFormat {
         return (minimum, maximum)
     }
 
-    /// Centre bounds expanded by each splat's largest scale, matching `computeGaussianSplatBoundingBox`.
+    /// Centre bounds expanded by each splat's largest scale (`computeGaussianSplatBoundingBox`
+    /// applies the same rule to importer splats through `expandedBoundingBox`).
     static func defaultBoundingBox(of splats: [UntoldGSSplat]) -> (min: SIMD3<Float>, max: SIMD3<Float>) {
+        expandedBoundingBox(count: splats.count, position: { splats[$0].position }, radius: { splats[$0].scale.max() })
+    }
+
+    /// Bounds of `count` centres, each grown by its radius: the box a splat visually extends
+    /// to, rather than a centres-only box. Empty input gives the empty (inverted) box.
+    static func expandedBoundingBox(
+        count: Int,
+        position: (Int) -> SIMD3<Float>,
+        radius: (Int) -> Float
+    ) -> (min: SIMD3<Float>, max: SIMD3<Float>) {
         var minimum = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
         var maximum = SIMD3<Float>(repeating: -.greatestFiniteMagnitude)
-        for splat in splats {
-            let extent = SIMD3<Float>(repeating: splat.scale.max())
-            minimum = simd_min(minimum, splat.position - extent)
-            maximum = simd_max(maximum, splat.position + extent)
+        for index in 0 ..< count {
+            let extent = SIMD3<Float>(repeating: radius(index))
+            let center = position(index)
+            minimum = simd_min(minimum, center - extent)
+            maximum = simd_max(maximum, center + extent)
         }
         return (minimum, maximum)
     }

--- a/Sources/UntoldEngine/Systems/RegistrationSystem.swift
+++ b/Sources/UntoldEngine/Systems/RegistrationSystem.swift
@@ -3280,7 +3280,11 @@ public func encodeCustomComponent<T: Component & Codable>(
     customComponentDecoderMap[decKey] = { entityId, data in
         guard let decoded = try? JSONDecoder().decode(T.self, from: data) else { return }
         if var existing = scene.assign(to: entityId, component: T.self) {
-            if let merge { merge(&existing, decoded) } else { existing = decoded }
+            if let merge {
+                merge(&existing, decoded)
+            } else {
+                existing = decoded
+            }
         }
         // (Optional) If you still want editor visibility auto-restored:
         // EditorComponentsState.shared.components[entityId, default: [:]][encKey] = <your editor metadata>
@@ -3308,7 +3312,9 @@ public func loadRawMesh(
        !node.primitives.isEmpty
     {
         let meshes = makeMeshes(from: node)
-        if !meshes.isEmpty { return meshes }
+        if !meshes.isEmpty {
+            return meshes
+        }
     }
 
     // ---- Fallback path: fabricate a safe default mesh ----
@@ -3342,220 +3348,7 @@ struct GaussianLoadResult {
     let boundingBox: (min: simd_float3, max: simd_float3)
 }
 
-public enum UntoldGSError: Error, CustomStringConvertible {
-    case badMagic
-    case unsupportedVersion(UInt32)
-    case truncated
-    case sizeMismatch(String)
-
-    public var description: String {
-        switch self {
-        case .badMagic: "Not an Untold Gaussian splat file"
-        case let .unsupportedVersion(version): "Unsupported Untold Gaussian splat version \(version)"
-        case .truncated: "Untold Gaussian splat file is truncated"
-        case let .sizeMismatch(reason): "Untold Gaussian splat size mismatch: \(reason)"
-        }
-    }
-}
-
-public struct UntoldGSAsset {
-    public let encodedSplats: [EncodedGaussianSplat]
-    public let shCoefficients: [UInt8]
-    public let shMetadata: GaussianSHMetadata?
-    /// Mean of this tier's splats' squared major-axis extent, baked in by
-    /// `bakeGaussianSplatProgressiveTiers` — see `estimatedGaussianOverdraw`. 0 for files
-    /// baked before this field existed (indistinguishable from a real 0, but a real 0 can only
-    /// happen for a tier with no splats, which never gets written).
-    public let meanSquaredSplatExtent: Float
-    /// Asset-level local-space bounding box (shared by every tier of the same bake, not
-    /// per-tier — see `bakeGaussianSplatProgressiveTiers`), baked in at version 2. Lets any
-    /// registration path — including streaming, which needs a real box before it can decide
-    /// whether to load anything — read a real box via `UntoldGSFormat.readHeader` without a
-    /// caller-supplied value.
-    public let boundingBoxMin: simd_float3
-    public let boundingBoxMax: simd_float3
-
-    public var splatCount: Int {
-        encodedSplats.count
-    }
-}
-
-public enum UntoldGSFormat {
-    private static let magic: UInt32 = 0x5347_5455 // "UTGS"
-    // v2 appended boundingBoxMin/boundingBoxMax (24 bytes) after the v1 header — every v1 field
-    // offset is unchanged. No dual-version reader: .untoldgs is a regeneratable cache of the
-    // source .ply, not hand-authored data, so a version bump just means "re-bake," the same way
-    // an EncodedGaussianSplat layout change already does.
-    private static let version: UInt32 = 2
-    private static let headerByteCount = 72
-
-    public static func write(
-        encodedSplats: [EncodedGaussianSplat],
-        sphericalHarmonics: PackedGaussianSphericalHarmonics?,
-        meanSquaredSplatExtent: Float = 0,
-        boundingBoxMin: simd_float3,
-        boundingBoxMax: simd_float3,
-        to url: URL
-    ) throws {
-        var data = Data()
-        appendUInt32(magic, to: &data)
-        appendUInt32(version, to: &data)
-        appendUInt64(UInt64(encodedSplats.count), to: &data)
-        appendUInt32(sphericalHarmonics?.metadata.degree ?? 0, to: &data)
-        appendUInt32(sphericalHarmonics?.metadata.coefficientsPerChannel ?? 0, to: &data)
-        appendUInt32(sphericalHarmonics?.metadata.higherOrderCoefficientsPerSplat ?? 0, to: &data)
-        appendFloat(meanSquaredSplatExtent, to: &data)
-        appendUInt64(UInt64(encodedSplats.count * MemoryLayout<EncodedGaussianSplat>.stride), to: &data)
-        appendUInt64(UInt64(sphericalHarmonics?.coefficients.count ?? 0), to: &data)
-        appendFloat(boundingBoxMin.x, to: &data)
-        appendFloat(boundingBoxMin.y, to: &data)
-        appendFloat(boundingBoxMin.z, to: &data)
-        appendFloat(boundingBoxMax.x, to: &data)
-        appendFloat(boundingBoxMax.y, to: &data)
-        appendFloat(boundingBoxMax.z, to: &data)
-
-        encodedSplats.withUnsafeBytes { data.append(contentsOf: $0) }
-        if let sphericalHarmonics {
-            data.append(contentsOf: sphericalHarmonics.coefficients)
-        }
-
-        try FileManager.default.createDirectory(
-            at: url.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-        try data.write(to: url, options: .atomic)
-    }
-
-    /// Check just enough to identify the version before checking the full v2 header length — an
-    /// old, valid-but-shorter v1 file (48 bytes) must report .unsupportedVersion (a clear
-    /// "re-bake me" signal), not .truncated, which would otherwise fire first purely because
-    /// it's shorter than the current header size. Shared by read() and readHeader() so both
-    /// report the same error for the same malformed input.
-    private static func validateMagicAndVersion(_ data: Data) throws {
-        guard data.count >= 8 else { throw UntoldGSError.truncated }
-        let magicValue = readUInt32(data, at: 0)
-        guard magicValue == magic else { throw UntoldGSError.badMagic }
-        let versionValue = readUInt32(data, at: 4)
-        guard versionValue == version else { throw UntoldGSError.unsupportedVersion(versionValue) }
-    }
-
-    /// Reads only `boundingBoxMin`/`boundingBoxMax` from the fixed-size header via a bounded
-    /// `FileHandle` read — not `Data(contentsOf:)`, which would pull the entire (potentially
-    /// multi-megabyte) splat/SH payload into memory just to look at 24 header bytes. Lets
-    /// registration paths (including streaming, which needs a real box before it can decide
-    /// whether to load anything) get one synchronously without a caller-supplied value.
-    public static func readHeader(from url: URL) throws -> (boundingBoxMin: simd_float3, boundingBoxMax: simd_float3) {
-        guard let fileHandle = FileHandle(forReadingAtPath: url.path) else {
-            throw UntoldGSError.truncated
-        }
-        defer { try? fileHandle.close() }
-
-        let data = try (fileHandle.read(upToCount: headerByteCount)) ?? Data()
-        try validateMagicAndVersion(data)
-        guard data.count >= headerByteCount else { throw UntoldGSError.truncated }
-
-        let boundingBoxMin = simd_float3(readFloat(data, at: 48), readFloat(data, at: 52), readFloat(data, at: 56))
-        let boundingBoxMax = simd_float3(readFloat(data, at: 60), readFloat(data, at: 64), readFloat(data, at: 68))
-        return (boundingBoxMin, boundingBoxMax)
-    }
-
-    public static func read(from url: URL) throws -> UntoldGSAsset {
-        let data = try Data(contentsOf: url)
-        try validateMagicAndVersion(data)
-        guard data.count >= headerByteCount else { throw UntoldGSError.truncated }
-
-        let splatCountRaw = readUInt64(data, at: 8)
-        let shDegree = readUInt32(data, at: 16)
-        let shCoefficientsPerChannel = readUInt32(data, at: 20)
-        let shHigherOrderPerSplat = readUInt32(data, at: 24)
-        let meanSquaredSplatExtent = readFloat(data, at: 28)
-        let encodedByteCountRaw = readUInt64(data, at: 32)
-        let shByteCountRaw = readUInt64(data, at: 40)
-        let boundingBoxMin = simd_float3(readFloat(data, at: 48), readFloat(data, at: 52), readFloat(data, at: 56))
-        let boundingBoxMax = simd_float3(readFloat(data, at: 60), readFloat(data, at: 64), readFloat(data, at: 68))
-
-        // Validate every header-declared count against the actual file size using
-        // overflow-checked UInt64 arithmetic before converting anything to Int — a corrupt or
-        // malicious header can declare values that overflow a plain multiply/add or don't fit
-        // Int, and an unchecked Int(...) conversion would trap the process instead of throwing
-        // a catchable UntoldGSError.
-        let stride = UInt64(MemoryLayout<EncodedGaussianSplat>.stride)
-        let (expectedEncodedBytes, splatByteOverflow) = splatCountRaw.multipliedReportingOverflow(by: stride)
-        guard !splatByteOverflow, encodedByteCountRaw == expectedEncodedBytes else {
-            throw UntoldGSError.sizeMismatch("encoded splat bytes \(encodedByteCountRaw), expected \(expectedEncodedBytes)")
-        }
-
-        let (headerPlusEncoded, headerOverflow) = UInt64(headerByteCount).addingReportingOverflow(encodedByteCountRaw)
-        let (totalExpectedBytes, totalOverflow) = headerPlusEncoded.addingReportingOverflow(shByteCountRaw)
-        guard !headerOverflow, !totalOverflow, UInt64(data.count) == totalExpectedBytes else {
-            throw UntoldGSError.sizeMismatch("file has \(data.count) bytes, expected \(totalExpectedBytes)")
-        }
-
-        // Both counts are now provably <= data.count (a valid Int), so these conversions
-        // cannot trap.
-        guard let encodedByteCount = Int(exactly: encodedByteCountRaw),
-              let shByteCount = Int(exactly: shByteCountRaw)
-        else {
-            throw UntoldGSError.sizeMismatch("header-declared byte counts do not fit in memory")
-        }
-
-        let encodedStart = headerByteCount
-        let encodedEnd = encodedStart + encodedByteCount
-        let encodedSplats = data[encodedStart ..< encodedEnd].withUnsafeBytes { rawBuffer in
-            Array(rawBuffer.bindMemory(to: EncodedGaussianSplat.self))
-        }
-
-        let shStart = encodedEnd
-        let shCoefficients = shByteCount > 0 ? Array(data[shStart ..< shStart + shByteCount]) : []
-        let shMetadata: GaussianSHMetadata? = shByteCount > 0
-            ? GaussianSHMetadata(
-                degree: shDegree,
-                coefficientsPerChannel: shCoefficientsPerChannel,
-                higherOrderCoefficientsPerSplat: shHigherOrderPerSplat,
-                _pad0: 0
-            )
-            : nil
-
-        return UntoldGSAsset(
-            encodedSplats: encodedSplats,
-            shCoefficients: shCoefficients,
-            shMetadata: shMetadata,
-            meanSquaredSplatExtent: meanSquaredSplatExtent,
-            boundingBoxMin: boundingBoxMin,
-            boundingBoxMax: boundingBoxMax
-        )
-    }
-
-    private static func appendUInt32(_ value: UInt32, to data: inout Data) {
-        var littleEndian = value.littleEndian
-        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
-    }
-
-    private static func appendFloat(_ value: Float, to data: inout Data) {
-        appendUInt32(value.bitPattern, to: &data)
-    }
-
-    private static func readFloat(_ data: Data, at offset: Int) -> Float {
-        Float(bitPattern: readUInt32(data, at: offset))
-    }
-
-    private static func appendUInt64(_ value: UInt64, to data: inout Data) {
-        var littleEndian = value.littleEndian
-        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
-    }
-
-    private static func readUInt32(_ data: Data, at offset: Int) -> UInt32 {
-        data.withUnsafeBytes { rawBuffer in
-            UInt32(littleEndian: rawBuffer.loadUnaligned(fromByteOffset: offset, as: UInt32.self))
-        }
-    }
-
-    private static func readUInt64(_ data: Data, at offset: Int) -> UInt64 {
-        data.withUnsafeBytes { rawBuffer in
-            UInt64(littleEndian: rawBuffer.loadUnaligned(fromByteOffset: offset, as: UInt64.self))
-        }
-    }
-}
+// `UntoldGSError`, `UntoldGSAsset` and `UntoldGSFormat` live in AssetFormat/UntoldGS*.swift.
 
 /// Builds GPU buffers from already-encoded Gaussian splat data.
 /// Returns `nil` on any failure, calling `handleError` internally — callers just guard-return.
@@ -4359,22 +4152,19 @@ private func nearestSelectedBucketDistanceSquared(
     return best
 }
 
-private func subsetSphericalHarmonics(
-    _ sh: GaussianSphericalHarmonics,
-    keeping indices: [Int]
-) -> GaussianSphericalHarmonics {
-    let perSplat = sh.coefficientsPerSplat
-    var subset: [Float] = []
-    subset.reserveCapacity(indices.count * perSplat)
-    for index in indices {
-        let base = index * perSplat
-        subset.append(contentsOf: sh.coefficients[base ..< base + perSplat])
-    }
-    return GaussianSphericalHarmonics(
-        degree: sh.degree,
-        coefficientsPerChannel: sh.coefficientsPerChannel,
-        coefficients: subset
-    )
+/// Write options shared by every tier of one bake: the source SH degree, the asset-level
+/// bounding box (so it stays stable across LOD switches) and this tier's overdraw statistic.
+private func gaussianTierWriteOptions(
+    asset: GaussianSplatAsset,
+    boundingBox: (min: simd_float3, max: simd_float3),
+    meanSquaredSplatExtent: Float
+) -> UntoldGSWriteOptions {
+    var options = UntoldGSWriteOptions()
+    options.shDegree = UInt8(clamping: asset.sphericalHarmonics?.degree ?? 0)
+    options.boundingBoxMin = boundingBox.min
+    options.boundingBoxMax = boundingBox.max
+    options.meanSquaredSplatExtent = meanSquaredSplatExtent
+    return options
 }
 
 /// One baked `.untoldgs` tier plus the bake-time statistic needed for overdraw estimation —
@@ -4428,17 +4218,10 @@ public func bakeGaussianSplatProgressiveTiers(
     if lodFractions == [1.0] {
         let resultURL = outputBaseURL
         let allIndices = Array(asset.splats.indices)
-        let encodedSplats = asset.splats.map(encodeGaussianSplatForTBDR)
-        let packedSphericalHarmonics = try asset.sphericalHarmonics.map {
-            try packGaussianSphericalHarmonics($0, splatCount: asset.splats.count)
-        }
         let tierExtent = meanSquaredSplatExtent(asset.splats, keeping: allIndices)
         try UntoldGSFormat.write(
-            encodedSplats: encodedSplats,
-            sphericalHarmonics: packedSphericalHarmonics,
-            meanSquaredSplatExtent: tierExtent,
-            boundingBoxMin: assetBoundingBox.min,
-            boundingBoxMax: assetBoundingBox.max,
+            splats: makeUntoldGSSplats(asset: asset, keeping: allIndices),
+            options: gaussianTierWriteOptions(asset: asset, boundingBox: assetBoundingBox, meanSquaredSplatExtent: tierExtent),
             to: resultURL
         )
         return GaussianProgressiveBakeResult(
@@ -4459,23 +4242,13 @@ public func bakeGaussianSplatProgressiveTiers(
         let clampedFraction = min(max(fraction, 0), 1)
         let keepCount = max(1, Int((Float(asset.splats.count) * clampedFraction).rounded(.up)))
         let keptIndices = Array(rankedIndices.prefix(keepCount))
-        let encodedSplats = keptIndices.map { encodeGaussianSplatForTBDR(asset.splats[$0]) }
-        let packedSphericalHarmonics = try asset.sphericalHarmonics.map { sh in
-            try packGaussianSphericalHarmonics(
-                subsetSphericalHarmonics(sh, keeping: keptIndices),
-                splatCount: keptIndices.count
-            )
-        }
         let tierURL = baseDirectory
             .appendingPathComponent("\(baseName)_lod\(tierIndex)")
             .appendingPathExtension("untoldgs")
         let tierExtent = meanSquaredSplatExtent(asset.splats, keeping: keptIndices)
         try UntoldGSFormat.write(
-            encodedSplats: encodedSplats,
-            sphericalHarmonics: packedSphericalHarmonics,
-            meanSquaredSplatExtent: tierExtent,
-            boundingBoxMin: assetBoundingBox.min,
-            boundingBoxMax: assetBoundingBox.max,
+            splats: makeUntoldGSSplats(asset: asset, keeping: keptIndices),
+            options: gaussianTierWriteOptions(asset: asset, boundingBox: assetBoundingBox, meanSquaredSplatExtent: tierExtent),
             to: tierURL
         )
         tiers.append(GaussianLODTier(url: tierURL, meanSquaredSplatExtent: tierExtent))
@@ -4977,7 +4750,9 @@ public func addLODLevels(
             maxDistance: level.maxDistance,
             screenPercentage: level.screenPercentage
         ) { success in
-            if !success { allSuccess = false }
+            if !success {
+                allSuccess = false
+            }
             group.leave()
         }
     }

--- a/Sources/UntoldEngine/Systems/RegistrationSystem.swift
+++ b/Sources/UntoldEngine/Systems/RegistrationSystem.swift
@@ -3508,15 +3508,11 @@ func computeGaussianSplatPositionBoundingBox(_ positions: [simd_float3], padding
 /// `EncodedGaussianSplat` yet and real per-splat scale is still available.
 func computeGaussianSplatBoundingBox(_ splats: [GaussianSplat]) -> (min: simd_float3, max: simd_float3) {
     guard !splats.isEmpty else { return (min: .zero, max: .zero) }
-    var boundsMin = simd_float3(repeating: .infinity)
-    var boundsMax = simd_float3(repeating: -.infinity)
-    for splat in splats {
-        let center = simd_float3(splat.center.x, splat.center.y, splat.center.z)
-        let radius = simd_float3(repeating: gaussianMajorAxis(splat))
-        boundsMin = simd_min(boundsMin, center - radius)
-        boundsMax = simd_max(boundsMax, center + radius)
-    }
-    return (min: boundsMin, max: boundsMax)
+    return UntoldGSFormat.expandedBoundingBox(
+        count: splats.count,
+        position: { simd_float3(splats[$0].center.x, splats[$0].center.y, splats[$0].center.z) },
+        radius: { gaussianMajorAxis(splats[$0]) }
+    )
 }
 
 /// Reads a `.ply` Gaussian splat asset from disk and builds its GPU buffers.
@@ -4164,6 +4160,11 @@ private func gaussianTierWriteOptions(
     options.boundingBoxMin = boundingBox.min
     options.boundingBoxMax = boundingBox.max
     options.meanSquaredSplatExtent = meanSquaredSplatExtent
+    // What the importer knows about the source: its colours are the display-referred SH DC
+    // mapping (`UntoldGSSplat.color`), and the geometry is stored as read. The coordinate
+    // system and anti-aliasing flags become explicit cook options in the export command's
+    // cooking flags; until a source format carries them, the header keeps the defaults.
+    options.colorSpace = .sRGBDisplayReferred
     return options
 }
 
@@ -4288,6 +4289,8 @@ public struct PackedGaussianSphericalHarmonics {
 /// higher-order outliers (e.g. strong specular splats), and clamping only
 /// caps the affected highlight rather than discarding the whole asset.
 func quantizeGaussianSHCoefficient(_ value: Float) -> UInt8 {
+    // NaN would reach `Int(_:)` and trap (Swift's min/max propagate it); it quantises to 0.
+    guard value.isFinite else { return 128 }
     let clamped = min(max(value, -1), 1)
     return UInt8(clamping: Int(clamped * 127) + 128)
 }
@@ -4341,25 +4344,10 @@ func packGaussianSphericalHarmonics(
     )
 }
 
+/// The raw `.ply` path shares the rotation-to-covariance math with the v3 decoder
+/// (`UntoldGSSplat.encodedForTBDR`).
 private func encodeGaussianSplatForTBDR(_ splat: GaussianSplat) -> EncodedGaussianSplat {
-    let scale = simd_float3(splat.scale.x, splat.scale.y, splat.scale.z)
-    let rotation = simd_quatf(
-        ix: splat.quat.y,
-        iy: splat.quat.z,
-        iz: splat.quat.w,
-        r: splat.quat.x
-    ).normalized
-    let transform = simd_float3x3(rotation) * simd_float3x3(diagonal: scale)
-    let covariance = transform * transform.transpose
-
-    return EncodedGaussianSplat(
-        position: simd_float3(splat.center.x, splat.center.y, splat.center.z),
-        covA: simd_half3(Float16(covariance[0, 0]), Float16(covariance[0, 1]), Float16(covariance[0, 2])),
-        covB: simd_half3(Float16(covariance[1, 1]), Float16(covariance[1, 2]), Float16(covariance[2, 2])),
-        colorAndOpacity: simd_half4(
-            Float16(splat.color.x), Float16(splat.color.y), Float16(splat.color.z), Float16(splat.opacity)
-        )
-    )
+    UntoldGSSplat(splat).encodedForTBDR()
 }
 
 // MARK: Static Batching

--- a/Tests/UntoldEngineRenderTests/GaussianProgressiveLODTest.swift
+++ b/Tests/UntoldEngineRenderTests/GaussianProgressiveLODTest.swift
@@ -628,30 +628,23 @@ final class GaussianProgressiveLODTest: BaseRenderSetup {
     // MARK: - UntoldGSFormat corrupt-header handling
 
     func testReadThrowsInsteadOfTrappingOnOverflowingHeaderCounts() throws {
-        // Hand-crafted 72-byte v2 header (magic "UTGS", version 2) declaring a splatCount of
-        // UInt64.max, which overflows when multiplied by EncodedGaussianSplat's stride to
-        // compute the expected encoded-splat byte count. Before the overflow-checked rewrite,
-        // the unchecked `Int(UInt64)`/`*` in UntoldGSFormat.read would trap the process on a
-        // file like this instead of throwing a catchable error. Must be a well-formed v2 header
-        // (real version, real byte count) so this test actually exercises the overflow guard in
-        // .sizeMismatch, not just the unrelated .unsupportedVersion check.
-        var bytes: [UInt8] = []
-        bytes += [0x55, 0x54, 0x47, 0x53] // magic "UTGS", little-endian
-        bytes += [2, 0, 0, 0] // version = 2
-        bytes += [UInt8](repeating: 0xFF, count: 8) // splatCount = UInt64.max
-        bytes += [0, 0, 0, 0] // shDegree
-        bytes += [0, 0, 0, 0] // shCoefficientsPerChannel
-        bytes += [0, 0, 0, 0] // shHigherOrderCoefficientsPerSplat
-        bytes += [0, 0, 0, 0] // meanSquaredSplatExtent (0.0 as Float bit pattern)
-        bytes += [UInt8](repeating: 0, count: 8) // encodedByteCount
-        bytes += [UInt8](repeating: 0, count: 8) // shByteCount
-        bytes += [UInt8](repeating: 0, count: 24) // boundingBoxMin/boundingBoxMax (6 floats)
-        XCTAssertEqual(bytes.count, 72)
+        // A well-formed v3 header (magic "UTGS", version 3) declaring chunk and node counts of
+        // UInt32.max, which overflow when multiplied by the entry sizes. The reader must report a
+        // catchable .sizeMismatch rather than trapping on unchecked arithmetic.
+        var header = UntoldGSHeaderV3(
+            splatCount: 1, chunkCount: UInt32.max, nodeCount: UInt32.max,
+            boundsMin: .zero, boundsMax: .zero, boundingBoxMin: .zero, boundingBoxMax: .zero,
+            chunkIndexOffset: 16384, nodeTreeOffset: 32768, payloadOffset: 49152, fileSize: 65536
+        )
+        header.lodLevels = 1
+        let writer = UntoldBinaryWriter()
+        header.encode(to: writer)
+        XCTAssertEqual(writer.count, UntoldGSFormat.headerSize)
 
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("UntoldGSFormat-overflow-\(UUID().uuidString)")
             .appendingPathExtension("untoldgs")
-        try Data(bytes).write(to: url)
+        try (writer.data + Data(count: 65536 - writer.count)).write(to: url)
         defer { try? FileManager.default.removeItem(at: url) }
 
         XCTAssertThrowsError(try UntoldGSFormat.read(from: url)) { error in
@@ -695,6 +688,31 @@ final class GaussianProgressiveLODTest: BaseRenderSetup {
         }
     }
 
+    func testReadRejectsV2HeaderAsUnsupportedVersion() throws {
+        // A pre-chunked v2 file (72-byte header, flat encoded-splat payload) must fail with
+        // .unsupportedVersion — the fix is re-running `untoldengine export`.
+        var bytes: [UInt8] = []
+        bytes += [0x55, 0x54, 0x47, 0x53] // magic "UTGS", little-endian
+        bytes += [2, 0, 0, 0] // version = 2
+        bytes += [UInt8](repeating: 0, count: 64)
+        XCTAssertEqual(bytes.count, 72)
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("UntoldGSFormat-v2-\(UUID().uuidString)")
+            .appendingPathExtension("untoldgs")
+        try Data(bytes).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(try UntoldGSFormat.read(from: url)) { error in
+            guard case let UntoldGSError.unsupportedVersion(version) = error else {
+                XCTFail("Expected .unsupportedVersion, got \(error)")
+                return
+            }
+            XCTAssertEqual(version, 2)
+        }
+        XCTAssertThrowsError(try UntoldGSFormat.readHeader(from: url))
+    }
+
     func testWriteBakesBoundingBoxIntoHeaderAtExpectedOffsets() throws {
         let output = FileManager.default.temporaryDirectory
             .appendingPathComponent("UntoldGSFormat-boxheader-\(UUID().uuidString)")
@@ -710,14 +728,14 @@ final class GaussianProgressiveLODTest: BaseRenderSetup {
         // contract (version + fixed offsets), not just whatever read() happens to decode.
         let data = try Data(contentsOf: tierURL)
         let versionBits = data[4 ..< 8].withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 0, as: UInt32.self) }
-        XCTAssertEqual(UInt32(littleEndian: versionBits), 2)
+        XCTAssertEqual(UInt32(littleEndian: versionBits), 3)
 
         func readFloat(at offset: Int) -> Float {
             let bits = data[offset ..< offset + 4].withUnsafeBytes { $0.loadUnaligned(fromByteOffset: 0, as: UInt32.self) }
             return Float(bitPattern: UInt32(littleEndian: bits))
         }
-        let boundingBoxMin = simd_float3(readFloat(at: 48), readFloat(at: 52), readFloat(at: 56))
-        let boundingBoxMax = simd_float3(readFloat(at: 60), readFloat(at: 64), readFloat(at: 68))
+        let boundingBoxMin = simd_float3(readFloat(at: 56), readFloat(at: 60), readFloat(at: 64))
+        let boundingBoxMax = simd_float3(readFloat(at: 68), readFloat(at: 72), readFloat(at: 76))
         XCTAssertEqual(boundingBoxMin, bakeResult.boundingBoxMin)
         XCTAssertEqual(boundingBoxMax, bakeResult.boundingBoxMax)
 

--- a/Tests/UntoldEngineTests/UntoldGSFormatTests.swift
+++ b/Tests/UntoldEngineTests/UntoldGSFormatTests.swift
@@ -314,6 +314,119 @@ final class UntoldGSFormatTests: XCTestCase {
         }
     }
 
+    /// A NaN or infinite value in one splat — a scale that overflowed through exp() on import, a
+    /// NaN colour — must fail the bake with an error, not trap inside an integer conversion.
+    func testWriterRejectsNonFiniteSplatsInsteadOfTrapping() {
+        var rng = SplitMix64(seed: 11)
+        let base = (0 ..< 8).map { _ in rng.nextSplat(boundsMin: [0, 0, 0], boundsMax: [1, 1, 1], shCount: 0) }
+
+        var nanPosition = base
+        nanPosition[2].position.y = .nan
+        var infiniteScale = base
+        infiniteScale[5].scale.x = .infinity
+        var zeroScale = base
+        zeroScale[1].scale.z = 0
+        var nanOpacity = base
+        nanOpacity[0].opacity = .nan
+        var nanRotation = base
+        nanRotation[4].rotation = simd_quatf(ix: .nan, iy: 0, iz: 0, r: 1)
+        var nanColor = base
+        nanColor[7].color.z = .nan
+
+        for (name, splats) in [("position", nanPosition), ("scale", infiniteScale), ("zero scale", zeroScale), ("opacity", nanOpacity), ("rotation", nanRotation), ("colour", nanColor)] {
+            XCTAssertThrowsError(try UntoldGSFormat.write(splats: splats), name) { error in
+                guard case UntoldGSError.invalidInput? = error as? UntoldGSError else {
+                    return XCTFail("\(name): unexpected error \(error)")
+                }
+            }
+        }
+        XCTAssertNoThrow(try UntoldGSFormat.write(splats: base), "The same set without the bad value writes")
+    }
+
+    func testNonFiniteValuesClampAndQuantiseInsteadOfTrapping() {
+        XCTAssertEqual(UntoldGSPacking.clamp01(.nan), 0)
+        XCTAssertEqual(UntoldGSPacking.clamp01(.infinity), 1)
+        XCTAssertEqual(UntoldGSPacking.clamp01(-.infinity), 0)
+        XCTAssertEqual(quantizeGaussianSHCoefficient(.nan), 128, "NaN quantises to zero (byte 128)")
+        XCTAssertEqual(quantizeGaussianSHCoefficient(.infinity), 128)
+        XCTAssertEqual(quantizeGaussianSHCoefficient(1), 255)
+        XCTAssertEqual(quantizeGaussianSHCoefficient(-1), 1)
+        XCTAssertEqual(UntoldGSPacking.packSHCoefficient(.nan), 128)
+    }
+
+    func testHeaderSectionsMustNotOverlap() {
+        var header = makeHeader()
+        XCTAssertNoThrow(try UntoldGSFormat.validate(header: header), "Sanity: the fixture header is valid")
+
+        header.nodeTreeOffset = header.chunkIndexOffset
+        XCTAssertThrowsError(try UntoldGSFormat.validate(header: header)) { error in
+            guard case UntoldGSError.sizeMismatch? = error as? UntoldGSError else {
+                return XCTFail("unexpected error \(error)")
+            }
+        }
+
+        header = makeHeader()
+        header.payloadOffset = header.nodeTreeOffset
+        XCTAssertThrowsError(try UntoldGSFormat.validate(header: header), "The payload may not start inside the node tree")
+
+        header = makeHeader()
+        header.chunkIndexOffset = 0
+        XCTAssertThrowsError(try UntoldGSFormat.validate(header: header), "The chunk index may not sit on the header")
+    }
+
+    /// Load-time cost of the v3 decode at a realistic splat count. v2 was one memcpy; v3 verifies
+    /// a CRC per chunk and rebuilds each splat (bit-unpack, quaternion normalise, covariance),
+    /// so the guard is relative to the cost of building the same GPU records straight from
+    /// memory (`encodedForTBDR`, what the raw `.ply` path pays): a regression that makes the
+    /// decode an order of magnitude heavier fails here on any machine, and the absolute ceiling
+    /// catches a pathological one. Timings are printed for the record.
+    func testHalfAMillionSplatsDecodeWithinABoundedMultipleOfTheInMemoryEncode() throws {
+        var rng = SplitMix64(seed: 21)
+        let count = 500_000
+        let splats = (0 ..< count).map { _ in rng.nextSplat(boundsMin: [-5, -5, -5], boundsMax: [5, 5, 5], shCount: 9) }
+        var options = UntoldGSWriteOptions()
+        options.shDegree = 1
+
+        let encodeStart = Date()
+        let direct = splats.map { $0.encodedForTBDR() }
+        let encodeSeconds = max(Date().timeIntervalSince(encodeStart), 1e-3)
+        XCTAssertEqual(direct.count, count)
+
+        let writeStart = Date()
+        let data = try UntoldGSFormat.write(splats: splats, options: options)
+        let writeSeconds = Date().timeIntervalSince(writeStart)
+        let url = try writeTemporaryFile(data)
+
+        let readStart = Date()
+        let asset = try UntoldGSFormat.read(from: url)
+        let readSeconds = Date().timeIntervalSince(readStart)
+
+        XCTAssertEqual(asset.encodedSplats.count, count)
+        print("[perf] \(count) splats: in-memory encode \(String(format: "%.3f", encodeSeconds)) s, v3 write \(String(format: "%.3f", writeSeconds)) s (\(data.count / 1024) KB), v3 read+decode \(String(format: "%.3f", readSeconds)) s")
+        XCTAssertLessThan(readSeconds, 12 * encodeSeconds + 0.5, "v3 read+decode should stay within a small multiple of the in-memory encode")
+        XCTAssertLessThan(readSeconds, 10, "Reading half a million splats should take well under ten seconds")
+    }
+
+    /// The importer path and the writer expand the bounding box by the same rule, through the
+    /// one shared helper.
+    func testImporterAndWriterBoundingBoxesAgree() {
+        var rng = SplitMix64(seed: 5)
+        let splats = (0 ..< 64).map { _ in rng.nextSplat(boundsMin: [-2, -1, 0], boundsMax: [3, 4, 5], shCount: 0) }
+        let importerSplats = splats.map { splat in
+            GaussianSplat(
+                center: simd_float4(splat.position.x, splat.position.y, splat.position.z, 1),
+                scale: simd_float4(splat.scale.x, splat.scale.y, splat.scale.z, 0),
+                color: simd_float4(splat.color.x, splat.color.y, splat.color.z, 1),
+                quat: simd_float4(splat.rotation.real, splat.rotation.imag.x, splat.rotation.imag.y, splat.rotation.imag.z),
+                opacity: splat.opacity
+            )
+        }
+        let writerBox = UntoldGSFormat.defaultBoundingBox(of: splats)
+        let importerBox = computeGaussianSplatBoundingBox(importerSplats)
+        XCTAssertEqual(writerBox.min, importerBox.min)
+        XCTAssertEqual(writerBox.max, importerBox.max)
+    }
+
     func testImportanceOrderKeepsOpaqueLargeSplatsFirst() throws {
         var rng = SplitMix64(seed: 8)
         let splats = (0 ..< 300).map { _ in rng.nextSplat(boundsMin: [0, 0, 0], boundsMax: [1, 1, 1], shCount: 0) }

--- a/Tests/UntoldEngineTests/UntoldGSFormatTests.swift
+++ b/Tests/UntoldEngineTests/UntoldGSFormatTests.swift
@@ -1,0 +1,522 @@
+//
+//  UntoldGSFormatTests.swift
+//  UntoldEngineTests
+//
+//  Tests for the version-3 .untoldgs Gaussian splat container: record sizes,
+//  quantisation error bounds, Morton ordering, CRC, write → range-read → decode
+//  roundtrips, and the whole-asset read the runtime uses.
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import CShaderTypes
+import simd
+@testable import UntoldEngine
+import XCTest
+
+final class UntoldGSFormatTests: XCTestCase {
+    private var temporaryFiles: [URL] = []
+
+    override func tearDown() {
+        for url in temporaryFiles {
+            try? FileManager.default.removeItem(at: url)
+        }
+        temporaryFiles.removeAll()
+        super.tearDown()
+    }
+
+    // MARK: - Record sizes
+
+    func testHeaderEncodesTwoHundredFiftySixBytes() throws {
+        let header = makeHeader()
+        let writer = UntoldBinaryWriter()
+        header.encode(to: writer)
+        XCTAssertEqual(writer.count, UntoldGSFormat.headerSize)
+        XCTAssertEqual(Array(writer.data.prefix(4)), UntoldGSFormat.magicBytes)
+        XCTAssertEqual(try UntoldGSHeaderV3.decode(from: UntoldBinaryReader(data: writer.data)), header)
+    }
+
+    func testChunkEntryEncodesSixtyFourBytes() throws {
+        let entry = UntoldGSChunkEntry(
+            payloadOffset: 65536, payloadBytes: 16384, coreBytes: 16 * 100, splatCount: 100,
+            lodLevel: 2, nodeId: 7, aabbMin: [-1, -2, -3], aabbMax: [1, 2, 3],
+            logScaleMin: -5, logScaleMax: -1, crc32: 0xDEAD_BEEF
+        )
+        let writer = UntoldBinaryWriter()
+        entry.encode(to: writer)
+        XCTAssertEqual(writer.count, UntoldGSFormat.chunkEntrySize)
+        XCTAssertEqual(try UntoldGSChunkEntry.decode(from: UntoldBinaryReader(data: writer.data)), entry)
+    }
+
+    func testTreeNodeEncodesFortyEightBytes() throws {
+        let node = UntoldGSTreeNode(aabbMin: [0, 0, 0], aabbMax: [1, 1, 1], child0: 1, child1: 2, firstChunk: 0, chunkCount: 9, geometricError: 0.5)
+        let writer = UntoldBinaryWriter()
+        node.encode(to: writer)
+        XCTAssertEqual(writer.count, UntoldGSFormat.treeNodeSize)
+        XCTAssertEqual(try UntoldGSTreeNode.decode(from: UntoldBinaryReader(data: writer.data)), node)
+    }
+
+    func testSHCoefficientCountsMatchTheGPUContract() {
+        XCTAssertEqual(UntoldGSFormat.shCoefficientCount(degree: 0), 0)
+        XCTAssertEqual(UntoldGSFormat.shCoefficientCount(degree: 1), 9)
+        XCTAssertEqual(UntoldGSFormat.shCoefficientCount(degree: 2), 24)
+        XCTAssertEqual(UntoldGSFormat.shCoefficientCount(degree: 3), 45)
+        var header = makeHeader()
+        header.flags = UntoldGSFlags.hasSphericalHarmonics
+        header.shDegree = 2
+        XCTAssertEqual(header.shMetadata?.coefficientsPerChannel, 9)
+        XCTAssertEqual(header.shMetadata?.higherOrderCoefficientsPerSplat, 24)
+        header.flags = 0
+        XCTAssertNil(header.shMetadata)
+    }
+
+    // MARK: - Packing
+
+    func testPositionPackingErrorIsWithinHalfAStep() {
+        var rng = SplitMix64(seed: 1)
+        for _ in 0 ..< 2000 {
+            let t = SIMD3<Float>(rng.nextUnitFloat(), rng.nextUnitFloat(), rng.nextUnitFloat())
+            let back = UntoldGSPacking.unpack11_10_11(UntoldGSPacking.pack11_10_11(t))
+            XCTAssertLessThanOrEqual(abs(back.x - t.x), 0.5 / 2047 + 1e-6)
+            XCTAssertLessThanOrEqual(abs(back.y - t.y), 0.5 / 1023 + 1e-6)
+            XCTAssertLessThanOrEqual(abs(back.z - t.z), 0.5 / 2047 + 1e-6)
+        }
+        XCTAssertEqual(UntoldGSPacking.pack11_10_11([0, 0, 0]), 0)
+        XCTAssertEqual(UntoldGSPacking.pack11_10_11([1, 1, 1]), 0xFFFF_FFFF)
+    }
+
+    func testRotationPackingPreservesOrientation() {
+        var rng = SplitMix64(seed: 2)
+        for _ in 0 ..< 2000 {
+            let q = rng.nextUnitQuaternion()
+            let back = UntoldGSPacking.unpackRotation(UntoldGSPacking.packRotation(q))
+            let relative = q.inverse * back
+            let angle = 2 * acos(min(1, abs(relative.real)))
+            XCTAssertLessThan(angle, 0.005, "orientation error \(angle) rad for \(q)")
+            XCTAssertEqual(simd_length(back.vector), 1, accuracy: 1e-3)
+        }
+        for q in [simd_quatf(vector: [1, 0, 0, 0]), simd_quatf(vector: [0, 1, 0, 0]), simd_quatf(vector: [0, 0, 1, 0]), simd_quatf(vector: [0, 0, 0, -1])] {
+            let back = UntoldGSPacking.unpackRotation(UntoldGSPacking.packRotation(q))
+            XCTAssertEqual(abs((q.inverse * back).real), 1, accuracy: 1e-3)
+        }
+    }
+
+    func testColorPackingRoundtrip() {
+        let packed = UntoldGSPacking.packRGBA(color: [1, 0.5, 0], opacity: 0.25)
+        XCTAssertEqual(packed >> 24, 255)
+        XCTAssertEqual((packed >> 16) & 0xFF, 128)
+        XCTAssertEqual((packed >> 8) & 0xFF, 0)
+        XCTAssertEqual(packed & 0xFF, 64)
+        let back = UntoldGSPacking.unpackRGBA(packed)
+        XCTAssertEqual(back.color.y, 128 / 255, accuracy: 1e-6)
+        XCTAssertEqual(back.opacity, 64 / 255, accuracy: 1e-6)
+    }
+
+    func testSHPackingUsesTheRendererByteContract() {
+        // Same byte the runtime PLY path writes, dequantised the way Gaussians.metal does.
+        XCTAssertEqual(UntoldGSPacking.packSHCoefficient(0.5), quantizeGaussianSHCoefficient(0.5))
+        XCTAssertEqual(UntoldGSPacking.unpackSHCoefficient(128), 0)
+        XCTAssertEqual(UntoldGSPacking.unpackSHCoefficient(255), 127 / 128)
+        XCTAssertEqual(UntoldGSPacking.packSHCoefficient(3), 255) // clamped
+    }
+
+    func testMortonSpreadAndOrdering() {
+        XCTAssertEqual(UntoldGSPacking.spread21(0b111), 0b1001001)
+        XCTAssertEqual(UntoldGSPacking.spread21(0x1FFFFF), 0x1249_2492_4924_9249)
+
+        let boundsMin = SIMD3<Float>(repeating: -1)
+        let boundsMax = SIMD3<Float>(repeating: 1)
+        var rng = SplitMix64(seed: 3)
+        let splats = (0 ..< 500).map { _ in rng.nextSplat(boundsMin: boundsMin, boundsMax: boundsMax, shCount: 0) }
+        let order = UntoldGSFormat.mortonOrder(splats, boundsMin: boundsMin, boundsMax: boundsMax)
+        XCTAssertEqual(Set(order).count, splats.count)
+        let keys = order.map { UntoldGSPacking.mortonKey(splats[$0].position, boundsMin: boundsMin, boundsMax: boundsMax) }
+        for index in 1 ..< keys.count {
+            XCTAssertLessThanOrEqual(keys[index - 1], keys[index])
+        }
+    }
+
+    func testCRC32KnownVector() {
+        XCTAssertEqual(UntoldGSCRC32.checksum(Data("123456789".utf8)), 0xCBF4_3926)
+        XCTAssertEqual(UntoldGSCRC32.checksum(Data()), 0)
+    }
+
+    func testImporterConversionAndEncodedLayout() {
+        // PLY order (w, x, y, z): a 90° rotation about Y.
+        let half = Float(0.5).squareRoot()
+        let source = GaussianSplat(center: [1, 2, 3, 1], scale: [0.1, 0.2, 0.3, 1], color: [0.5, 0.6, 0.7, 0.9], quat: [half, 0, half, 0], opacity: 0.9)
+        let splat = UntoldGSSplat(source, sphericalHarmonics: [1, 2, 3])
+        XCTAssertEqual(splat.position, [1, 2, 3])
+        XCTAssertEqual(splat.scale, [0.1, 0.2, 0.3])
+        XCTAssertEqual(splat.color, [0.5, 0.6, 0.7])
+        XCTAssertEqual(splat.opacity, 0.9)
+        XCTAssertEqual(splat.sphericalHarmonics, [1, 2, 3])
+        let rotated = splat.rotation.act(SIMD3<Float>(1, 0, 0))
+        XCTAssertEqual(rotated.z, -1, accuracy: 1e-5)
+
+        let encoded = splat.encodedForTBDR()
+        XCTAssertEqual(encoded.position, [1, 2, 3])
+        XCTAssertEqual(Float(encoded.colorAndOpacity.w), 0.9, accuracy: 1e-3)
+        // Covariance of an axis-aligned splat yawed by 90°: x and z variances swap.
+        XCTAssertEqual(Float(encoded.covA.x), 0.09, accuracy: 2e-3)
+        XCTAssertEqual(Float(encoded.covB.z), 0.01, accuracy: 2e-3)
+        XCTAssertEqual(Float(encoded.covB.x), 0.04, accuracy: 2e-3)
+    }
+
+    // MARK: - Write / read roundtrip
+
+    func testWriteAndRangeReadRoundtrip() throws {
+        let boundsMin = SIMD3<Float>(-0.8, 0, -0.4)
+        let boundsMax = SIMD3<Float>(0.8, 0.9, 0.4)
+        var rng = SplitMix64(seed: 4)
+        let splats = (0 ..< 5000).map { _ in rng.nextSplat(boundsMin: boundsMin, boundsMax: boundsMax, shCount: 0) }
+
+        var options = UntoldGSWriteOptions()
+        options.log2ChunkSplats = 8 // 256 per chunk → 20 chunks
+        options.sortByImportanceWithinChunk = false
+        options.leafMaxChunks = 4
+        options.meanSquaredSplatExtent = 0.0123
+        let fileData = try UntoldGSFormat.write(splats: splats, options: options)
+        let file = try UntoldGSFile(url: writeTemporaryFile(fileData))
+        let header = file.header
+        XCTAssertEqual(header.version, 3)
+        XCTAssertEqual(header.splatCount, 5000)
+        XCTAssertEqual(header.chunkCount, 20)
+        XCTAssertEqual(header.lodLevels, 1)
+        XCTAssertEqual(header.fileSize, UInt64(fileData.count))
+        XCTAssertEqual(header.meanSquaredSplatExtent, 0.0123)
+        XCTAssertFalse(header.hasSphericalHarmonics)
+        // Default bounding box: centre bounds expanded by the largest scale.
+        XCTAssertLessThan(header.boundingBoxMin.x, header.boundsMin.x)
+        XCTAssertGreaterThan(header.boundingBoxMax.y, header.boundsMax.y)
+
+        let page = UInt64(UntoldGSFormat.pageAlignment)
+        XCTAssertEqual(header.chunkIndexOffset % page, 0)
+        XCTAssertEqual(header.nodeTreeOffset % page, 0)
+        XCTAssertEqual(header.payloadOffset % page, 0)
+        XCTAssertEqual(header.fileSize % page, 0)
+        for chunk in file.index.chunks {
+            XCTAssertEqual(chunk.payloadOffset % page, 0)
+            XCTAssertEqual(UInt64(chunk.payloadBytes) % page, 0)
+            XCTAssertEqual(chunk.coreBytes, chunk.splatCount * 16)
+        }
+
+        let order = UntoldGSFormat.mortonOrder(splats, boundsMin: header.boundsMin, boundsMax: header.boundsMax)
+        let decoded = try file.decodeAll()
+        XCTAssertEqual(decoded.count, splats.count)
+
+        var cursor = 0
+        for chunk in file.index.chunks {
+            let extent = chunk.aabbMax - chunk.aabbMin
+            for _ in 0 ..< Int(chunk.splatCount) {
+                let original = splats[order[cursor]]
+                let back = decoded[cursor]
+                cursor += 1
+                XCTAssertLessThanOrEqual(abs(back.position.x - original.position.x), extent.x * 0.5 / 2047 + 1e-5)
+                XCTAssertLessThanOrEqual(abs(back.position.y - original.position.y), extent.y * 0.5 / 1023 + 1e-5)
+                XCTAssertLessThanOrEqual(abs(back.position.z - original.position.z), extent.z * 0.5 / 2047 + 1e-5)
+                for axis in 0 ..< 3 {
+                    let step = (chunk.logScaleMax - chunk.logScaleMin) / (axis == 1 ? 1023 : 2047)
+                    XCTAssertLessThanOrEqual(abs(log(back.scale[axis]) - log(original.scale[axis])), step * 0.5 + 1e-4)
+                }
+                XCTAssertEqual(back.opacity, original.opacity, accuracy: 0.5 / 255 + 1e-5)
+                XCTAssertEqual(back.color.x, original.color.x, accuracy: 0.5 / 255 + 1e-5)
+                XCTAssertLessThan(2 * acos(min(1, abs((original.rotation.inverse * back.rotation).real))), 0.005)
+            }
+        }
+        XCTAssertEqual(cursor, splats.count)
+    }
+
+    func testSphericalHarmonicsBlockRoundtrip() throws {
+        var rng = SplitMix64(seed: 5)
+        let shCount = UntoldGSFormat.shCoefficientCount(degree: 1)
+        let splats = (0 ..< 1200).map { _ in rng.nextSplat(boundsMin: [-2, -2, -2], boundsMax: [2, 2, 2], shCount: shCount) }
+
+        var options = UntoldGSWriteOptions()
+        options.shDegree = 1
+        options.log2ChunkSplats = 9
+        options.sortByImportanceWithinChunk = false
+        let file = try UntoldGSFile(url: writeTemporaryFile(UntoldGSFormat.write(splats: splats, options: options)))
+        XCTAssertTrue(file.header.hasSphericalHarmonics)
+        XCTAssertEqual(file.header.shBytesPerSplat, 9)
+        XCTAssertEqual(file.index.chunks.count, 3)
+
+        let order = UntoldGSFormat.mortonOrder(splats, boundsMin: file.header.boundsMin, boundsMax: file.header.boundsMax)
+        let decoded = try file.decodeAll()
+        for (cursor, back) in decoded.enumerated() {
+            let original = splats[order[cursor]].sphericalHarmonics
+            XCTAssertEqual(back.sphericalHarmonics.count, shCount)
+            for (a, b) in zip(original, back.sphericalHarmonics) {
+                // The renderer's contract truncates at ×127 and dequantises at ÷128 (see
+                // quantizeGaussianSHCoefficient), so the worst case is one step of each.
+                XCTAssertLessThanOrEqual(abs(a - b), 1.0 / 127 + 1.0 / 128 + 1e-4)
+            }
+        }
+    }
+
+    func testReadProducesTheRuntimeLayout() throws {
+        var rng = SplitMix64(seed: 6)
+        let shCount = UntoldGSFormat.shCoefficientCount(degree: 2)
+        let splats = (0 ..< 700).map { _ in rng.nextSplat(boundsMin: [0, 0, 0], boundsMax: [1, 1, 1], shCount: shCount) }
+        var options = UntoldGSWriteOptions()
+        options.shDegree = 2
+        options.log2ChunkSplats = 8
+        options.boundingBoxMin = [-9, -9, -9]
+        options.boundingBoxMax = [9, 9, 9]
+        options.meanSquaredSplatExtent = 0.5
+        let url = try writeTemporaryFile(UntoldGSFormat.write(splats: splats, options: options))
+
+        let asset = try UntoldGSFormat.read(from: url)
+        XCTAssertEqual(asset.splatCount, 700)
+        XCTAssertEqual(asset.shCoefficients.count, 700 * 24)
+        XCTAssertEqual(asset.shMetadata?.degree, 2)
+        XCTAssertEqual(asset.shMetadata?.coefficientsPerChannel, 9)
+        XCTAssertEqual(asset.shMetadata?.higherOrderCoefficientsPerSplat, 24)
+        XCTAssertEqual(asset.meanSquaredSplatExtent, 0.5)
+        XCTAssertEqual(asset.boundingBoxMin, [-9, -9, -9])
+        XCTAssertEqual(asset.boundingBoxMax, [9, 9, 9])
+
+        let header = try UntoldGSFormat.readHeader(from: url)
+        XCTAssertEqual(header.boundingBoxMin, [-9, -9, -9])
+        XCTAssertEqual(header.boundingBoxMax, [9, 9, 9])
+
+        // Encoded splats correspond to the decoded ones: same positions, SH bytes byte-identical.
+        let file = try UntoldGSFile(url: url)
+        let decoded = try file.decodeAll()
+        for (encoded, splat) in zip(asset.encodedSplats, decoded) {
+            XCTAssertEqual(encoded.position, splat.position)
+        }
+        let firstChunkPayload = try file.chunkPayload(at: 0)
+        let firstChunk = file.index.chunks[0]
+        let shStart = Int(firstChunk.coreBytes)
+        XCTAssertEqual(Array(firstChunkPayload[shStart ..< shStart + 24]), Array(asset.shCoefficients.prefix(24)))
+    }
+
+    func testWriterRejectsBadInput() {
+        var rng = SplitMix64(seed: 7)
+        var splats = (0 ..< 10).map { _ in rng.nextSplat(boundsMin: [0, 0, 0], boundsMax: [1, 1, 1], shCount: 9) }
+        splats[3].sphericalHarmonics = []
+        var options = UntoldGSWriteOptions()
+        options.shDegree = 1
+        XCTAssertThrowsError(try UntoldGSFormat.write(splats: splats, options: options)) { error in
+            guard case UntoldGSError.invalidInput? = error as? UntoldGSError else {
+                return XCTFail("unexpected error \(error)")
+            }
+        }
+        XCTAssertThrowsError(try UntoldGSFormat.write(splats: [])) { error in
+            guard case UntoldGSError.invalidInput? = error as? UntoldGSError else {
+                return XCTFail("unexpected error \(error)")
+            }
+        }
+    }
+
+    func testImportanceOrderKeepsOpaqueLargeSplatsFirst() throws {
+        var rng = SplitMix64(seed: 8)
+        let splats = (0 ..< 300).map { _ in rng.nextSplat(boundsMin: [0, 0, 0], boundsMax: [1, 1, 1], shCount: 0) }
+        var options = UntoldGSWriteOptions()
+        options.log2ChunkSplats = 9 // one chunk
+        let file = try UntoldGSFile(url: writeTemporaryFile(UntoldGSFormat.write(splats: splats, options: options)))
+        XCTAssertEqual(file.index.chunks.count, 1)
+        let decoded = try file.decodeChunk(at: 0)
+        let importance = decoded.map { $0.opacity * ($0.scale.x * $0.scale.y + $0.scale.y * $0.scale.z + $0.scale.z * $0.scale.x) }
+        XCTAssertGreaterThan(importance.first ?? 0, importance.last ?? 1)
+        XCTAssertGreaterThan(importance.prefix(30).reduce(0, +), importance.suffix(30).reduce(0, +))
+    }
+
+    // MARK: - Tree
+
+    func testTreeCoversEveryChunkExactlyOnce() throws {
+        var rng = SplitMix64(seed: 9)
+        let splats = (0 ..< 4000).map { _ in rng.nextSplat(boundsMin: [-3, -1, -3], boundsMax: [3, 1, 3], shCount: 0) }
+        var options = UntoldGSWriteOptions()
+        options.log2ChunkSplats = 7 // 128 per chunk → 32 chunks
+        options.leafMaxChunks = 3
+        let index = try UntoldGSFile(url: writeTemporaryFile(UntoldGSFormat.write(splats: splats, options: options))).index
+
+        let root = index.nodes[0]
+        XCTAssertEqual(root.firstChunk, 0)
+        XCTAssertEqual(root.chunkCount, UInt32(index.chunks.count))
+        XCTAssertEqual(root.aabbMin, index.header.boundsMin)
+        XCTAssertEqual(root.aabbMax, index.header.boundsMax)
+
+        var coverage = [Int](repeating: 0, count: index.chunks.count)
+        for (nodeIndex, node) in index.nodes.enumerated() {
+            for child in [node.child0, node.child1] where child != UntoldGSFormat.invalidNode {
+                let childNode = index.nodes[Int(child)]
+                XCTAssertGreaterThanOrEqual(childNode.firstChunk, node.firstChunk)
+                XCTAssertLessThanOrEqual(childNode.firstChunk + childNode.chunkCount, node.firstChunk + node.chunkCount)
+            }
+            guard node.isLeaf else { continue }
+            XCTAssertLessThanOrEqual(Int(node.chunkCount), options.leafMaxChunks)
+            for chunkIndex in Int(node.firstChunk) ..< Int(node.firstChunk + node.chunkCount) {
+                coverage[chunkIndex] += 1
+                XCTAssertEqual(Int(index.chunks[chunkIndex].nodeId), nodeIndex)
+            }
+        }
+        XCTAssertEqual(coverage, [Int](repeating: 1, count: index.chunks.count))
+    }
+
+    // MARK: - Validation
+
+    func testIndexParsesFromPrefixOnly() throws {
+        var rng = SplitMix64(seed: 10)
+        let splats = (0 ..< 700).map { _ in rng.nextSplat(boundsMin: [0, 0, 0], boundsMax: [1, 1, 1], shCount: 0) }
+        var options = UntoldGSWriteOptions()
+        options.log2ChunkSplats = 8
+        let fileData = try UntoldGSFormat.write(splats: splats, options: options)
+        let header = try UntoldGSFormat.readHeaderV3(from: fileData.prefix(UntoldGSFormat.headerSize))
+        let prefix = fileData.prefix(UntoldGSIndex.prefixSize(header: header))
+        XCTAssertLessThan(prefix.count, fileData.count)
+
+        let index = try UntoldGSFormat.readIndex(from: prefix)
+        XCTAssertEqual(index.chunks.count, 3)
+        XCTAssertEqual(index, try UntoldGSFormat.readIndex(from: fileData))
+        XCTAssertThrowsError(try UntoldGSFormat.readIndex(from: fileData.prefix(prefix.count - 1)))
+    }
+
+    func testCorruptedChunkFailsCRC() throws {
+        var rng = SplitMix64(seed: 11)
+        let splats = (0 ..< 600).map { _ in rng.nextSplat(boundsMin: [0, 0, 0], boundsMax: [1, 1, 1], shCount: 0) }
+        var options = UntoldGSWriteOptions()
+        options.log2ChunkSplats = 8
+        var fileData = try UntoldGSFormat.write(splats: splats, options: options)
+        let index = try UntoldGSFormat.readIndex(from: fileData)
+        fileData[Int(index.chunks[1].payloadOffset) + 5] ^= 0xFF
+
+        let file = try UntoldGSFile(url: writeTemporaryFile(fileData))
+        XCTAssertNoThrow(try file.chunkPayload(at: 0))
+        XCTAssertThrowsError(try file.chunkPayload(at: 1)) { error in
+            guard case UntoldGSError.corrupt? = error as? UntoldGSError else {
+                return XCTFail("unexpected error \(error)")
+            }
+        }
+        XCTAssertNoThrow(try file.chunkPayload(at: 1, verify: false))
+        XCTAssertThrowsError(try UntoldGSFormat.read(from: file.url))
+    }
+
+    func testRejectsInvalidMagicOlderVersionsAndTruncation() throws {
+        var rng = SplitMix64(seed: 12)
+        let splats = (0 ..< 50).map { _ in rng.nextSplat(boundsMin: [0, 0, 0], boundsMax: [1, 1, 1], shCount: 0) }
+        let fileData = try UntoldGSFormat.write(splats: splats)
+
+        var badMagic = fileData
+        badMagic[0] = 0x58
+        XCTAssertEqual(try thrownError(UntoldGSFormat.readHeaderV3(from: badMagic)), .badMagic)
+
+        var version2 = fileData
+        version2[4] = 2
+        XCTAssertEqual(try thrownError(UntoldGSFormat.readHeaderV3(from: version2)), .unsupportedVersion(2))
+        XCTAssertEqual(try thrownError(UntoldGSFormat.read(from: writeTemporaryFile(version2))), .unsupportedVersion(2))
+
+        XCTAssertEqual(try thrownError(UntoldGSFormat.readHeaderV3(from: fileData.prefix(6))), .truncated)
+        XCTAssertEqual(try thrownError(UntoldGSFormat.readHeaderV3(from: fileData.prefix(100))), .truncated)
+
+        let truncated = Data(fileData.prefix(fileData.count - UntoldGSFormat.pageAlignment))
+        guard case .sizeMismatch? = try thrownError(UntoldGSFile(url: writeTemporaryFile(truncated))) else {
+            return XCTFail("expected sizeMismatch for a truncated file")
+        }
+    }
+
+    func testOverflowingHeaderCountsThrowInsteadOfTrapping() throws {
+        var header = makeHeader()
+        header.chunkCount = UInt32.max
+        header.nodeCount = UInt32.max
+        let writer = UntoldBinaryWriter()
+        header.encode(to: writer)
+        guard case .sizeMismatch? = try thrownError(UntoldGSFormat.readHeaderV3(from: writer.data)) else {
+            return XCTFail("expected sizeMismatch")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func thrownError(_ body: @autoclosure () throws -> some Any) -> UntoldGSError? {
+        do {
+            _ = try body()
+            return nil
+        } catch {
+            return error as? UntoldGSError
+        }
+    }
+
+    private func makeHeader() -> UntoldGSHeaderV3 {
+        UntoldGSHeaderV3(
+            flags: UntoldGSFlags.antialiased,
+            shDegree: 0,
+            log2ChunkSplats: 10,
+            splatCount: 123_456,
+            chunkCount: 121,
+            nodeCount: 31,
+            lodLevels: 1,
+            boundsMin: [-1, -2, -3],
+            boundsMax: [4, 5, 6],
+            boundingBoxMin: [-1.5, -2.5, -3.5],
+            boundingBoxMax: [4.5, 5.5, 6.5],
+            meanSquaredSplatExtent: 0.02,
+            captureExposureEV: -1.5,
+            captureWhiteBalance: [1.1, 1.0, 0.9],
+            splatToMesh: simd_float4x4(diagonal: [2, 2, 2, 1]),
+            chunkIndexOffset: 16384,
+            nodeTreeOffset: 32768,
+            paletteOffset: 0,
+            payloadOffset: 49152,
+            fileSize: 1_048_576
+        )
+    }
+
+    private func writeTemporaryFile(_ data: Data) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("UntoldGSFormatTests-\(UUID().uuidString)")
+            .appendingPathExtension("untoldgs")
+        try data.write(to: url)
+        temporaryFiles.append(url)
+        return url
+    }
+}
+
+/// Deterministic generator so failures reproduce.
+private struct SplitMix64: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+
+    mutating func nextUnitFloat() -> Float {
+        Float(next() >> 40) / Float(1 << 24)
+    }
+
+    mutating func nextFloat(in range: ClosedRange<Float>) -> Float {
+        range.lowerBound + nextUnitFloat() * (range.upperBound - range.lowerBound)
+    }
+
+    mutating func nextUnitQuaternion() -> simd_quatf {
+        let v = SIMD4<Float>(nextFloat(in: -1 ... 1), nextFloat(in: -1 ... 1), nextFloat(in: -1 ... 1), nextFloat(in: -1 ... 1))
+        return simd_quatf(vector: simd_normalize(v))
+    }
+
+    mutating func nextSplat(boundsMin: SIMD3<Float>, boundsMax: SIMD3<Float>, shCount: Int) -> UntoldGSSplat {
+        let t = SIMD3<Float>(nextUnitFloat(), nextUnitFloat(), nextUnitFloat())
+        let scale = SIMD3<Float>(exp(nextFloat(in: -7 ... -2)), exp(nextFloat(in: -7 ... -2)), exp(nextFloat(in: -7 ... -2)))
+        return UntoldGSSplat(
+            position: boundsMin + t * (boundsMax - boundsMin),
+            scale: scale,
+            rotation: nextUnitQuaternion(),
+            color: SIMD3<Float>(nextUnitFloat(), nextUnitFloat(), nextUnitFloat()),
+            opacity: nextUnitFloat(),
+            sphericalHarmonics: (0 ..< shCount).map { _ in nextFloat(in: -1 ... 1) }
+        )
+    }
+}

--- a/docs/Architecture/untoldgsFormat.md
+++ b/docs/Architecture/untoldgsFormat.md
@@ -1,0 +1,141 @@
+# UntoldEngine Gaussian Splat Format (`.untoldgs`)
+
+## Overview
+
+`.untoldgs` is the engine-native container for Gaussian splat assets. It is a
+regeneratable cache of a source capture (`.ply`): `untoldengine export` bakes it, and a
+version bump means "re-bake". It is **not** an interchange format.
+
+Versions 1 and 2 stored one flat array of GPU-encoded splats and were read whole.
+**Version 3** stores quantised splats in page-aligned chunks so the runtime can read any
+chunk by byte range, memory-map it, or load it with Metal fast resource loading straight
+into a GPU page, without ever reading the whole file. Everything the scene needs to know
+about a splat asset beyond its payload (mesh twin, budgets, portal bakes) lives in the
+`.untold` asset that references it (see the `gaussianAsset` record in
+[`assetFormat.md`](assetFormat.md)), the same way textures live in `.utex` files.
+
+Design goals:
+
+- any chunk loads on its own by byte range, with per-chunk integrity
+- a chunk lands in a GPU page with no CPU transform
+- the first read shows the whole asset coarsely (coarsest level first)
+- rotation and scale survive quantisation so LOD merging and re-encoding stay possible
+- spherical harmonics are optional per device tier and use the renderer's byte contract
+- stable on-disk layout independent of Swift ABI
+
+## Core rules
+
+- Little-endian throughout. Magic `"UTGS"` at offset 0 and the version at offset 4 are
+  unchanged since version 1, so older files are recognised and rejected with
+  `.unsupportedVersion` (re-bake), never misread.
+- Every section offset and every chunk payload offset is a multiple of **16 384 bytes**
+  (`UntoldGSFormat.pageAlignment`), the VM page size on current Apple devices.
+  `MTLDevice.makeBuffer(bytesNoCopy:)` requires page-aligned pointer and length, and
+  Metal fast resource loading decompresses on 64 KB chunk boundaries.
+- No whole-file hash. A streamed payload is never fully resident, so integrity is a
+  CRC-32 per chunk over the unpadded payload.
+- One LOD level per chunk. Chunks under a tree node are contiguous in the index, so a
+  node maps to one byte range per level.
+
+## Layout
+
+```
+[0]                  UntoldGSHeaderV3       256 bytes, padded to 16 KB
+[chunkIndexOffset]   UntoldGSChunkEntry[]   64 bytes each, padded to a 16 KB multiple
+[nodeTreeOffset]     UntoldGSTreeNode[]     48 bytes each, padded
+[paletteOffset]      reserved for an SH palette (0 when absent)
+[payloadOffset]      chunk payloads, each padded to a 16 KB multiple:
+                       core block  16 bytes × splatCount
+                       SH block    higher-order SH bytes × splatCount (optional)
+```
+
+### Header (256 bytes)
+
+| Offset | Size | Field | Notes |
+|---|---|---|---|
+| 0 | 4 | `magic` | `"UTGS"` |
+| 4 | 4 | `version` | 3 |
+| 8 | 4 | `flags` | `UntoldGSFlags`: `hasSphericalHarmonics`, `sphericalHarmonicsPalette` (reserved), `antialiased`, `environment` |
+| 12 | 1 | `shDegree` | 0…3 |
+| 13 | 1 | `coordinateSystem` | `UntoldGSCoordinateSystem` (0 = right/up/back, the engine convention) |
+| 14 | 1 | `colorSpace` | `UntoldGSColorSpace` (0 = sRGB display-referred) |
+| 15 | 1 | `log2ChunkSplats` | 10 → 1024 splats per chunk (objects), 12 → 4096 (environments) |
+| 16 | 4+4+4 | `splatCount`, `chunkCount`, `nodeCount` | |
+| 28 | 1+3 | `lodLevels`, pad | |
+| 32 | 12+12 | `boundsMin`, `boundsMax` | bounds of the splat centres |
+| 56 | 12+12 | `boundingBoxMin`, `boundingBoxMax` | asset-level box expanded by splat extent, shared by every tier of a bake; what `readHeader` returns |
+| 80 | 4 | `meanSquaredSplatExtent` | bake-time overdraw statistic (see `estimatedGaussianOverdraw`) |
+| 84 | 4 | `captureExposureEV` | |
+| 88 | 12 | `captureWhiteBalance` | |
+| 100 | 64 | `splatToMesh` | registration onto the mesh twin; identity for worlds |
+| 164 | 8×5 | `chunkIndexOffset`, `nodeTreeOffset`, `paletteOffset`, `payloadOffset`, `fileSize` | |
+| 204 | 52 | reserved | zero |
+
+### Chunk index entry (64 bytes)
+
+`payloadOffset`, `payloadBytes` (padded), `coreBytes` (= 16 × `splatCount`),
+`splatCount`, `lodLevel` (0 = coarsest), `nodeId`, `aabbMin`/`aabbMax` (position decode
+constants), `logScaleMin`/`logScaleMax` (scale decode constants), reserved, `crc32`.
+
+Everything needed to serve and decode one chunk is in its entry; the reader never needs
+another chunk.
+
+### Tree node (48 bytes)
+
+A binary tree over the chunk array built by range halving, stored in preorder.
+`aabbMin`/`aabbMax`, `child0`/`child1` (`0xFFFFFFFF` on leaves), `firstChunk`,
+`chunkCount`, `geometricError` (zero for single-level files), `visibilityMaskOffset`
+(environments only). Leaves stamp their index into `nodeId` of their chunks.
+
+## The 16-byte core record
+
+The bit layout is the one PlayCanvas ships in `compressed.ply`: proven in production and
+about twenty ALU operations to decode.
+
+| Word | Bits | Meaning | Decode |
+|---|---|---|---|
+| `position` | 11 · 10 · 11 | x, y, z normalised inside the chunk AABB | `mix(aabbMin, aabbMax, t)` |
+| `rotation` | 2 + 3 × 10 | smallest-three quaternion; top two bits index the dropped (largest) component, sign chosen so it is positive; the rest in `[-1/√2, 1/√2]` | three masks, one sqrt |
+| `scale` | 11 · 10 · 11 | per-axis log-scale normalised inside the chunk's `[logScaleMin, logScaleMax]` | `exp(mix(lo, hi, t))` |
+| `rgba` | 8 × 4 | SH DC colour (`0.5 + 0.2821 × f_dc`, display-referred) and post-sigmoid opacity | `/ 255` |
+
+Because chunks are cut from a Morton-ordered array, a chunk of 1024 splats on an
+arm's-length object spans a few centimetres and 11-bit positions land well under a
+millimetre. Rotation and scale are stored rather than a baked covariance, so the baker
+can re-read a file to build coarser levels and the loader can still produce the
+`EncodedGaussianSplat` covariance the shaders expect (`UntoldGSSplat.encodedForTBDR`).
+
+Within a chunk, splats are ordered by importance (opacity × area) descending, so a
+partial read of a chunk yields its most important splats first.
+
+## Spherical harmonics block
+
+Optional, structure-of-arrays after the core block, so a device tier that skips SH does
+not read those bytes. Bytes use the renderer's existing contract
+(`quantizeGaussianSHCoefficient`: fixed `[-1, 1]`, dequantised in `Gaussians.metal` as
+`(byte - 128) / 128`), channel-major, higher orders only: 9, 24 or 45 bytes per splat for
+degree 1, 2, 3. The block can therefore be bound to the GPU as-is. A 16-bit palette
+encoding is reserved by the `sphericalHarmonicsPalette` flag and rejected by the reader.
+
+## Swift API
+
+- `UntoldGSFormat.write(splats:options:)` / `write(splats:options:to:)` encode `[UntoldGSSplat]`: Morton order, chunking, per-chunk ranges, tree, page-aligned sections, CRCs. `UntoldGSWriteOptions` carries chunk size, SH degree, the asset-level bounding box and `meanSquaredSplatExtent` of the tier.
+- `UntoldGSFormat.read(from:)` returns `UntoldGSAsset` in the layout the renderer consumes (every chunk decoded on the CPU). `readHeader(from:)` returns the baked bounding box through a bounded `FileHandle` read; `readHeaderV3` and `readIndex` expose the full header, chunk index and tree.
+- `UntoldGSFile(url:)` opens a file, parses only the prefix, and serves `chunkPayload(at:)` by byte range with CRC verification; `decodeChunk(at:)` and `decodeAll()` decode on the CPU.
+- `UntoldGSPacking` holds the pure pack/unpack functions for the record and the Morton key; `UntoldGSCRC32` the checksum; `UntoldGSSplat` converts from the importer's `GaussianSplat` and to `EncodedGaussianSplat`.
+
+`bakeGaussianSplatProgressiveTiers` writes every progressive tier as a version-3 file.
+The mmap and Metal fast resource loading paths arrive with the streaming loader.
+
+## Validation
+
+The reader rejects: wrong magic; any version other than 3; SH degree over 3; chunk size
+outside 2…16384; the reserved palette flag; empty assets; any misaligned section or chunk
+offset; header counts whose byte sizes overflow; sections or chunks outside `fileSize`;
+chunk counts and splat totals that disagree with the header; a chunk whose padded size
+cannot hold its core and SH blocks; tree nodes that span outside the index or reference
+children behind them; a root that does not cover every chunk. `chunkPayload(at:)`
+additionally rejects a chunk whose CRC does not match.
+
+Tests: `Tests/UntoldEngineTests/UntoldGSFormatTests.swift` and the format cases in
+`Tests/UntoldEngineRenderTests/GaussianProgressiveLODTest.swift`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
     - XR Rendering System: Architecture/xrRenderingSystem.md
     - Animation Pose Layer: Architecture/animationPoseLayer.md
     - Asset Format: Architecture/assetFormat.md
+    - Gaussian Splat Format (.untoldgs): Architecture/untoldgsFormat.md
     - Scene Channels: Architecture/sceneChannels.md
     - Tile-Based Streaming: Architecture/tilebasedstreaming.md
     - Out-of-Core Geometry: Architecture/outOfCore.md


### PR DESCRIPTION
Replay of miolabs/UntoldEngine#19, developed and verified end to end on the fork (engine series https://github.com/miolabs/UntoldEngine/pull/18 … https://github.com/miolabs/UntoldEngine/pull/22, editor untoldengine/UntoldEditor#91).

Part 2 of the Gaussian splat streaming series (proposal: #1176). **Re-scoped:** the first version of this PR added a separate `.usplat` format. After auditing the gaussian work on `develop` (`.untoldgs` v2, `export --lod-levels`, `GaussianLODSystem`, gaussian streaming, HZB culling), the chunked payload is now **`.untoldgs` version 3** under the existing name, magic and entry points. No second format, no second loader.

## What

- **`UntoldGSFormat` moves out of `RegistrationSystem.swift`** into `AssetFormat/UntoldGS{Format,Packing,Writer,Reader}.swift`. `UntoldGSError` (four new cases), `UntoldGSAsset` and the `read(from:)` / `readHeader(from:)` entry points keep their names and result shapes; `readHeader` still reads only the header through a bounded `FileHandle`.
- **Version 3 layout:** 256-byte header (magic and version at the same offsets as v1/v2, so old files report `.unsupportedVersion`, the format's stated re-bake contract), 64-byte chunk index entries, 48-byte tree nodes, and page-aligned chunk payloads. Every section and chunk offset is a multiple of 16 KB (the Apple VM page) so chunks can be memory-mapped or loaded by range straight into GPU pages. The header also carries the asset bounding box and `meanSquaredSplatExtent` that v2 carried, plus registration and capture-exposure fields for later PRs.
- **16-byte core record** per splat (11/10/11 position in the chunk AABB, smallest-three rotation, 11/10/11 log-scale in the chunk range, RGBA8) instead of the 48-byte GPU struct on disk. Rotation and scale are kept, so a later bake can merge or re-encode; `UntoldGSSplat.encodedForTBDR()` produces today's `EncodedGaussianSplat` covariance. The **SH block uses the renderer's existing `[-1, 1]` byte contract** (`quantizeGaussianSHCoefficient`), so chunk bytes bind to the GPU unchanged.
- **Writer:** Morton order, chunks of `2^log2ChunkSplats` splats, per-chunk ranges, importance order within a chunk, a binary tree over the chunk array by range halving (a node is one contiguous byte range), CRC-32 per chunk. **Reader:** `UntoldGSFile` opens a file, parses only the prefix, serves `chunkPayload(at:)` by byte range with CRC verification; `read(from:)` decodes every chunk on the CPU into the runtime layout (the streaming loader in PR 5 reads by range instead).
- **Bake:** `bakeGaussianSplatProgressiveTiers` writes every tier as v3 through `makeUntoldGSSplats` (importer splats + channel-major SH with the DC term dropped). Tier files, ranking and the `export` command are unchanged.
- **Docs:** `docs/Architecture/untoldgsFormat.md` (+ mkdocs nav).

## Behaviour change

`.untoldgs` files baked before this PR (v2) are rejected with `.unsupportedVersion(2)`; re-run `untoldengine export`. This is the contract the v2 code already documented for its own bump from v1. Splat order inside a tier changes (Morton + importance), which no consumer depends on.

## Verification

- `swift build` clean (Xcode 26.6 toolchain).
- New `UntoldGSFormatTests` (21 tests): record sizes and roundtrips; position error ≤ half a step; rotation orientation error < 0.005 rad over 2000 quaternions; colour and SH byte contract; Morton spread and ordering; CRC-32 vector; importer conversion and encoded covariance; write → range-read → decode of 5000 splats over 20 chunks with per-field bounds; SH block roundtrip; `read(from:)` produces the runtime layout with byte-identical SH; bad input, importance order, tree coverage, prefix parsing, CRC corruption, magic / v2 / truncation rejection, overflowing counts.
- Render suites touching the format: `GaussianProgressiveLODTest` (23), `GaussianStreamingTest` (15) and `GaussianRenderingTest` (30): 68 tests, the only failure is `testGaussianTarget`, which needs `cv2` for its PSNR script and is skipped in CI for the same reason (it loads the `.ply` path, which this PR does not touch). The three tests that pinned v2 header offsets now pin v3 (version 3 at offset 4, bounding box at 56/68) and a v2-rejection test was added.
- SwiftFormat lint clean on the changed files (local 0.62.1; CI's pinned 0.60.1 will confirm).