### PR TITLE
[Feature] Add the gaussianAsset chunk to the .untold format

### DIFF
--- a/Sources/UntoldEngine/AssetFormat/UntoldBinaryCodable.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldBinaryCodable.swift
@@ -865,6 +865,64 @@ extension UntoldPBRStaticVertexV1: UntoldBinaryEncodable, UntoldBinaryDecodable 
     }
 }
 
+extension UntoldGaussianAssetRecordV1: UntoldBinaryEncodable, UntoldBinaryDecodable {
+    /// Serialized size in bytes: 4 words, 4 + 4 LOD entries, 3 floats, 5 reserved words.
+    public static let encodedSize = 80
+
+    public func encode(to writer: UntoldBinaryWriter) {
+        writer.writeUInt32LE(entityId)
+        writer.writeUInt32LE(payloadPathOffset)
+        writer.writeUInt32LE(flags)
+        writer.writeUInt32LE(lodCount)
+        for index in 0 ..< Self.maxLODLevels {
+            writer.writeUInt32LE(lodSplatCounts[index])
+        }
+        for index in 0 ..< Self.maxLODLevels {
+            writer.writeFloat32LE(lodSwitchScreenHeights[index])
+        }
+        writer.writeFloat32LE(occluderShrinkMeters)
+        writer.writeFloat32LE(exposureOffsetEV)
+        writer.writeFloat32LE(swapDistanceMeters)
+        for index in 0 ..< Self.reservedWordCount {
+            writer.writeUInt32LE(reserved0[index])
+        }
+    }
+
+    public static func decode(from reader: UntoldBinaryReader) throws -> UntoldGaussianAssetRecordV1 {
+        let entityId = try reader.readUInt32LE()
+        let payloadPathOffset = try reader.readUInt32LE()
+        let flags = try reader.readUInt32LE()
+        let lodCount = try reader.readUInt32LE()
+        var lodSplatCounts: [UInt32] = []
+        for _ in 0 ..< maxLODLevels {
+            try lodSplatCounts.append(reader.readUInt32LE())
+        }
+        var lodSwitchScreenHeights: [Float] = []
+        for _ in 0 ..< maxLODLevels {
+            try lodSwitchScreenHeights.append(reader.readFloat32LE())
+        }
+        let occluderShrinkMeters = try reader.readFloat32LE()
+        let exposureOffsetEV = try reader.readFloat32LE()
+        let swapDistanceMeters = try reader.readFloat32LE()
+        var reserved0: [UInt32] = []
+        for _ in 0 ..< reservedWordCount {
+            try reserved0.append(reader.readUInt32LE())
+        }
+        return UntoldGaussianAssetRecordV1(
+            entityId: entityId,
+            payloadPathOffset: payloadPathOffset,
+            flags: flags,
+            lodCount: lodCount,
+            lodSplatCounts: lodSplatCounts,
+            lodSwitchScreenHeights: lodSwitchScreenHeights,
+            occluderShrinkMeters: occluderShrinkMeters,
+            exposureOffsetEV: exposureOffsetEV,
+            swapDistanceMeters: swapDistanceMeters,
+            reserved0: reserved0
+        )
+    }
+}
+
 public extension UntoldBinaryWriter {
     func writeMatrix4x4LE(_ matrix: simd_float4x4) {
         for column in 0 ..< 4 {

--- a/Sources/UntoldEngine/AssetFormat/UntoldFormat.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldFormat.swift
@@ -85,6 +85,8 @@ public struct UntoldChunkType: RawRepresentable, Hashable, Sendable, Equatable {
     public static let cameraTable = UntoldChunkType(rawValue: 20)
     public static let colorManagementTable = UntoldChunkType(rawValue: 21)
     public static let colorGradeLUTTable = UntoldChunkType(rawValue: 22)
+    /// 23–24 are reserved for the morph-target channel (in flight on develop).
+    public static let gaussianAssetTable = UntoldChunkType(rawValue: 25)
 
     public static let firstPluginChunkRawValue: UInt32 = 0x8000
 
@@ -658,6 +660,78 @@ public struct UntoldColorGradeLUTRecordV1: Sendable, Equatable {
         self.lutSize = lutSize
         self.domainMin = domainMin
         self.domainMax = domainMax
+    }
+}
+
+public enum UntoldGaussianAssetFlags {
+    /// The entity also carries a mesh that acts as the splat's twin: it is the
+    /// depth-only occluder, shadow caster and collider while the splat is shown.
+    public static let meshTwin: UInt32 = 1 << 0
+    /// The payload is an environment streamed by visibility rather than an object.
+    public static let environment: UInt32 = 1 << 1
+    /// The payload is a world seen through a window from a fixed view cell.
+    public static let windowWorld: UInt32 = 1 << 2
+}
+
+/// Links an entity to a cooked Gaussian splat payload (`.untoldgs`, see
+/// docs/Architecture/untoldgsFormat.md) and carries the scene-side facts the
+/// runtime needs to place, budget and swap it. One record per splat entity.
+/// Registration onto the mesh twin and capture exposure live in the payload
+/// header; this record holds what the scene author tunes.
+public struct UntoldGaussianAssetRecordV1: Sendable, Equatable {
+    public static let maxLODLevels = 4
+    public static let reservedWordCount = 5
+
+    public var entityId: UInt32
+    /// String-table offset of the payload path, relative to this asset's directory.
+    public var payloadPathOffset: UInt32
+    /// See `UntoldGaussianAssetFlags`.
+    public var flags: UInt32
+    /// Valid entries in `lodSplatCounts` / `lodSwitchScreenHeights`, 0...4. Zero means one level.
+    public var lodCount: UInt32
+    /// Splat count per LOD level, coarsest first. Always 4 entries; unused are zero.
+    public var lodSplatCounts: [UInt32]
+    /// Screen height in pixels above which the next finer level is preferred. Always 4 entries.
+    public var lodSwitchScreenHeights: [Float]
+    /// Metres the mesh twin's depth-only occluder shell is shrunk along its normals.
+    public var occluderShrinkMeters: Float
+    /// Editor exposure offset in EV, applied on top of the payload's capture exposure.
+    public var exposureOffsetEV: Float
+    /// Camera distance at which the swap and its prefetch arm. Zero means always.
+    public var swapDistanceMeters: Float
+    /// Always 5 words. Write as zero.
+    public var reserved0: [UInt32]
+
+    public init(
+        entityId: UInt32,
+        payloadPathOffset: UInt32,
+        flags: UInt32 = 0,
+        lodCount: UInt32 = 0,
+        lodSplatCounts: [UInt32] = [],
+        lodSwitchScreenHeights: [Float] = [],
+        occluderShrinkMeters: Float = 0.02,
+        exposureOffsetEV: Float = 0,
+        swapDistanceMeters: Float = 0,
+        reserved0: [UInt32] = []
+    ) {
+        self.entityId = entityId
+        self.payloadPathOffset = payloadPathOffset
+        self.flags = flags
+        self.lodCount = lodCount
+        self.lodSplatCounts = Self.fixed(lodSplatCounts, count: Self.maxLODLevels, fill: 0)
+        self.lodSwitchScreenHeights = Self.fixed(lodSwitchScreenHeights, count: Self.maxLODLevels, fill: 0)
+        self.occluderShrinkMeters = occluderShrinkMeters
+        self.exposureOffsetEV = exposureOffsetEV
+        self.swapDistanceMeters = swapDistanceMeters
+        self.reserved0 = Self.fixed(reserved0, count: Self.reservedWordCount, fill: 0)
+    }
+
+    private static func fixed<T>(_ values: [T], count: Int, fill: T) -> [T] {
+        var result = Array(values.prefix(count))
+        while result.count < count {
+            result.append(fill)
+        }
+        return result
     }
 }
 

--- a/Sources/UntoldEngine/AssetFormat/UntoldReader.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldReader.swift
@@ -129,6 +129,12 @@ public final class UntoldReader: @unchecked Sendable {
             from: data,
             entries: chunks
         )
+        let gaussianAssets = try decodeTableIfPresent(
+            UntoldGaussianAssetRecordV1.self,
+            chunkType: .gaussianAssetTable,
+            from: data,
+            entries: chunks
+        )
         let pluginChunks = try decodePluginChunks(from: data, entries: chunks)
 
         let decoded = UntoldDecodedAsset(
@@ -151,8 +157,10 @@ public final class UntoldReader: @unchecked Sendable {
             animationChannels: animationChannels,
             translationKeyframes: translationKeyframes,
             rotationKeyframes: rotationKeyframes,
+            gaussianAssets: gaussianAssets,
             pluginChunks: pluginChunks
         )
+        try validateGaussianAssets(decoded)
         try validateDecodedAsset(decoded)
         return decoded
     }
@@ -232,6 +240,32 @@ public final class UntoldReader: @unchecked Sendable {
         let computed = Array(SHA256.hash(data: hashInput))
         guard computed == header.contentHash else {
             throw UntoldValidationError.contentHashMismatch
+        }
+    }
+
+    /// Gaussian asset records must reference an entity of this file and a readable
+    /// payload path. Checked before the mesh validation because a splat-only tile
+    /// may carry no vertex or index chunk at all.
+    private func validateGaussianAssets(_ asset: UntoldDecodedAsset) throws {
+        for (index, record) in asset.gaussianAssets.enumerated() {
+            guard asset.entities.contains(where: { $0.entityId == record.entityId }) else {
+                throw UntoldValidationError.invalidGaussianAssetRecord(
+                    index: index,
+                    reason: "entity \(record.entityId) is not in the entity table"
+                )
+            }
+            guard let path = try asset.string(at: record.payloadPathOffset), !path.isEmpty else {
+                throw UntoldValidationError.invalidGaussianAssetRecord(index: index, reason: "missing payload path")
+            }
+            guard record.lodCount <= UInt32(UntoldGaussianAssetRecordV1.maxLODLevels) else {
+                throw UntoldValidationError.invalidGaussianAssetRecord(
+                    index: index,
+                    reason: "lodCount \(record.lodCount) exceeds \(UntoldGaussianAssetRecordV1.maxLODLevels)"
+                )
+            }
+            guard record.occluderShrinkMeters >= 0, record.swapDistanceMeters >= 0 else {
+                throw UntoldValidationError.invalidGaussianAssetRecord(index: index, reason: "negative distance")
+            }
         }
     }
 
@@ -548,6 +582,7 @@ public struct UntoldDecodedAsset: Sendable {
     public let animationChannels: [UntoldAnimationChannelRecordV1]
     public let translationKeyframes: [UntoldTranslationKeyframeRecordV1]
     public let rotationKeyframes: [UntoldRotationKeyframeRecordV1]
+    public let gaussianAssets: [UntoldGaussianAssetRecordV1]
     public let pluginChunks: [UntoldPluginChunk]
 
     public init(
@@ -570,6 +605,7 @@ public struct UntoldDecodedAsset: Sendable {
         animationChannels: [UntoldAnimationChannelRecordV1],
         translationKeyframes: [UntoldTranslationKeyframeRecordV1],
         rotationKeyframes: [UntoldRotationKeyframeRecordV1],
+        gaussianAssets: [UntoldGaussianAssetRecordV1] = [],
         pluginChunks: [UntoldPluginChunk] = []
     ) {
         self.header = header
@@ -591,6 +627,7 @@ public struct UntoldDecodedAsset: Sendable {
         self.animationChannels = animationChannels
         self.translationKeyframes = translationKeyframes
         self.rotationKeyframes = rotationKeyframes
+        self.gaussianAssets = gaussianAssets
         self.pluginChunks = pluginChunks
     }
 

--- a/Sources/UntoldEngine/AssetFormat/UntoldValidation.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldValidation.swift
@@ -41,4 +41,5 @@ public enum UntoldValidationError: Error, Sendable, Equatable {
     case invalidColorGradeLUTRecord
     case invalidPluginChunkHeader
     case unsupportedPluginChunkVersion(UInt32)
+    case invalidGaussianAssetRecord(index: Int, reason: String)
 }

--- a/Tests/UntoldEngineTests/NativeFormatTests.swift
+++ b/Tests/UntoldEngineTests/NativeFormatTests.swift
@@ -288,6 +288,93 @@ final class NativeFormatTests: XCTestCase {
         XCTAssertEqual(decoded.entities.count, 1)
     }
 
+    // MARK: - Gaussian asset table
+
+    func testGaussianAssetRecordEncodesEightyBytes() throws {
+        let record = UntoldGaussianAssetRecordV1(
+            entityId: 3,
+            payloadPathOffset: 25,
+            flags: UntoldGaussianAssetFlags.meshTwin,
+            lodCount: 3,
+            lodSplatCounts: [20000, 60000, 180_000],
+            lodSwitchScreenHeights: [120, 360, 1080],
+            occluderShrinkMeters: 0.015,
+            exposureOffsetEV: -0.3,
+            swapDistanceMeters: 4
+        )
+        XCTAssertEqual(record.lodSplatCounts, [20000, 60000, 180_000, 0])
+        XCTAssertEqual(record.lodSwitchScreenHeights, [120, 360, 1080, 0])
+        XCTAssertEqual(record.reserved0, [0, 0, 0, 0, 0])
+
+        let writer = UntoldBinaryWriter()
+        record.encode(to: writer)
+        XCTAssertEqual(writer.count, UntoldGaussianAssetRecordV1.encodedSize)
+        XCTAssertEqual(try UntoldGaussianAssetRecordV1.decode(from: UntoldBinaryReader(data: writer.data)), record)
+    }
+
+    func testGaussianAssetTableRoundtrip() throws {
+        var probe = makeTinyFixture()
+        let record = UntoldGaussianAssetRecordV1(
+            entityId: probe.entity.entityId,
+            payloadPathOffset: probe.texture.uriOffset,
+            flags: UntoldGaussianAssetFlags.meshTwin,
+            lodCount: 1,
+            lodSplatCounts: [150_000],
+            occluderShrinkMeters: 0.02
+        )
+        let writer = UntoldBinaryWriter()
+        record.encode(to: writer)
+        probe = makeTinyFixture(pluginChunks: [(.gaussianAssetTable, writer.data, 1)])
+
+        let decoded = try UntoldReader().readAsset(from: probe.fileData)
+        XCTAssertEqual(decoded.gaussianAssets, [record])
+        XCTAssertEqual(try decoded.string(at: decoded.gaussianAssets[0].payloadPathOffset), "albedo.ktx2")
+        XCTAssertTrue(decoded.pluginChunks.isEmpty)
+        XCTAssertEqual(decoded.meshes.count, 1)
+    }
+
+    func testGaussianAssetWithoutTableDecodesEmpty() throws {
+        let decoded = try UntoldReader().readAsset(from: makeTinyFixture().fileData)
+        XCTAssertTrue(decoded.gaussianAssets.isEmpty)
+    }
+
+    func testGaussianAssetRejectsUnknownEntity() throws {
+        let probe = makeTinyFixture()
+        let record = UntoldGaussianAssetRecordV1(entityId: 42, payloadPathOffset: probe.texture.uriOffset)
+        let writer = UntoldBinaryWriter()
+        record.encode(to: writer)
+        let fixture = makeTinyFixture(pluginChunks: [(.gaussianAssetTable, writer.data, 1)])
+
+        XCTAssertThrowsError(try UntoldReader().readAsset(from: fixture.fileData)) { error in
+            guard case let .invalidGaussianAssetRecord(index, _)? = error as? UntoldValidationError else {
+                return XCTFail("unexpected error \(error)")
+            }
+            XCTAssertEqual(index, 0)
+        }
+    }
+
+    func testGaussianAssetRejectsMissingPathAndTooManyLevels() throws {
+        let probe = makeTinyFixture()
+
+        let noPath = UntoldGaussianAssetRecordV1(entityId: probe.entity.entityId, payloadPathOffset: UntoldFormat.invalidIndex)
+        var writer = UntoldBinaryWriter()
+        noPath.encode(to: writer)
+        XCTAssertThrowsError(try UntoldReader().readAsset(from: makeTinyFixture(pluginChunks: [(.gaussianAssetTable, writer.data, 1)]).fileData)) { error in
+            guard case .invalidGaussianAssetRecord? = error as? UntoldValidationError else {
+                return XCTFail("unexpected error \(error)")
+            }
+        }
+
+        let tooManyLevels = UntoldGaussianAssetRecordV1(entityId: probe.entity.entityId, payloadPathOffset: probe.texture.uriOffset, lodCount: 5)
+        writer = UntoldBinaryWriter()
+        tooManyLevels.encode(to: writer)
+        XCTAssertThrowsError(try UntoldReader().readAsset(from: makeTinyFixture(pluginChunks: [(.gaussianAssetTable, writer.data, 1)]).fileData)) { error in
+            guard case .invalidGaussianAssetRecord? = error as? UntoldValidationError else {
+                return XCTFail("unexpected error \(error)")
+            }
+        }
+    }
+
     func testColorManagementRoundtripsThroughRuntimeLoader() throws {
         // Reuses the tiny fixture's existing texture (index 0, "albedo.ktx2")
         // as the LUT reference, to exercise the same index -> URL resolution

--- a/docs/Architecture/assetFormat.md
+++ b/docs/Architecture/assetFormat.md
@@ -492,8 +492,8 @@ value.w                      Float32
 ## Gaussian Asset Record Encoding
 
 Chunk type `25` (`gaussianAssetTable`) links an entity to a cooked Gaussian splat
-payload stored in a separate `.usplat` file (see
-[`nativeSplatFormat.md`](nativeSplatFormat.md)), the way texture references point at
+payload stored in a separate `.untoldgs` file (see
+[`untoldgsFormat.md`](untoldgsFormat.md)), the way texture references point at
 `.utex` files. One record per splat entity; `elementCount` is the record count.
 Types 22–24 are reserved for the morph-target channel.
 
@@ -515,7 +515,7 @@ Rules:
 - `entityId` must be present in the entity table
 - `payloadPathOffset` must resolve to a non-empty string
 - `lodCount <= 4`; `occluderShrinkMeters` and `swapDistanceMeters` are non-negative
-- registration onto the mesh twin and capture exposure live in the `.usplat` header,
+- registration onto the mesh twin and capture exposure live in the `.untoldgs` header,
   not here; this record holds what the scene author tunes
 - a file whose only geometry is a splat may omit the vertex and index chunks
 

--- a/docs/Architecture/assetFormat.md
+++ b/docs/Architecture/assetFormat.md
@@ -489,6 +489,36 @@ value.z                      Float32
 value.w                      Float32
 ```
 
+## Gaussian Asset Record Encoding
+
+Chunk type `25` (`gaussianAssetTable`) links an entity to a cooked Gaussian splat
+payload stored in a separate `.usplat` file (see
+[`nativeSplatFormat.md`](nativeSplatFormat.md)), the way texture references point at
+`.utex` files. One record per splat entity; `elementCount` is the record count.
+Types 22–24 are reserved for the morph-target channel.
+
+```text
+entityId                     UInt32
+payloadPathOffset            UInt32   // string table, path relative to this file
+flags                        UInt32   // 1 = meshTwin, 2 = environment, 4 = windowWorld
+lodCount                     UInt32   // valid LOD entries, 0...4 (0 means one level)
+lodSplatCounts               UInt32 x 4   // per level, coarsest first
+lodSwitchScreenHeights       Float32 x 4  // pixels above which the next finer level is preferred
+occluderShrinkMeters         Float32  // mesh twin depth-only shell shrink along normals
+exposureOffsetEV             Float32  // editor offset on top of the payload's capture exposure
+swapDistanceMeters           Float32  // 0 = always armed
+reserved0                    UInt32 x 5
+```
+
+Rules:
+
+- `entityId` must be present in the entity table
+- `payloadPathOffset` must resolve to a non-empty string
+- `lodCount <= 4`; `occluderShrinkMeters` and `swapDistanceMeters` are non-negative
+- registration onto the mesh twin and capture exposure live in the `.usplat` header,
+  not here; this record holds what the scene author tunes
+- a file whose only geometry is a splat may omit the vertex and index chunks
+
 ## Compression Rules
 
 Supported compression types:

--- a/scripts/untoldexplorer.py
+++ b/scripts/untoldexplorer.py
@@ -89,6 +89,7 @@ CHUNK_TYPES = {
     "camera_table": 20,
     "color_management_table": 21,
     "color_grade_lut_table": 22,
+    "gaussian_asset_table": 25,
 }
 
 VERTEX_LAYOUT_PBR_STATIC_V1 = 1


### PR DESCRIPTION
Replay of miolabs/UntoldEngine#20, developed and verified end to end on the fork (engine series https://github.com/miolabs/UntoldEngine/pull/18 … https://github.com/miolabs/UntoldEngine/pull/22, editor untoldengine/UntoldEditor#91).

Part 3 of the Gaussian splat streaming series (proposal: #1176). Independent of #1177; both are needed by the cooker (part 4) and the runtime loader (part 5).

## What

- **New core chunk type `gaussianAssetTable = 25`** in `UntoldChunkType`. Ids 22–24 are left for the morph-target channel in flight on `develop`.
- **`UntoldGaussianAssetRecordV1`** (80 bytes, `UntoldFormat.swift`): links an entity to a cooked `.untoldgs` payload by string-table path and carries the scene-side facts the runtime tunes: flags (`meshTwin`, `environment`, `windowWorld`), a four-entry LOD budget table (splat count per level, screen-height switch points), the mesh twin's occluder shell shrink, an editor exposure offset, and a swap/prefetch distance. Registration onto the twin and capture exposure stay in the payload header; this record holds what the scene author edits. Fixed-size arrays are normalised in `init` so encode/decode are exact.
- **Codable** in `UntoldBinaryCodable.swift`; **reader** decodes the table into `UntoldDecodedAsset.gaussianAssets` (new field, defaulted in `init` so existing call sites compile); **validation** (`validateGaussianAssets`, run before the mesh validation because a splat-only tile may carry no vertex or index chunk) rejects an unknown entity id, a missing path, more than four LOD levels, or negative distances, via the new `UntoldValidationError.invalidGaussianAssetRecord`.
- **Docs:** "Gaussian Asset Record Encoding" section in `docs/Architecture/assetFormat.md`. **Scripts:** `gaussian_asset_table` added to the chunk-name map in `untoldexplorer.py` so the inspector names it; the exporter does not emit it (the cooker will).

No format version bump: older runtimes ignore the unknown core chunk (covered by the existing `testUnknownCoreChunkTypeIsIgnored`).

## Verification

- `swift build` clean (Xcode 26.6 toolchain).
- `NativeFormatTests`: 38 tests green, including five new ones: record encodes to 80 bytes and roundtrips; a fixture with the chunk decodes to the record and resolves its path through the string table; a fixture without the chunk decodes to an empty table; unknown entity rejected; missing path and `lodCount = 5` rejected.
- Full core suite: 1155 tests, 0 unexpected failures.
- `python3 -m unittest discover -s scripts/tests`: 153 tests OK.
- SwiftFormat lint clean on the changed files (local 0.62.1; CI's pinned 0.60.1 will confirm).