### PR TITLE
[Feature] Add cooking flags to untoldengine export for Gaussian splats

### DIFF
--- a/Sources/UntoldEngine/AssetFormat/UntoldGSCooker.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldGSCooker.swift
@@ -56,6 +56,17 @@ public struct UntoldGSCookOptions: Sendable {
     public var cropMargin: Float = 0
     /// Splats with a lower post-sigmoid opacity are dropped.
     public var minimumOpacity: Float = 0.005
+    /// Keeps at most this many splats after the other pruning steps, the most important first
+    /// (opacity times the geometric mean of the three scales, in the transformed space). `nil`
+    /// keeps every survivor. The runtime refuses to load an entity above
+    /// `GaussianRuntimeLimits.maxSplatsPerEntity`, so a capture meant for every platform is
+    /// cooked with `splatBudgetMobile`; one that only has to load on a Mac may use `splatBudgetMac`.
+    public var maxSplatCount: Int?
+
+    /// The per-entity splat cap of Apple Vision Pro, iPhone, iPad and Apple TV.
+    public static let splatBudgetMobile = GaussianRuntimeLimits.maxSplatsPerEntityMobile
+    /// The per-entity splat cap of the Mac.
+    public static let splatBudgetMac = GaussianRuntimeLimits.maxSplatsPerEntityMac
     /// Spherical-harmonics degree to keep. `nil` keeps the source degree (capped at 3); 0 drops SH.
     public var shDegree: UInt8?
     /// log2 of the maximum splat count per chunk. 10 (1024) for objects, 12 (4096) for environments.
@@ -91,14 +102,17 @@ public struct UntoldGSCookReport: Sendable, Equatable {
     public var prunedByOpacity: Int
     public var prunedByDegenerateGeometry: Int
     public var prunedByCrop: Int
+    /// Splats dropped to meet `UntoldGSCookOptions.maxSplatCount`, the least important first.
+    public var prunedByBudget: Int
     public var shDegree: UInt8
 
-    public init(inputSplatCount: Int, keptSplatCount: Int, prunedByOpacity: Int, prunedByDegenerateGeometry: Int, prunedByCrop: Int, shDegree: UInt8) {
+    public init(inputSplatCount: Int, keptSplatCount: Int, prunedByOpacity: Int, prunedByDegenerateGeometry: Int, prunedByCrop: Int, shDegree: UInt8, prunedByBudget: Int = 0) {
         self.inputSplatCount = inputSplatCount
         self.keptSplatCount = keptSplatCount
         self.prunedByOpacity = prunedByOpacity
         self.prunedByDegenerateGeometry = prunedByDegenerateGeometry
         self.prunedByCrop = prunedByCrop
+        self.prunedByBudget = prunedByBudget
         self.shDegree = shDegree
     }
 
@@ -179,13 +193,22 @@ public enum UntoldGSCooker {
             keptIndices.append(index)
         }
 
+        var prunedByBudget = 0
+        if let budget = options.maxSplatCount, budget > 0, kept.count > budget {
+            let survivors = selectMostImportant(kept, count: budget)
+            prunedByBudget = kept.count - survivors.count
+            kept = survivors.map { kept[$0] }
+            keptIndices = survivors.map { keptIndices[$0] }
+        }
+
         let report = UntoldGSCookReport(
             inputSplatCount: asset.splats.count,
             keptSplatCount: kept.count,
             prunedByOpacity: prunedByOpacity,
             prunedByDegenerateGeometry: prunedByDegenerate,
             prunedByCrop: prunedByCrop,
-            shDegree: targetDegree
+            shDegree: targetDegree,
+            prunedByBudget: prunedByBudget
         )
         guard !kept.isEmpty else {
             throw UntoldGSCookError.noSplatsLeftAfterPruning(report)
@@ -193,6 +216,34 @@ public enum UntoldGSCooker {
 
         let harmonics = reduceSphericalHarmonics(asset.sphericalHarmonics, keeping: keptIndices, toDegree: targetDegree)
         return (GaussianSplatAsset(splats: kept, sphericalHarmonics: harmonics), report)
+    }
+
+    /// How much a splat is worth keeping: its opacity times the geometric mean of its scales,
+    /// a proxy for the light it contributes over the area it covers. Cheap, view independent
+    /// and enough to shed the faint, tiny splats a budget has to drop first.
+    static func importance(of splat: GaussianSplat) -> Float {
+        let volume = max(splat.scale.x * splat.scale.y * splat.scale.z, 0)
+        return splat.opacity * cbrt(volume)
+    }
+
+    /// Indices (ascending, so the source order survives) of the `count` most important splats.
+    /// Ties at the cut-off keep the earlier splats.
+    static func selectMostImportant(_ splats: [GaussianSplat], count: Int) -> [Int] {
+        guard count < splats.count else { return Array(splats.indices) }
+        let importance = splats.map(importance(of:))
+        let threshold = importance.sorted(by: >)[count - 1]
+        var selected: [Int] = []
+        selected.reserveCapacity(count)
+        var tiesLeft = count - importance.filter { $0 > threshold }.count
+        for (index, value) in importance.enumerated() {
+            if value > threshold {
+                selected.append(index)
+            } else if value == threshold, tiesLeft > 0 {
+                selected.append(index)
+                tiesLeft -= 1
+            }
+        }
+        return selected
     }
 
     /// Write options that carry the cook's chunk size, flags, transform and capture lighting.

--- a/Sources/UntoldEngine/AssetFormat/UntoldGSCooker.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldGSCooker.swift
@@ -20,9 +20,34 @@ import CShaderTypes
 import Foundation
 import simd
 
+/// Which axis points up in the capture. Captures are rotated to the engine's Y-up frame
+/// before any other transform, so a cooked file never needs a correction in the scene.
+public enum UntoldGSCaptureUpAxis: String, CaseIterable, Sendable {
+    /// Already the engine convention: +Y up, −Z forward. No rotation.
+    case y
+    /// Scanner and CAD convention (+Z up): rotated −90° about X, (x, y, z) → (x, z, −y).
+    case z
+    /// The 3DGS training convention (−Y up, +Z forward): rotated 180° about X, (x, y, z) → (x, −y, −z).
+    case negativeY = "-y"
+
+    /// Rotation that brings this convention to Y-up.
+    public var rotation: simd_float4x4 {
+        switch self {
+        case .y:
+            matrix_identity_float4x4
+        case .z:
+            simd_float4x4(simd_quatf(angle: -.pi / 2, axis: SIMD3<Float>(1, 0, 0)))
+        case .negativeY:
+            simd_float4x4(diagonal: SIMD4<Float>(1, -1, -1, 1))
+        }
+    }
+}
+
 public struct UntoldGSCookOptions: Sendable {
     /// Similarity transform (rotation, uniform scale, translation) from capture space to the
     /// space the payload is used in. Baked into every splat and recorded in the header.
+    /// Build it with `UntoldGSCookOptions.transform(upAxis:scale:yawDegrees:translation:)`
+    /// to compose the common cases in the right order.
     public var transform: simd_float4x4 = matrix_identity_float4x4
     /// Optional crop box in the transformed space; splats whose centre falls outside are dropped.
     public var cropMin: SIMD3<Float>?
@@ -41,6 +66,23 @@ public struct UntoldGSCookOptions: Sendable {
     public var captureWhiteBalance = SIMD3<Float>(repeating: 1)
 
     public init() {}
+
+    /// Composes the registration transform the cookers expose: up-axis fix first, then
+    /// uniform scale, then yaw about the engine's +Y, then translation.
+    public static func transform(
+        upAxis: UntoldGSCaptureUpAxis = .y,
+        scale: Float = 1,
+        yawDegrees: Float = 0,
+        translation: SIMD3<Float> = .zero
+    ) -> simd_float4x4 {
+        var transform = simd_mul(simd_float4x4(diagonal: SIMD4<Float>(scale, scale, scale, 1)), upAxis.rotation)
+        if yawDegrees != 0 {
+            let yaw = simd_quatf(angle: yawDegrees * .pi / 180, axis: SIMD3<Float>(0, 1, 0))
+            transform = simd_mul(simd_float4x4(yaw), transform)
+        }
+        transform.columns.3 = SIMD4<Float>(translation, 1)
+        return transform
+    }
 }
 
 public struct UntoldGSCookReport: Sendable, Equatable {

--- a/Sources/UntoldEngine/AssetFormat/UntoldGSCooker.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldGSCooker.swift
@@ -1,0 +1,237 @@
+//
+//  UntoldGSCooker.swift
+//  UntoldEngine
+//
+//  Prepares an imported Gaussian splat capture for baking: bakes a
+//  registration transform into every splat, drops near-transparent and
+//  degenerate splats, crops to a box, and selects the spherical-harmonics
+//  degree. Works on the importer's structs so `bakeGaussianSplatProgressiveTiers`
+//  can rank, box and tier the result exactly as before. The `export` command's
+//  `--splat-*` flags map onto `UntoldGSCookOptions`.
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import CShaderTypes
+import Foundation
+import simd
+
+public struct UntoldGSCookOptions: Sendable {
+    /// Similarity transform (rotation, uniform scale, translation) from capture space to the
+    /// space the payload is used in. Baked into every splat and recorded in the header.
+    public var transform: simd_float4x4 = matrix_identity_float4x4
+    /// Optional crop box in the transformed space; splats whose centre falls outside are dropped.
+    public var cropMin: SIMD3<Float>?
+    public var cropMax: SIMD3<Float>?
+    /// Grows the crop box on every side.
+    public var cropMargin: Float = 0
+    /// Splats with a lower post-sigmoid opacity are dropped.
+    public var minimumOpacity: Float = 0.005
+    /// Spherical-harmonics degree to keep. `nil` keeps the source degree (capped at 3); 0 drops SH.
+    public var shDegree: UInt8?
+    /// log2 of the maximum splat count per chunk. 10 (1024) for objects, 12 (4096) for environments.
+    public var log2ChunkSplats: UInt8 = UntoldGSFormat.defaultLog2ChunkSplats
+    public var antialiased = false
+    public var isEnvironment = false
+    public var captureExposureEV: Float = 0
+    public var captureWhiteBalance = SIMD3<Float>(repeating: 1)
+
+    public init() {}
+}
+
+public struct UntoldGSCookReport: Sendable, Equatable {
+    public var inputSplatCount: Int
+    public var keptSplatCount: Int
+    public var prunedByOpacity: Int
+    public var prunedByDegenerateGeometry: Int
+    public var prunedByCrop: Int
+    public var shDegree: UInt8
+
+    public init(inputSplatCount: Int, keptSplatCount: Int, prunedByOpacity: Int, prunedByDegenerateGeometry: Int, prunedByCrop: Int, shDegree: UInt8) {
+        self.inputSplatCount = inputSplatCount
+        self.keptSplatCount = keptSplatCount
+        self.prunedByOpacity = prunedByOpacity
+        self.prunedByDegenerateGeometry = prunedByDegenerateGeometry
+        self.prunedByCrop = prunedByCrop
+        self.shDegree = shDegree
+    }
+
+    /// A cook that changed nothing: every splat kept at the source degree.
+    public static func passthrough(splatCount: Int, shDegree: UInt8) -> UntoldGSCookReport {
+        UntoldGSCookReport(inputSplatCount: splatCount, keptSplatCount: splatCount, prunedByOpacity: 0, prunedByDegenerateGeometry: 0, prunedByCrop: 0, shDegree: shDegree)
+    }
+}
+
+public enum UntoldGSCookError: Error, Equatable, CustomStringConvertible {
+    /// The transform mirrors, shears or scales non-uniformly; splat covariances need a similarity.
+    case transformIsNotASimilarity
+    case requestedSHDegreeExceedsSource(requested: UInt8, source: UInt8)
+    case noSplatsLeftAfterPruning(UntoldGSCookReport)
+
+    public var description: String {
+        switch self {
+        case .transformIsNotASimilarity:
+            "the splat transform must be a rotation, a uniform scale and a translation"
+        case let .requestedSHDegreeExceedsSource(requested, source):
+            "requested spherical-harmonics degree \(requested) but the source has degree \(source)"
+        case let .noSplatsLeftAfterPruning(report):
+            "no splats left after pruning: \(report.prunedByOpacity) below the opacity floor, "
+                + "\(report.prunedByDegenerateGeometry) degenerate, \(report.prunedByCrop) outside the crop box"
+        }
+    }
+}
+
+public enum UntoldGSCooker {
+    /// Applies the options to an imported asset and returns the asset to bake plus a report.
+    public static func cook(asset: GaussianSplatAsset, options: UntoldGSCookOptions = .init()) throws -> (asset: GaussianSplatAsset, report: UntoldGSCookReport) {
+        let similarity = try Similarity(options.transform)
+        let sourceDegree = UInt8(clamping: asset.sphericalHarmonics?.degree ?? 0)
+        let targetDegree = min(options.shDegree ?? sourceDegree, UntoldGSFormat.maxSHDegree)
+        guard targetDegree <= sourceDegree else {
+            throw UntoldGSCookError.requestedSHDegreeExceedsSource(requested: targetDegree, source: sourceDegree)
+        }
+
+        let crop: (min: SIMD3<Float>, max: SIMD3<Float>)? = {
+            guard let cropMin = options.cropMin, let cropMax = options.cropMax else { return nil }
+            let margin = SIMD3<Float>(repeating: options.cropMargin)
+            return (cropMin - margin, cropMax + margin)
+        }()
+
+        var kept: [GaussianSplat] = []
+        kept.reserveCapacity(asset.splats.count)
+        var keptIndices: [Int] = []
+        keptIndices.reserveCapacity(asset.splats.count)
+        var prunedByOpacity = 0
+        var prunedByDegenerate = 0
+        var prunedByCrop = 0
+
+        for (index, splat) in asset.splats.enumerated() {
+            guard splat.opacity >= options.minimumOpacity else {
+                prunedByOpacity += 1
+                continue
+            }
+            let scale = SIMD3<Float>(splat.scale.x, splat.scale.y, splat.scale.z)
+            let center = SIMD3<Float>(splat.center.x, splat.center.y, splat.center.z)
+            guard isFinite(center), isFinite(scale), scale.min() > 0,
+                  splat.quat.x.isFinite, splat.quat.y.isFinite, splat.quat.z.isFinite, splat.quat.w.isFinite,
+                  simd_length_squared(splat.quat) > 0
+            else {
+                prunedByDegenerate += 1
+                continue
+            }
+            let transformed = similarity.apply(to: splat)
+            if let crop {
+                let p = SIMD3<Float>(transformed.center.x, transformed.center.y, transformed.center.z)
+                guard p.x >= crop.min.x, p.y >= crop.min.y, p.z >= crop.min.z,
+                      p.x <= crop.max.x, p.y <= crop.max.y, p.z <= crop.max.z
+                else {
+                    prunedByCrop += 1
+                    continue
+                }
+            }
+            kept.append(transformed)
+            keptIndices.append(index)
+        }
+
+        let report = UntoldGSCookReport(
+            inputSplatCount: asset.splats.count,
+            keptSplatCount: kept.count,
+            prunedByOpacity: prunedByOpacity,
+            prunedByDegenerateGeometry: prunedByDegenerate,
+            prunedByCrop: prunedByCrop,
+            shDegree: targetDegree
+        )
+        guard !kept.isEmpty else {
+            throw UntoldGSCookError.noSplatsLeftAfterPruning(report)
+        }
+
+        let harmonics = reduceSphericalHarmonics(asset.sphericalHarmonics, keeping: keptIndices, toDegree: targetDegree)
+        return (GaussianSplatAsset(splats: kept, sphericalHarmonics: harmonics), report)
+    }
+
+    /// Write options that carry the cook's chunk size, flags, transform and capture lighting.
+    public static func writeOptions(for options: UntoldGSCookOptions) -> UntoldGSWriteOptions {
+        var write = UntoldGSWriteOptions()
+        write.log2ChunkSplats = options.log2ChunkSplats
+        write.antialiased = options.antialiased
+        write.isEnvironment = options.isEnvironment
+        write.splatToMesh = options.transform
+        write.captureExposureEV = options.captureExposureEV
+        write.captureWhiteBalance = options.captureWhiteBalance
+        return write
+    }
+
+    // MARK: - Spherical harmonics
+
+    /// Keeps the DC term and the low orders of each channel for `degree`, in the importer's
+    /// channel-major layout; `nil` for degree 0.
+    static func reduceSphericalHarmonics(_ harmonics: GaussianSphericalHarmonics?, keeping indices: [Int], toDegree degree: UInt8) -> GaussianSphericalHarmonics? {
+        guard let harmonics, degree > 0 else { return nil }
+        let targetPerChannel = Int(degree + 1) * Int(degree + 1)
+        let sourcePerChannel = harmonics.coefficientsPerChannel
+        let sourcePerSplat = sourcePerChannel * 3
+        var reduced: [Float] = []
+        reduced.reserveCapacity(indices.count * targetPerChannel * 3)
+        for index in indices {
+            let base = index * sourcePerSplat
+            for channel in 0 ..< 3 {
+                let start = base + channel * sourcePerChannel
+                reduced.append(contentsOf: harmonics.coefficients[start ..< start + targetPerChannel])
+            }
+        }
+        return GaussianSphericalHarmonics(degree: Int(degree), coefficientsPerChannel: targetPerChannel, coefficients: reduced)
+    }
+
+    // MARK: - Transform
+
+    /// Rotation, uniform scale and translation extracted from a similarity matrix.
+    struct Similarity {
+        var rotation: simd_quatf
+        var scale: Float
+        var matrix: simd_float4x4
+        var isIdentity: Bool
+
+        init(_ matrix: simd_float4x4) throws {
+            self.matrix = matrix
+            isIdentity = matrix == matrix_identity_float4x4
+            let c0 = SIMD3<Float>(matrix.columns.0.x, matrix.columns.0.y, matrix.columns.0.z)
+            let c1 = SIMD3<Float>(matrix.columns.1.x, matrix.columns.1.y, matrix.columns.1.z)
+            let c2 = SIMD3<Float>(matrix.columns.2.x, matrix.columns.2.y, matrix.columns.2.z)
+            let lengths = SIMD3<Float>(simd_length(c0), simd_length(c1), simd_length(c2))
+            let scale = (lengths.x + lengths.y + lengths.z) / 3
+            let determinant = simd_dot(c0, simd_cross(c1, c2))
+            let tolerance = scale * 0.01
+            guard scale > 0, determinant > 0,
+                  abs(lengths.x - scale) <= tolerance, abs(lengths.y - scale) <= tolerance, abs(lengths.z - scale) <= tolerance,
+                  abs(simd_dot(c0, c1)) <= scale * tolerance,
+                  abs(simd_dot(c1, c2)) <= scale * tolerance,
+                  abs(simd_dot(c0, c2)) <= scale * tolerance
+            else {
+                throw UntoldGSCookError.transformIsNotASimilarity
+            }
+            rotation = simd_normalize(simd_quatf(simd_float3x3(c0 / scale, c1 / scale, c2 / scale)))
+            self.scale = scale
+        }
+
+        func apply(to splat: GaussianSplat) -> GaussianSplat {
+            guard !isIdentity else { return splat }
+            var result = splat
+            let center = matrix * SIMD4<Float>(splat.center.x, splat.center.y, splat.center.z, 1)
+            result.center = SIMD4<Float>(center.x, center.y, center.z, 1)
+            result.scale = SIMD4<Float>(splat.scale.x * scale, splat.scale.y * scale, splat.scale.z * scale, 1)
+            // The importer keeps the PLY order (w, x, y, z).
+            let q = simd_quatf(ix: splat.quat.y, iy: splat.quat.z, iz: splat.quat.w, r: splat.quat.x)
+            let rotated = simd_normalize(rotation * q)
+            result.quat = SIMD4<Float>(rotated.real, rotated.imag.x, rotated.imag.y, rotated.imag.z)
+            return result
+        }
+    }
+
+    static func isFinite(_ v: SIMD3<Float>) -> Bool {
+        v.x.isFinite && v.y.isFinite && v.z.isFinite
+    }
+}

--- a/Sources/UntoldEngine/Systems/GaussianSystem.swift
+++ b/Sources/UntoldEngine/Systems/GaussianSystem.swift
@@ -20,7 +20,8 @@ import Foundation
 import Metal
 import simd
 
-let maxNumOfGaussians: UInt64 = 1024 * 1024 * 5
+/// Per-entity splat cap for this platform — see GaussianRuntimeLimits.
+let maxNumOfGaussians = UInt64(GaussianRuntimeLimits.maxSplatsPerEntity)
 
 private func activeGaussianSortCount(_ component: GaussianComponent) -> Int {
     min(Int(component.visibleSplatCountForRendering), Int(component.splatCount))

--- a/Sources/UntoldEngine/Systems/RegistrationSystem.swift
+++ b/Sources/UntoldEngine/Systems/RegistrationSystem.swift
@@ -4153,9 +4153,10 @@ private func nearestSelectedBucketDistanceSquared(
 private func gaussianTierWriteOptions(
     asset: GaussianSplatAsset,
     boundingBox: (min: simd_float3, max: simd_float3),
-    meanSquaredSplatExtent: Float
+    meanSquaredSplatExtent: Float,
+    cookOptions: UntoldGSCookOptions
 ) -> UntoldGSWriteOptions {
-    var options = UntoldGSWriteOptions()
+    var options = UntoldGSCooker.writeOptions(for: cookOptions)
     options.shDegree = UInt8(clamping: asset.sphericalHarmonics?.degree ?? 0)
     options.boundingBoxMin = boundingBox.min
     options.boundingBoxMax = boundingBox.max
@@ -4182,6 +4183,8 @@ public struct GaussianProgressiveBakeResult {
     public let tiers: [GaussianLODTier]
     public let boundingBoxMin: simd_float3
     public let boundingBoxMax: simd_float3
+    /// What the cook step (`UntoldGSCooker`) kept and pruned before ranking and tiering.
+    public let cookReport: UntoldGSCookReport
 }
 
 private func meanSquaredSplatExtent(_ splats: [GaussianSplat], keeping indices: [Int]) -> Float {
@@ -4204,16 +4207,21 @@ private func meanSquaredSplatExtent(_ splats: [GaussianSplat], keeping indices: 
 public func bakeGaussianSplatProgressiveTiers(
     plyURL: URL,
     outputBaseURL: URL,
-    lodFractions: [Float]
+    lodFractions: [Float],
+    cookOptions: UntoldGSCookOptions = UntoldGSCookOptions()
 ) throws -> GaussianProgressiveBakeResult {
     guard !lodFractions.isEmpty else {
         throw UntoldGSError.sizeMismatch("lodFractions must contain at least one entry")
     }
 
-    let asset = try PLYReader.readGaussianAsset(from: plyURL)
-    guard !asset.splats.isEmpty else {
+    let sourceAsset = try PLYReader.readGaussianAsset(from: plyURL)
+    guard !sourceAsset.splats.isEmpty else {
         throw UntoldGSError.sizeMismatch("source .ply contains no splats")
     }
+    // Registration transform, opacity floor, crop and SH degree are applied once here so the
+    // ranking, bounding box and every tier below see the cooked splats.
+    let cooked = try UntoldGSCooker.cook(asset: sourceAsset, options: cookOptions)
+    let asset = cooked.asset
     let assetBoundingBox = computeGaussianSplatBoundingBox(asset.splats)
 
     if lodFractions == [1.0] {
@@ -4222,13 +4230,14 @@ public func bakeGaussianSplatProgressiveTiers(
         let tierExtent = meanSquaredSplatExtent(asset.splats, keeping: allIndices)
         try UntoldGSFormat.write(
             splats: makeUntoldGSSplats(asset: asset, keeping: allIndices),
-            options: gaussianTierWriteOptions(asset: asset, boundingBox: assetBoundingBox, meanSquaredSplatExtent: tierExtent),
+            options: gaussianTierWriteOptions(asset: asset, boundingBox: assetBoundingBox, meanSquaredSplatExtent: tierExtent, cookOptions: cookOptions),
             to: resultURL
         )
         return GaussianProgressiveBakeResult(
             tiers: [GaussianLODTier(url: resultURL, meanSquaredSplatExtent: tierExtent)],
             boundingBoxMin: assetBoundingBox.min,
-            boundingBoxMax: assetBoundingBox.max
+            boundingBoxMax: assetBoundingBox.max,
+            cookReport: cooked.report
         )
     }
 
@@ -4249,7 +4258,7 @@ public func bakeGaussianSplatProgressiveTiers(
         let tierExtent = meanSquaredSplatExtent(asset.splats, keeping: keptIndices)
         try UntoldGSFormat.write(
             splats: makeUntoldGSSplats(asset: asset, keeping: keptIndices),
-            options: gaussianTierWriteOptions(asset: asset, boundingBox: assetBoundingBox, meanSquaredSplatExtent: tierExtent),
+            options: gaussianTierWriteOptions(asset: asset, boundingBox: assetBoundingBox, meanSquaredSplatExtent: tierExtent, cookOptions: cookOptions),
             to: tierURL
         )
         tiers.append(GaussianLODTier(url: tierURL, meanSquaredSplatExtent: tierExtent))
@@ -4257,14 +4266,16 @@ public func bakeGaussianSplatProgressiveTiers(
     return GaussianProgressiveBakeResult(
         tiers: tiers,
         boundingBoxMin: assetBoundingBox.min,
-        boundingBoxMax: assetBoundingBox.max
+        boundingBoxMax: assetBoundingBox.max,
+        cookReport: cooked.report
     )
 }
 
 public func bakeGaussianSplatProgressiveTiers(
     plyURL: URL,
     outputBaseURL: URL,
-    levelCount: Int
+    levelCount: Int,
+    cookOptions: UntoldGSCookOptions = UntoldGSCookOptions()
 ) throws -> GaussianProgressiveBakeResult {
     guard levelCount > 0 else {
         throw UntoldGSError.sizeMismatch("levelCount must be at least 1, got \(levelCount)")
@@ -4273,7 +4284,8 @@ public func bakeGaussianSplatProgressiveTiers(
     return try bakeGaussianSplatProgressiveTiers(
         plyURL: plyURL,
         outputBaseURL: outputBaseURL,
-        lodFractions: fractions
+        lodFractions: fractions,
+        cookOptions: cookOptions
     )
 }
 

--- a/Sources/UntoldEngine/Utils/GaussianRuntimeLimits.swift
+++ b/Sources/UntoldEngine/Utils/GaussianRuntimeLimits.swift
@@ -1,0 +1,33 @@
+//
+//  GaussianRuntimeLimits.swift
+//  UntoldEngine
+//
+//  Per-entity size limits of the Gaussian splat runtime. Every loaded splat keeps about
+//  270 bytes resident on the GPU (encoded record, per-frame precomputed data, sort keys and
+//  visible indices for every frame in flight, spherical harmonics), so the cap is a memory
+//  guard per platform, not a format limit. Cooks that must load everywhere use the mobile
+//  figure as their splat budget (`UntoldGSCookOptions.maxSplatCount`).
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+public enum GaussianRuntimeLimits {
+    /// Apple Vision Pro, iPhone, iPad and Apple TV: 5,242,880 splats per entity (about 1.4 GB).
+    public static let maxSplatsPerEntityMobile = 1024 * 1024 * 5
+    /// Mac: 16,777,216 splats per entity (about 4.5 GB of unified memory).
+    public static let maxSplatsPerEntityMac = 1024 * 1024 * 16
+
+    /// The cap the running binary enforces when a splat asset loads.
+    public static var maxSplatsPerEntity: Int {
+        #if os(macOS)
+            maxSplatsPerEntityMac
+        #else
+            maxSplatsPerEntityMobile
+        #endif
+    }
+}

--- a/Sources/UntoldEngine/Utils/PLYReader.swift
+++ b/Sources/UntoldEngine/Utils/PLYReader.swift
@@ -76,6 +76,20 @@ public class PLYReader {
         try readGaussianAsset(from: url).splats
     }
 
+    /// Number of splats a Gaussian `.ply` declares, read from the header alone — cheap enough
+    /// for a file browser to show before a cook, however large the body is.
+    public static func readGaussianSplatCount(from url: URL) throws -> Int {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        // parseHeader scans at most the first 100 000 bytes for `end_header`.
+        let prefix = try handle.read(upToCount: 100_000) ?? Data()
+        let (header, _) = try parseHeader(from: prefix)
+        guard let vertexElement = header.elements.first(where: { $0.name == "vertex" }) else {
+            throw PLYError.missingElement("vertex")
+        }
+        return vertexElement.count
+    }
+
     /// Reads Gaussian geometry and preserves all spherical-harmonic coefficients.
     public static func readGaussianAsset(from url: URL) throws -> GaussianSplatAsset {
         let data = try Data(contentsOf: url)

--- a/Tests/UntoldEngineTests/UntoldGSCookerTests.swift
+++ b/Tests/UntoldEngineTests/UntoldGSCookerTests.swift
@@ -51,6 +51,55 @@ final class UntoldGSCookerTests: XCTestCase {
         XCTAssertNil(cooked.asset.sphericalHarmonics)
     }
 
+    func testSplatBudgetKeepsTheMostImportantInSourceOrder() throws {
+        // importance = opacity × geometric mean scale: 0.9·0.01, 0.5·0.02, 0.2·0.01, 0.9·0.005, 0.1·0.1, 0.9·0.01
+        let splats: [GaussianSplat] = [
+            GaussianSplat(center: [0, 0, 0, 1], scale: [0.01, 0.01, 0.01, 1], color: [1, 1, 1, 1], quat: [1, 0, 0, 0], opacity: 0.9), // 0.009
+            GaussianSplat(center: [1, 0, 0, 1], scale: [0.02, 0.02, 0.02, 1], color: [1, 1, 1, 1], quat: [1, 0, 0, 0], opacity: 0.5), // 0.010
+            GaussianSplat(center: [2, 0, 0, 1], scale: [0.01, 0.01, 0.01, 1], color: [1, 1, 1, 1], quat: [1, 0, 0, 0], opacity: 0.2), // 0.002
+            GaussianSplat(center: [3, 0, 0, 1], scale: [0.005, 0.005, 0.005, 1], color: [1, 1, 1, 1], quat: [1, 0, 0, 0], opacity: 0.9), // 0.0045
+            GaussianSplat(center: [4, 0, 0, 1], scale: [0.1, 0.1, 0.1, 1], color: [1, 1, 1, 1], quat: [1, 0, 0, 0], opacity: 0.1), // 0.010
+            GaussianSplat(center: [5, 0, 0, 1], scale: [0.01, 0.01, 0.01, 1], color: [1, 1, 1, 1], quat: [1, 0, 0, 0], opacity: 0.9), // 0.009
+        ]
+        var options = UntoldGSCookOptions()
+        options.maxSplatCount = 3
+        let cooked = try UntoldGSCooker.cook(asset: GaussianSplatAsset(splats: splats, sphericalHarmonics: nil), options: options)
+
+        // The two 0.010 splats and the first 0.009 (ties at the cut-off keep the earlier splat).
+        XCTAssertEqual(cooked.asset.splats.map(\.center.x), [0, 1, 4])
+        XCTAssertEqual(cooked.report.keptSplatCount, 3)
+        XCTAssertEqual(cooked.report.prunedByBudget, 3)
+        XCTAssertEqual(cooked.report.inputSplatCount, 6)
+
+        // A budget at or above the survivors changes nothing.
+        options.maxSplatCount = 6
+        let untouched = try UntoldGSCooker.cook(asset: GaussianSplatAsset(splats: splats, sphericalHarmonics: nil), options: options)
+        XCTAssertEqual(untouched.report.prunedByBudget, 0)
+        XCTAssertEqual(untouched.asset.splats.count, 6)
+
+        // The budget applies after the other pruning steps and keeps the SH rows aligned.
+        options.maxSplatCount = 2
+        options.minimumOpacity = 0.3 // drops centres 2 and 4 first
+        // Degree 1: DC plus three coefficients per channel, twelve floats per splat.
+        let harmonics = GaussianSphericalHarmonics(degree: 1, coefficientsPerChannel: 4, coefficients: (0 ..< 6 * 12).map { Float($0) })
+        let pruned = try UntoldGSCooker.cook(asset: GaussianSplatAsset(splats: splats, sphericalHarmonics: harmonics), options: options)
+        XCTAssertEqual(pruned.report.prunedByOpacity, 2)
+        XCTAssertEqual(pruned.report.prunedByBudget, 2)
+        XCTAssertEqual(pruned.asset.splats.map(\.center.x), [0, 1])
+        XCTAssertEqual(pruned.asset.sphericalHarmonics?.coefficients.count, 24, "two survivors keep their twelve coefficients each")
+        XCTAssertEqual(pruned.asset.sphericalHarmonics?.coefficients.prefix(12).map { $0 }, (0 ..< 12).map { Float($0) }, "the first survivor keeps its own SH row")
+    }
+
+    func testSplatBudgetPresetsMatchTheRuntimeLimits() {
+        XCTAssertEqual(UntoldGSCookOptions.splatBudgetMobile, 5_242_880)
+        XCTAssertEqual(UntoldGSCookOptions.splatBudgetMac, 16_777_216)
+        #if os(macOS)
+            XCTAssertEqual(GaussianRuntimeLimits.maxSplatsPerEntity, GaussianRuntimeLimits.maxSplatsPerEntityMac)
+        #else
+            XCTAssertEqual(GaussianRuntimeLimits.maxSplatsPerEntity, GaussianRuntimeLimits.maxSplatsPerEntityMobile)
+        #endif
+    }
+
     func testCookFailsWhenNothingSurvives() {
         var splat = makeSplat(center: .zero)
         splat.opacity = 0
@@ -204,6 +253,7 @@ final class UntoldGSCookerTests: XCTestCase {
 
         """
         let plyURL = try writeTemporaryFile(Data((header + body).utf8), extension: "ply")
+        XCTAssertEqual(try PLYReader.readGaussianSplatCount(from: plyURL), count, "header-only count matches the body")
         let output = try temporaryURL(extension: "untoldgs")
 
         var options = UntoldGSCookOptions()

--- a/Tests/UntoldEngineTests/UntoldGSCookerTests.swift
+++ b/Tests/UntoldEngineTests/UntoldGSCookerTests.swift
@@ -128,6 +128,33 @@ final class UntoldGSCookerTests: XCTestCase {
         XCTAssertEqual(write.splatToMesh, transform)
     }
 
+    func testUpAxisRotationsBringCapturesToYUp() {
+        let up = SIMD3<Float>(0, 1, 0)
+        func rotate(_ axis: UntoldGSCaptureUpAxis, _ v: SIMD3<Float>) -> SIMD3<Float> {
+            let r = axis.rotation * SIMD4<Float>(v, 1)
+            return SIMD3<Float>(r.x, r.y, r.z)
+        }
+        XCTAssertEqual(rotate(.y, up), up)
+        // A Z-up capture's up vector (0,0,1) lands on +Y; its forward +Y (CAD convention) lands
+        // on the engine's forward −Z, so handedness is preserved.
+        let zUp = rotate(.z, SIMD3<Float>(0, 0, 1))
+        XCTAssertEqual(zUp.x, 0, accuracy: 1e-6); XCTAssertEqual(zUp.y, 1, accuracy: 1e-6); XCTAssertEqual(zUp.z, 0, accuracy: 1e-6)
+        let zForward = rotate(.z, SIMD3<Float>(0, 1, 0))
+        XCTAssertEqual(zForward.z, -1, accuracy: 1e-6)
+        // A training-convention capture's up vector (0,−1,0) lands on +Y.
+        XCTAssertEqual(rotate(.negativeY, SIMD3<Float>(0, -1, 0)), up)
+        XCTAssertEqual(UntoldGSCaptureUpAxis(rawValue: "-y"), .negativeY)
+        XCTAssertEqual(UntoldGSCaptureUpAxis.allCases.map(\.rawValue), ["y", "z", "-y"])
+
+        // Composition order: up-axis first, then scale, yaw about +Y, translation.
+        let transform = UntoldGSCookOptions.transform(upAxis: .z, scale: 2, yawDegrees: 90, translation: [10, 0, 0])
+        let p = transform * SIMD4<Float>(0, 0, 1, 1) // Z-up "up" → (0,2,0) → yaw keeps Y → (10,2,0)
+        XCTAssertEqual(p.x, 10, accuracy: 1e-5); XCTAssertEqual(p.y, 2, accuracy: 1e-5); XCTAssertEqual(p.z, 0, accuracy: 1e-5)
+        let q = transform * SIMD4<Float>(1, 0, 0, 1) // +X → scaled (2,0,0) → yaw 90° → (0,0,−2) → (10,0,−2)
+        XCTAssertEqual(q.x, 10, accuracy: 1e-5); XCTAssertEqual(q.z, -2, accuracy: 1e-5)
+        XCTAssertNoThrow(try UntoldGSCooker.cook(asset: GaussianSplatAsset(splats: [makeSplat(center: .zero)], sphericalHarmonics: nil), options: { var o = UntoldGSCookOptions(); o.transform = transform; return o }()))
+    }
+
     func testNonSimilarityTransformIsRejected() {
         let asset = GaussianSplatAsset(splats: [makeSplat(center: .zero)], sphericalHarmonics: nil)
         var options = UntoldGSCookOptions()

--- a/Tests/UntoldEngineTests/UntoldGSCookerTests.swift
+++ b/Tests/UntoldEngineTests/UntoldGSCookerTests.swift
@@ -1,0 +1,227 @@
+//
+//  UntoldGSCookerTests.swift
+//  UntoldEngineTests
+//
+//  Tests for the splat cooker behind `untoldengine export --splat-*`: pruning,
+//  crop, baked registration transform, SH degree selection, and a bake roundtrip.
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import CShaderTypes
+import simd
+@testable import UntoldEngine
+import XCTest
+
+final class UntoldGSCookerTests: XCTestCase {
+    private var temporaryFiles: [URL] = []
+
+    override func tearDown() {
+        for url in temporaryFiles {
+            try? FileManager.default.removeItem(at: url)
+        }
+        temporaryFiles.removeAll()
+        super.tearDown()
+    }
+
+    // MARK: - Pruning and crop
+
+    func testPruningByOpacityGeometryAndCrop() throws {
+        var splats = (0 ..< 20).map { index in makeSplat(center: [Float(index), 0, 0]) }
+        splats[0].opacity = 0.001
+        splats[1].scale = [0, 0.01, 0.01, 1]
+        splats[2].center.y = .nan
+        var options = UntoldGSCookOptions()
+        options.cropMin = [4.5, -1, -1]
+        options.cropMax = [14.5, 1, 1]
+        options.cropMargin = 0.4 // admits 4.1...14.9 → indices 5...14
+
+        let cooked = try UntoldGSCooker.cook(asset: GaussianSplatAsset(splats: splats, sphericalHarmonics: nil), options: options)
+        XCTAssertEqual(cooked.report.inputSplatCount, 20)
+        XCTAssertEqual(cooked.report.prunedByOpacity, 1)
+        XCTAssertEqual(cooked.report.prunedByDegenerateGeometry, 2)
+        XCTAssertEqual(cooked.report.prunedByCrop, 7) // 3, 4, 15...19
+        XCTAssertEqual(cooked.report.keptSplatCount, 10)
+        XCTAssertEqual(cooked.report.shDegree, 0)
+        XCTAssertEqual(cooked.asset.splats.map(\.center.x), (5 ... 14).map { Float($0) })
+        XCTAssertNil(cooked.asset.sphericalHarmonics)
+    }
+
+    func testCookFailsWhenNothingSurvives() {
+        var splat = makeSplat(center: .zero)
+        splat.opacity = 0
+        XCTAssertThrowsError(try UntoldGSCooker.cook(asset: GaussianSplatAsset(splats: [splat], sphericalHarmonics: nil))) { error in
+            guard case let .noSplatsLeftAfterPruning(report)? = error as? UntoldGSCookError else {
+                return XCTFail("unexpected error \(error)")
+            }
+            XCTAssertEqual(report.prunedByOpacity, 1)
+        }
+    }
+
+    func testDefaultOptionsPassEverythingThrough() throws {
+        let splats = (0 ..< 5).map { index in makeSplat(center: [Float(index), 1, 2]) }
+        let cooked = try UntoldGSCooker.cook(asset: GaussianSplatAsset(splats: splats, sphericalHarmonics: nil))
+        XCTAssertEqual(cooked.report, .passthrough(splatCount: 5, shDegree: 0))
+        XCTAssertEqual(cooked.asset.splats.map(\.center), splats.map(\.center))
+    }
+
+    // MARK: - Spherical harmonics
+
+    func testSHDegreeReductionKeepsDCAndLowOrdersPerChannel() throws {
+        // Degree 2: 9 per channel including DC.
+        var coefficients: [Float] = []
+        for channel in 0 ..< 3 {
+            for term in 0 ..< 9 {
+                coefficients.append(Float(channel * 100 + term))
+            }
+        }
+        let asset = GaussianSplatAsset(
+            splats: [makeSplat(center: .zero)],
+            sphericalHarmonics: GaussianSphericalHarmonics(degree: 2, coefficientsPerChannel: 9, coefficients: coefficients)
+        )
+        var options = UntoldGSCookOptions()
+        options.shDegree = 1
+        let cooked = try UntoldGSCooker.cook(asset: asset, options: options)
+        XCTAssertEqual(cooked.report.shDegree, 1)
+        XCTAssertEqual(cooked.asset.sphericalHarmonics?.degree, 1)
+        XCTAssertEqual(cooked.asset.sphericalHarmonics?.coefficientsPerChannel, 4)
+        XCTAssertEqual(cooked.asset.sphericalHarmonics?.coefficients, [0, 1, 2, 3, 100, 101, 102, 103, 200, 201, 202, 203])
+
+        options.shDegree = 0
+        XCTAssertNil(try UntoldGSCooker.cook(asset: asset, options: options).asset.sphericalHarmonics)
+
+        options.shDegree = 3
+        XCTAssertThrowsError(try UntoldGSCooker.cook(asset: asset, options: options)) { error in
+            XCTAssertEqual(error as? UntoldGSCookError, .requestedSHDegreeExceedsSource(requested: 3, source: 2))
+        }
+    }
+
+    // MARK: - Transform
+
+    func testSimilarityTransformIsBakedIntoImporterSplats() throws {
+        let yaw = simd_quatf(angle: .pi / 2, axis: [0, 1, 0])
+        var transform = simd_mul(simd_float4x4(yaw), simd_float4x4(diagonal: [2, 2, 2, 1]))
+        transform.columns.3 = [10, 0, 0, 1]
+
+        var splat = makeSplat(center: [1, 0, 0])
+        splat.scale = [0.1, 0.2, 0.3, 1]
+        var options = UntoldGSCookOptions()
+        options.transform = transform
+        let cooked = try UntoldGSCooker.cook(asset: GaussianSplatAsset(splats: [splat], sphericalHarmonics: nil), options: options)
+        let result = cooked.asset.splats[0]
+
+        // (1,0,0) scaled by 2 → (2,0,0), yawed 90° about Y → (0,0,-2), translated → (10,0,-2).
+        XCTAssertEqual(result.center.x, 10, accuracy: 1e-5)
+        XCTAssertEqual(result.center.y, 0, accuracy: 1e-5)
+        XCTAssertEqual(result.center.z, -2, accuracy: 1e-5)
+        XCTAssertEqual(result.scale.x, 0.2, accuracy: 1e-6)
+        XCTAssertEqual(result.scale.z, 0.6, accuracy: 1e-6)
+        // PLY order (w, x, y, z): the identity rotation becomes the yaw.
+        let q = simd_quatf(ix: result.quat.y, iy: result.quat.z, iz: result.quat.w, r: result.quat.x)
+        XCTAssertEqual(q.act(SIMD3<Float>(1, 0, 0)).z, -1, accuracy: 1e-5)
+
+        let write = UntoldGSCooker.writeOptions(for: options)
+        XCTAssertEqual(write.splatToMesh, transform)
+    }
+
+    func testNonSimilarityTransformIsRejected() {
+        let asset = GaussianSplatAsset(splats: [makeSplat(center: .zero)], sphericalHarmonics: nil)
+        var options = UntoldGSCookOptions()
+        options.transform = simd_float4x4(diagonal: [1, 2, 1, 1])
+        XCTAssertThrowsError(try UntoldGSCooker.cook(asset: asset, options: options)) { error in
+            XCTAssertEqual(error as? UntoldGSCookError, .transformIsNotASimilarity)
+        }
+        options.transform = simd_float4x4(diagonal: [-1, 1, 1, 1]) // mirror
+        XCTAssertThrowsError(try UntoldGSCooker.cook(asset: asset, options: options))
+    }
+
+    // MARK: - Bake roundtrip
+
+    func testBakeAppliesCookOptionsAndWritesV3() throws {
+        let count = 300
+        var body = ""
+        for index in 0 ..< count {
+            let x = Float(index % 10) * 0.1
+            let y = Float(index / 10 % 10) * 0.1
+            let z = Float(index / 100) * 0.1
+            let rest = (0 ..< 9).map { "\(Float($0) * 0.01)" }.joined(separator: " ")
+            body += "\(x) \(y) \(z) 0 0 1 0.2 0.1 -0.1 \(rest) 2.0 -4 -4 -4 1 0 0 0\n"
+        }
+        let header = """
+        ply
+        format ascii 1.0
+        element vertex \(count)
+        property float x
+        property float y
+        property float z
+        property float nx
+        property float ny
+        property float nz
+        property float f_dc_0
+        property float f_dc_1
+        property float f_dc_2
+        \((0 ..< 9).map { "property float f_rest_\($0)" }.joined(separator: "\n"))
+        property float opacity
+        property float scale_0
+        property float scale_1
+        property float scale_2
+        property float rot_0
+        property float rot_1
+        property float rot_2
+        property float rot_3
+        end_header
+
+        """
+        let plyURL = try writeTemporaryFile(Data((header + body).utf8), extension: "ply")
+        let output = try temporaryURL(extension: "untoldgs")
+
+        var options = UntoldGSCookOptions()
+        options.log2ChunkSplats = 7 // 128 → 3 chunks
+        options.cropMin = [0, 0, 0]
+        options.cropMax = [0.95, 0.95, 0.15] // z layers 0 and 0.1 → 200 splats
+        options.shDegree = 0
+        let result = try bakeGaussianSplatProgressiveTiers(plyURL: plyURL, outputBaseURL: output, lodFractions: [1.0], cookOptions: options)
+        XCTAssertEqual(result.cookReport.inputSplatCount, count)
+        XCTAssertEqual(result.cookReport.prunedByCrop, 100)
+        XCTAssertEqual(result.cookReport.keptSplatCount, 200)
+        XCTAssertEqual(result.tiers.count, 1)
+
+        let file = try UntoldGSFile(url: result.tiers[0].url)
+        XCTAssertEqual(file.header.version, 3)
+        XCTAssertEqual(file.header.splatCount, 200)
+        XCTAssertEqual(file.header.log2ChunkSplats, 7)
+        XCTAssertEqual(file.index.chunks.count, 2)
+        XCTAssertFalse(file.header.hasSphericalHarmonics)
+        XCTAssertEqual(file.header.boundingBoxMin, result.boundingBoxMin)
+        for splat in try file.decodeAll() {
+            XCTAssertLessThanOrEqual(splat.position.z, 0.11)
+        }
+
+        // The runtime read path sees the cooked count too.
+        XCTAssertEqual(try UntoldGSFormat.read(from: result.tiers[0].url).splatCount, 200)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSplat(center: SIMD3<Float>) -> GaussianSplat {
+        GaussianSplat(center: SIMD4<Float>(center, 1), scale: [0.01, 0.01, 0.01, 1], color: [1, 1, 1, 1], quat: [1, 0, 0, 0], opacity: 1)
+    }
+
+    private func temporaryURL(extension ext: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("UntoldGSCookerTests-\(UUID().uuidString)")
+            .appendingPathExtension(ext)
+        temporaryFiles.append(url)
+        return url
+    }
+
+    private func writeTemporaryFile(_ data: Data, extension ext: String) throws -> URL {
+        let url = try temporaryURL(extension: ext)
+        try data.write(to: url)
+        return url
+    }
+}

--- a/Tools/UntoldEngineCLI/Package.swift
+++ b/Tools/UntoldEngineCLI/Package.swift
@@ -30,7 +30,9 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
 
         // Local dependency on UntoldEngine (two directories up from Tools/UntoldEngineCLI)
-        .package(path: "../../"),
+        // `name:` pins the package identity so the CLI also builds from a checkout
+        // whose directory is not called UntoldEngine (git worktrees, forks).
+        .package(name: "UntoldEngine", path: "../../"),
     ],
     targets: [
         .executableTarget(

--- a/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/ExportCommand.swift
+++ b/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/ExportCommand.swift
@@ -91,6 +91,9 @@ struct ExportCommand: ParsableCommand {
     @Option(name: .customLong("splat-min-opacity"), help: "Gaussian .ply export only: drop splats with a lower opacity")
     var splatMinOpacity: Float = 0.005
 
+    @Option(name: .customLong("splat-max-count"), help: "Gaussian .ply export only: keep at most this many splats, the most important by opacity and size (0 = no limit). The runtime loads at most \(UntoldGSCookOptions.splatBudgetMobile) per entity on Vision Pro, iPhone, iPad and Apple TV and \(UntoldGSCookOptions.splatBudgetMac) on the Mac.")
+    var splatMaxCount: Int = 0
+
     @Option(name: .customLong("splat-crop"), help: "Gaussian .ply export only: crop box in the output space, minX,minY,minZ,maxX,maxY,maxZ")
     var splatCrop: String?
 
@@ -205,7 +208,7 @@ struct ExportCommand: ParsableCommand {
         }
         let report = bakeResult.cookReport
         printInfo("Splats: \(report.keptSplatCount) of \(report.inputSplatCount) kept "
-            + "(opacity \(report.prunedByOpacity), degenerate \(report.prunedByDegenerateGeometry), crop \(report.prunedByCrop)), "
+            + "(opacity \(report.prunedByOpacity), degenerate \(report.prunedByDegenerateGeometry), crop \(report.prunedByCrop), budget \(report.prunedByBudget)), "
             + "SH degree \(report.shDegree), \(splatChunkSplats) splats per chunk")
         // meanSquaredSplatExtent is baked into each .untoldgs file and read automatically when
         // the engine loads it — printed here only as a diagnostic (e.g. to compare density
@@ -241,6 +244,10 @@ struct ExportCommand: ParsableCommand {
         options.log2ChunkSplats = UInt8(splatChunkSplats.trailingZeroBitCount)
         options.shDegree = splatSHDegree.map { UInt8($0) }
         options.minimumOpacity = splatMinOpacity
+        guard splatMaxCount >= 0 else {
+            throw ExportError.invalidSplatFlag("--splat-max-count must be zero or positive")
+        }
+        options.maxSplatCount = splatMaxCount > 0 ? splatMaxCount : nil
         options.cropMargin = splatCropMargin
         options.isEnvironment = splatEnvironment
         options.antialiased = splatAntialiased

--- a/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/ExportCommand.swift
+++ b/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/ExportCommand.swift
@@ -27,8 +27,8 @@ struct ExportCommand: ParsableCommand {
         `untoldengine texbake --dir` and `untoldengine texbake --patch-refs`.
 
         Gaussian `.ply` inputs skip Blender and export directly to `.untoldgs`.
-        The --splat-* flags register the capture onto its mesh twin (scale,
-        yaw, translation, the 3DGS axis flip), crop away floaters and the
+        The --splat-* flags register the capture onto its mesh twin (up axis,
+        scale, yaw, translation), crop away floaters and the
         captured floor, drop near-transparent splats, and pick the
         spherical-harmonics degree and chunk size. Values that start with a
         minus sign must use the --option=value form.
@@ -38,7 +38,7 @@ struct ExportCommand: ParsableCommand {
           untoldengine export --input model.blend --output model.untold --convert-orientation --optimize
           untoldengine export --input splats.ply --output splats.untoldgs
           untoldengine export --input splats.ply --output splats.untoldgs --lod-levels 4
-          untoldengine export --input sofa.ply --output sofa.untoldgs --splat-flip-yz \\
+          untoldengine export --input sofa.ply --output sofa.untoldgs --splat-up-axis z \\
             --splat-scale 0.5 --splat-translate 0,0.4,0 --splat-crop=-1,0,-1,1,1.2,1 --splat-sh-degree 2
         """
     )
@@ -106,7 +106,10 @@ struct ExportCommand: ParsableCommand {
     @Option(name: .customLong("splat-translate"), help: "Gaussian .ply export only: translation applied after rotation and scale, x,y,z")
     var splatTranslate: String?
 
-    @Flag(name: .customLong("splat-flip-yz"), help: "Gaussian .ply export only: convert from the 3DGS training convention (Y down, Z forward) to the engine's (Y up, Z back)")
+    @Option(name: .customLong("splat-up-axis"), help: "Gaussian .ply export only: which axis points up in the capture: y (engine convention, default), z (scanner/CAD, rotated to Y-up), or -y (3DGS training convention)")
+    var splatUpAxis: String = "y"
+
+    @Flag(name: .customLong("splat-flip-yz"), help: "Gaussian .ply export only: same as --splat-up-axis=-y")
     var splatFlipYZ = false
 
     @Flag(name: .customLong("splat-environment"), help: "Gaussian .ply export only: cook as an environment payload")
@@ -247,20 +250,20 @@ struct ExportCommand: ParsableCommand {
             options.cropMax = SIMD3<Float>(values[3], values[4], values[5])
         }
 
-        var transform = simd_float4x4(diagonal: [splatScale, splatScale, splatScale, 1])
-        if splatFlipYZ {
-            // 180° about X: (x, y, z) → (x, -y, -z).
-            transform = simd_mul(simd_float4x4(diagonal: [1, -1, -1, 1]), transform)
+        guard let upAxis = UntoldGSCaptureUpAxis(rawValue: splatUpAxis.lowercased()) else {
+            throw ExportError.invalidSplatUpAxis(splatUpAxis)
         }
-        if splatYawDegrees != 0 {
-            let yaw = simd_quatf(angle: splatYawDegrees * .pi / 180, axis: [0, 1, 0])
-            transform = simd_mul(simd_float4x4(yaw), transform)
-        }
+        var translation = SIMD3<Float>.zero
         if let splatTranslate {
             let values = try parseFloats(splatTranslate, count: 3, option: "--splat-translate")
-            transform.columns.3 = SIMD4<Float>(values[0], values[1], values[2], 1)
+            translation = SIMD3<Float>(values[0], values[1], values[2])
         }
-        options.transform = transform
+        options.transform = UntoldGSCookOptions.transform(
+            upAxis: splatFlipYZ ? .negativeY : upAxis,
+            scale: splatScale,
+            yawDegrees: splatYawDegrees,
+            translation: translation
+        )
         return options
     }
 
@@ -323,6 +326,7 @@ enum ExportError: LocalizedError {
     case invalidLODLevels(Int)
     case colorGradeLUTNotFound(String)
     case splatCookFailed(String)
+    case invalidSplatUpAxis(String)
     case invalidSplatFlag(String)
 
     var errorDescription: String? {
@@ -344,6 +348,8 @@ enum ExportError: LocalizedError {
             return "--color-grade-lut path does not exist: \(path)"
         case let .splatCookFailed(reason):
             return "Gaussian splat cook failed: \(reason)"
+        case let .invalidSplatUpAxis(value):
+            return "--splat-up-axis must be y, z or -y, got \(value)"
         case let .invalidSplatFlag(reason):
             return reason
         }

--- a/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/ExportCommand.swift
+++ b/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/ExportCommand.swift
@@ -10,6 +10,7 @@
 
 import ArgumentParser
 import Foundation
+import simd
 import UntoldEngine
 
 struct ExportCommand: ParsableCommand {
@@ -26,12 +27,19 @@ struct ExportCommand: ParsableCommand {
         `untoldengine texbake --dir` and `untoldengine texbake --patch-refs`.
 
         Gaussian `.ply` inputs skip Blender and export directly to `.untoldgs`.
+        The --splat-* flags register the capture onto its mesh twin (scale,
+        yaw, translation, the 3DGS axis flip), crop away floaters and the
+        captured floor, drop near-transparent splats, and pick the
+        spherical-harmonics degree and chunk size. Values that start with a
+        minus sign must use the --option=value form.
 
         Example:
           untoldengine export --input model.usdz --output model.untold --convert-orientation --optimize
           untoldengine export --input model.blend --output model.untold --convert-orientation --optimize
           untoldengine export --input splats.ply --output splats.untoldgs
           untoldengine export --input splats.ply --output splats.untoldgs --lod-levels 4
+          untoldengine export --input sofa.ply --output sofa.untoldgs --splat-flip-yz \\
+            --splat-scale 0.5 --splat-translate 0,0.4,0 --splat-crop=-1,0,-1,1,1.2,1 --splat-sh-degree 2
         """
     )
 
@@ -74,6 +82,39 @@ struct ExportCommand: ParsableCommand {
     @Option(name: .customLong("lod-levels"), help: "Gaussian .ply export only: number of progressive .untoldgs tiers to generate. Default 1 writes --output directly; values greater than 1 write <name>_lod0.untoldgs, <name>_lod1.untoldgs, ...")
     var lodLevels: Int = 1
 
+    @Option(name: .customLong("splat-chunk-splats"), help: "Gaussian .ply export only: splats per chunk, a power of two between 2 and 16384 (1024 for objects, 4096 for environments)")
+    var splatChunkSplats: Int = 1024
+
+    @Option(name: .customLong("splat-sh-degree"), help: "Gaussian .ply export only: spherical-harmonics degree to keep, 0...3 (default: the source degree)")
+    var splatSHDegree: Int?
+
+    @Option(name: .customLong("splat-min-opacity"), help: "Gaussian .ply export only: drop splats with a lower opacity")
+    var splatMinOpacity: Float = 0.005
+
+    @Option(name: .customLong("splat-crop"), help: "Gaussian .ply export only: crop box in the output space, minX,minY,minZ,maxX,maxY,maxZ")
+    var splatCrop: String?
+
+    @Option(name: .customLong("splat-crop-margin"), help: "Gaussian .ply export only: grow the crop box on every side, in metres")
+    var splatCropMargin: Float = 0
+
+    @Option(name: .customLong("splat-scale"), help: "Gaussian .ply export only: uniform scale applied to the capture")
+    var splatScale: Float = 1
+
+    @Option(name: .customLong("splat-yaw-degrees"), help: "Gaussian .ply export only: rotation about +Y applied after --splat-flip-yz, in degrees")
+    var splatYawDegrees: Float = 0
+
+    @Option(name: .customLong("splat-translate"), help: "Gaussian .ply export only: translation applied after rotation and scale, x,y,z")
+    var splatTranslate: String?
+
+    @Flag(name: .customLong("splat-flip-yz"), help: "Gaussian .ply export only: convert from the 3DGS training convention (Y down, Z forward) to the engine's (Y up, Z back)")
+    var splatFlipYZ = false
+
+    @Flag(name: .customLong("splat-environment"), help: "Gaussian .ply export only: cook as an environment payload")
+    var splatEnvironment = false
+
+    @Flag(name: .customLong("splat-antialiased"), help: "Gaussian .ply export only: mark the payload as cooked with the anti-aliased (3D smoothing) convention")
+    var splatAntialiased = false
+
     func run() throws {
         let inputURL = resolvePath(input).standardizedFileURL
         let outputURL = resolvePath(output).standardizedFileURL
@@ -89,7 +130,7 @@ struct ExportCommand: ParsableCommand {
             guard lodLevels > 0 else {
                 throw ExportError.invalidLODLevels(lodLevels)
             }
-            try runGaussianSplatExport(inputURL: inputURL, outputURL: outputURL)
+            try runGaussianSplatExport(inputURL: inputURL, outputURL: outputURL, cookOptions: makeSplatCookOptions())
             return
         }
 
@@ -146,13 +187,23 @@ struct ExportCommand: ParsableCommand {
         }
     }
 
-    private func runGaussianSplatExport(inputURL: URL, outputURL: URL) throws {
+    private func runGaussianSplatExport(inputURL: URL, outputURL: URL, cookOptions: UntoldGSCookOptions) throws {
         printInfo("Exporting Gaussian splats \(inputURL.path)")
-        let bakeResult = try bakeGaussianSplatProgressiveTiers(
-            plyURL: inputURL,
-            outputBaseURL: outputURL,
-            levelCount: lodLevels
-        )
+        let bakeResult: GaussianProgressiveBakeResult
+        do {
+            bakeResult = try bakeGaussianSplatProgressiveTiers(
+                plyURL: inputURL,
+                outputBaseURL: outputURL,
+                levelCount: lodLevels,
+                cookOptions: cookOptions
+            )
+        } catch let error as UntoldGSCookError {
+            throw ExportError.splatCookFailed(error.description)
+        }
+        let report = bakeResult.cookReport
+        printInfo("Splats: \(report.keptSplatCount) of \(report.inputSplatCount) kept "
+            + "(opacity \(report.prunedByOpacity), degenerate \(report.prunedByDegenerateGeometry), crop \(report.prunedByCrop)), "
+            + "SH degree \(report.shDegree), \(splatChunkSplats) splats per chunk")
         // meanSquaredSplatExtent is baked into each .untoldgs file and read automatically when
         // the engine loads it — printed here only as a diagnostic (e.g. to compare density
         // across source captures), not something to copy anywhere.
@@ -166,6 +217,59 @@ struct ExportCommand: ParsableCommand {
         // for the streaming path, which requires a real box before any tier is ever read.
         let halfExtent = (bakeResult.boundingBoxMax - bakeResult.boundingBoxMin) * 0.5
         printInfo("boundingBoxHalfExtent: (\(halfExtent.x), \(halfExtent.y), \(halfExtent.z))")
+    }
+
+    // MARK: - Gaussian cooking flags
+
+    /// `--validate` already occupies the `validate` name on this command, so flag checks run
+    /// here and surface as `ExportError.invalidSplatFlag` with their own message.
+    private func makeSplatCookOptions() throws -> UntoldGSCookOptions {
+        guard splatChunkSplats >= 2, splatChunkSplats <= 16384, splatChunkSplats & (splatChunkSplats - 1) == 0 else {
+            throw ExportError.invalidSplatFlag("--splat-chunk-splats must be a power of two between 2 and 16384")
+        }
+        if let splatSHDegree, !(0 ... 3).contains(splatSHDegree) {
+            throw ExportError.invalidSplatFlag("--splat-sh-degree must be between 0 and 3")
+        }
+        guard splatScale > 0 else {
+            throw ExportError.invalidSplatFlag("--splat-scale must be positive")
+        }
+
+        var options = UntoldGSCookOptions()
+        options.log2ChunkSplats = UInt8(splatChunkSplats.trailingZeroBitCount)
+        options.shDegree = splatSHDegree.map { UInt8($0) }
+        options.minimumOpacity = splatMinOpacity
+        options.cropMargin = splatCropMargin
+        options.isEnvironment = splatEnvironment
+        options.antialiased = splatAntialiased
+        if let splatCrop {
+            let values = try parseFloats(splatCrop, count: 6, option: "--splat-crop")
+            options.cropMin = SIMD3<Float>(values[0], values[1], values[2])
+            options.cropMax = SIMD3<Float>(values[3], values[4], values[5])
+        }
+
+        var transform = simd_float4x4(diagonal: [splatScale, splatScale, splatScale, 1])
+        if splatFlipYZ {
+            // 180° about X: (x, y, z) → (x, -y, -z).
+            transform = simd_mul(simd_float4x4(diagonal: [1, -1, -1, 1]), transform)
+        }
+        if splatYawDegrees != 0 {
+            let yaw = simd_quatf(angle: splatYawDegrees * .pi / 180, axis: [0, 1, 0])
+            transform = simd_mul(simd_float4x4(yaw), transform)
+        }
+        if let splatTranslate {
+            let values = try parseFloats(splatTranslate, count: 3, option: "--splat-translate")
+            transform.columns.3 = SIMD4<Float>(values[0], values[1], values[2], 1)
+        }
+        options.transform = transform
+        return options
+    }
+
+    private func parseFloats(_ text: String, count: Int, option: String) throws -> [Float] {
+        let values = text.split(separator: ",").map { Float($0.trimmingCharacters(in: .whitespaces)) }
+        guard values.count == count, !values.contains(nil) else {
+            throw ExportError.invalidSplatFlag("\(option) expects \(count) comma-separated numbers")
+        }
+        return values.compactMap(\.self)
     }
 
     private func optimizeTextures(outputURL: URL) throws {
@@ -218,6 +322,8 @@ enum ExportError: LocalizedError {
     case unsupportedPLYExportOutput(String)
     case invalidLODLevels(Int)
     case colorGradeLUTNotFound(String)
+    case splatCookFailed(String)
+    case invalidSplatFlag(String)
 
     var errorDescription: String? {
         switch self {
@@ -236,6 +342,10 @@ enum ExportError: LocalizedError {
             return "--lod-levels must be a positive integer, got \(value)"
         case let .colorGradeLUTNotFound(path):
             return "--color-grade-lut path does not exist: \(path)"
+        case let .splatCookFailed(reason):
+            return "Gaussian splat cook failed: \(reason)"
+        case let .invalidSplatFlag(reason):
+            return reason
         }
     }
 }

--- a/docs/API/UsingGaussianSystem.md
+++ b/docs/API/UsingGaussianSystem.md
@@ -89,6 +89,17 @@ Once everything is set up:
 
 ---
 
+## Per-entity splat limit
+
+Every loaded splat keeps about 270 bytes resident on the GPU (its encoded record, the
+per-frame precomputed data, sort keys and visible indices for each frame in flight, and
+its spherical harmonics), so the runtime caps one entity at
+`GaussianRuntimeLimits.maxSplatsPerEntity`: 5,242,880 splats on Apple Vision Pro, iPhone,
+iPad and Apple TV, 16,777,216 on the Mac. A `.untoldgs` or `.ply` above the cap fails to
+load with an "exceeds maximum" error. Cook large captures with a splat budget
+(`UntoldGSCookOptions.maxSplatCount`, `untoldengine export --splat-max-count`) that fits
+every platform the asset ships on, or split the scene into streamed tiles.
+
 ## Progressive Gaussian Splats
 
 Progressive Gaussian loading is available without a tile-streamed scene. Use it when you

--- a/docs/API/UsingUntoldEngineCLI.md
+++ b/docs/API/UsingUntoldEngineCLI.md
@@ -160,11 +160,14 @@ spherical-harmonics degree and chunk size.
 
 ```bash
 untoldengine export --input sofa.ply --output Gaussians/sofa.untoldgs \
-  --splat-flip-yz --splat-scale 0.5 --splat-yaw-degrees 90 --splat-translate 0,0.4,0 \
+  --splat-up-axis z --splat-scale 0.5 --splat-yaw-degrees 90 --splat-translate 0,0.4,0 \
   --splat-crop=-1,0,-1,1,1.2,1 --splat-crop-margin 0.05 --splat-sh-degree 2
 ```
 
-The transform is baked into every splat and recorded in the file header.
+`--splat-up-axis` names the capture's up axis (`y` is the engine convention and the default,
+`z` for scanner and CAD exports, `-y` for the 3DGS training convention); the rotation to
+Y-up is applied before scale, yaw and translation, and the whole transform is baked into
+every splat and recorded in the file header.
 `--splat-min-opacity` (default 0.005) drops near-transparent splats; `--splat-chunk-splats`
 sets the chunk size (1024 for objects, 4096 with `--splat-environment` for rooms and
 larger). Values that start with a minus sign must use the `--option=value` form. The

--- a/docs/API/UsingUntoldEngineCLI.md
+++ b/docs/API/UsingUntoldEngineCLI.md
@@ -173,6 +173,14 @@ sets the chunk size (1024 for objects, 4096 with `--splat-environment` for rooms
 larger). Values that start with a minus sign must use the `--option=value` form. The
 command prints how many splats were kept and pruned per reason.
 
+`--splat-max-count N` keeps at most N splats, dropping the least important first (opacity
+times the geometric mean of the scales). The runtime refuses to load an entity above its
+per-platform cap — 5,242,880 splats on Apple Vision Pro, iPhone, iPad and Apple TV,
+16,777,216 on the Mac (`GaussianRuntimeLimits`) — so a large capture that has to load
+everywhere is cooked with `--splat-max-count 5242880`; one that only has to run on a Mac
+can go up to the Mac figure. Captures beyond that belong to the streamed environment
+path, which decodes and sorts only the visible chunks (part 6 of the series).
+
 ---
 
 ## Partitioning Scenes into Streaming Tiles

--- a/docs/API/UsingUntoldEngineCLI.md
+++ b/docs/API/UsingUntoldEngineCLI.md
@@ -150,6 +150,28 @@ macOS location and is not available on `PATH`.
 
 ---
 
+### Gaussian splat captures
+
+A Gaussian splat `.ply` exports directly to `.untoldgs` (see [Gaussian Splat
+Format](../Architecture/untoldgsFormat.md)); `--lod-levels N` writes progressive tiers.
+The `--splat-*` flags cook the capture on the way: register it onto its mesh twin, crop
+away floaters and the captured floor, drop near-transparent splats, and choose the
+spherical-harmonics degree and chunk size.
+
+```bash
+untoldengine export --input sofa.ply --output Gaussians/sofa.untoldgs \
+  --splat-flip-yz --splat-scale 0.5 --splat-yaw-degrees 90 --splat-translate 0,0.4,0 \
+  --splat-crop=-1,0,-1,1,1.2,1 --splat-crop-margin 0.05 --splat-sh-degree 2
+```
+
+The transform is baked into every splat and recorded in the file header.
+`--splat-min-opacity` (default 0.005) drops near-transparent splats; `--splat-chunk-splats`
+sets the chunk size (1024 for objects, 4096 with `--splat-environment` for rooms and
+larger). Values that start with a minus sign must use the `--option=value` form. The
+command prints how many splats were kept and pruned per reason.
+
+---
+
 ## Partitioning Scenes into Streaming Tiles
 
 For large outdoor scenes, `export-tiles` partitions a USD/USDZ/`.blend` scene into


### PR DESCRIPTION
Replay of miolabs/UntoldEngine#21, developed and verified end to end on the fork (engine series https://github.com/miolabs/UntoldEngine/pull/18 … https://github.com/miolabs/UntoldEngine/pull/22, editor untoldengine/UntoldEditor#91).

Part 4 of the Gaussian splat streaming series (proposal: #1176). **Re-scoped:** the first version added a separate `cook-splats` command. The cooking steps are now flags on the existing `untoldengine export`, applied inside `bakeGaussianSplatProgressiveTiers`, so there is one baker. Its bases #1177 (`.untoldgs` v3) and #1178 (`gaussianAsset` chunk) are merged, so the branch is rebased onto `develop` and this diff is the cooker's own three commits: the export flags, the capture up-axis option, and the splat budget (`--splat-max-count`, `UntoldGSCookOptions.maxSplatCount`, `GaussianRuntimeLimits.maxSplatsPerEntity`).

## What

- **`UntoldGSCooker`** (engine, `AssetFormat/UntoldGSCooker.swift`): takes the importer's `GaussianSplatAsset` and returns the asset to bake plus a `UntoldGSCookReport`. Bakes a similarity transform (rotation, uniform scale, translation) into centres, PLY-order quaternions and scales; drops splats under `minimumOpacity` or with non-finite or non-positive geometry; crops to an optional box with margin; keeps the DC term and the low orders of each SH channel for the requested degree. Works on importer structs so the bake's ranking, bounding box and tiering run unchanged on the cooked splats. Mirroring, shear and non-uniform scale are rejected because splat covariances need a similarity.
- **`bakeGaussianSplatProgressiveTiers(..., cookOptions:)`** on both overloads, defaulting to a pass-through cook. The write options carry the cook's chunk size, flags, transform and capture lighting; `GaussianProgressiveBakeResult` gains `cookReport`.
- **`untoldengine export` flags** (all optional, `.ply` input only): `--splat-chunk-splats` (power of two; 1024 objects, 4096 environments), `--splat-sh-degree`, `--splat-min-opacity`, `--splat-crop minX,minY,minZ,maxX,maxY,maxZ`, `--splat-crop-margin`, `--splat-scale`, `--splat-yaw-degrees`, `--splat-translate x,y,z`, `--splat-up-axis y|z|-y` (the capture's up axis: engine convention, scanner/CAD Z-up, or the 3DGS training convention; rotated to Y-up before scale, yaw and translation), `--splat-flip-yz` kept as an alias for `-y`, `--splat-environment`, `--splat-antialiased`. The command prints kept and pruned counts per reason. Existing flags and defaults unchanged.
- **CLI package identity pinned** (`.package(name: "UntoldEngine", path: "../../")`) so the CLI builds from a checkout whose directory is not named `UntoldEngine` (worktrees, forks); SwiftPM otherwise derives the identity from the directory name and the `UntoldEngine` product reference fails to resolve.
- **Docs:** "Gaussian splat captures" subsection under Exporting Assets in `docs/API/UsingUntoldEngineCLI.md`.

## Not in this PR

Importance pruning from rendered contribution, ICP registration against the mesh twin, merged coarse levels, SPZ/SOG import, and writing the `.untold` side (`gaussianAsset` record) — the Python exporter remains the `.untold` producer.

## Also in this PR: splat budget and per-platform runtime cap

(Replay of miolabs/UntoldEngine#25, last commit.) A large capture (8,085,051 splats) cooked to one `.untoldgs` failed to load with "too many Gaussian splats … exceeds maximum 5242880" and nothing in the cook could target the limit.

- **`GaussianRuntimeLimits.maxSplatsPerEntity`**: 5,242,880 on Apple Vision Pro, iPhone, iPad and Apple TV (unchanged), 16,777,216 on the Mac; `maxNumOfGaussians` derives from it. Every splat keeps about 270 bytes resident, so the cap is a memory guard per platform.
- **`UntoldGSCookOptions.maxSplatCount`** keeps at most N splats after the other pruning steps, the least important first (opacity times the geometric mean of the scales); ties keep the earlier splat and the source order survives. `UntoldGSCookReport.prunedByBudget`; presets `splatBudgetMobile` / `splatBudgetMac`.
- **`--splat-max-count N`** on `export` (0 = no limit); the summary prints the budget prune.
- **`PLYReader.readGaussianSplatCount(from:)`** reads the declared count from the header alone.
- Docs: the flag in `UsingUntoldEngineCLI.md`, a "Per-entity splat limit" section in `UsingGaussianSystem.md`.
- Tests: `UntoldGSCookerTests` +2 (budget selection in source order with ties, no-op at or above the survivor count, applied after the other steps with SH rows aligned; presets equal the runtime limits) and a header-only count check in the bake test.

## Verification

- `swift build` clean for the engine and for the CLI package (Xcode 26.6 toolchain).
- New `UntoldGSCookerTests` (7 tests): opacity, degenerate-geometry and crop pruning with exact counts and surviving centres; nothing-left error carries the report; default options pass everything through unchanged; SH degree reduction keeps DC plus low orders per channel, degree 0 drops the block, an upgrade is rejected; a scale+yaw+translate transform is baked into centres, scales and PLY-order quaternions and recorded in the write options; non-uniform and mirrored transforms rejected; an ASCII PLY baked with a crop and chunk size produces a v3 file with the cooked count, chunk size and bounding box, readable through both `UntoldGSFile` and `UntoldGSFormat.read`.
- `UntoldGSFormatTests` (21) and `NativeFormatTests` (38) still green on the stacked branch.
- Render suites that bake (`GaussianProgressiveLODTest`, `GaussianStreamingTest`): 38 tests, 0 failures.
- CLI smoke test on a generated 5000-splat binary PLY: three tiers with `--splat-flip-yz --splat-sh-degree 1 --splat-crop=-1,-1,-1,1,1,1 --splat-chunk-splats 512`, the default export with no flags, and the validation error for a non-power-of-two chunk size.
- Second commit adds `UntoldGSCaptureUpAxis` and `UntoldGSCookOptions.transform(upAxis:scale:yawDegrees:translation:)` with a test of the three rotations and the composition order; CLI smoke test of `--splat-up-axis z` and the validation error for a bad value.
- SwiftFormat lint clean on the changed files (local 0.62.1; CI's pinned 0.60.1 will confirm).

