### PR TITLE
[Patch] Export packed textures as separate files and honor linked metallic/roughness sockets

### DIFF
--- a/scripts/tests/test_untoldexplorer.py
+++ b/scripts/tests/test_untoldexplorer.py
@@ -122,6 +122,35 @@ class UntoldExplorerTests(unittest.TestCase):
         self.assertIsNotNone(texture)
         self.assertEqual(texture.channel, u.TEXTURE_CHANNEL_A)
 
+    def test_resolve_texture_from_socket_keeps_packed_images_distinct(self) -> None:
+        """Packed/generated images have an empty filepath. They must be keyed by
+        their Blender image name, never by a path derived from the empty string:
+        that resolves to the asset's parent directory, so every packed texture in a
+        material shared one staging key and collapsed onto the base color."""
+        base_image = FakeData(filepath="", library=None, size=(2048, 2048), name="T_Zombie_BC")
+        normal_image = FakeData(filepath="", library=None, size=(2048, 2048), name="T_Zombie_N")
+        base_input = FakeSocket("Base Color")
+        base_input.link_from(FakeNode("ShaderNodeTexImage", image=base_image), "Color")
+        normal_color_input = FakeSocket("Color")
+        normal_color_input.link_from(FakeNode("ShaderNodeTexImage", image=normal_image), "Color")
+        normal_input = FakeSocket("Normal")
+        normal_input.link_from(FakeNode("ShaderNodeNormalMap", inputs={"Color": normal_color_input}), "Normal")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            asset_path = Path(tmpdir) / "asset.untold"
+            base = u.resolve_texture_from_socket(base_input, asset_path)
+            normal = u.resolve_texture_from_socket(normal_input, asset_path)
+
+        self.assertIsNotNone(base)
+        self.assertIsNotNone(normal)
+        for texture in (base, normal):
+            self.assertIsNone(texture.source_path, "packed images have no file on disk to key by")
+        self.assertEqual(base.source_image_name, "T_Zombie_BC")
+        self.assertEqual(normal.source_image_name, "T_Zombie_N")
+        self.assertNotEqual(base.name, normal.name)
+        self.assertNotEqual(base.uri, normal.uri)
+        self.assertNotEqual(u.texture_staging_key(base), u.texture_staging_key(normal))
+
     def test_unique_hdr_destination_name_deduplicates_collisions(self) -> None:
         context = u.HDRStagingContext()
 
@@ -861,6 +890,57 @@ class MaterialGraphAnalysisTests(unittest.TestCase):
         # built on top of the same structured data (behavior-preserving refactor).
         lines = u.material_fidelity_report_lines([supported_mesh, bakeable_mesh])
         self.assertIn("1 supported, 1 bakeable, 0 unbakeable", lines[0])
+
+    def test_extract_material_exports_unit_factor_for_textured_metallic_roughness(self) -> None:
+        """Blender ignores a socket's slider once a texture is linked to it, and the
+        engine multiplies the texture sample by the exported factor. A textured
+        Metallic or Roughness socket must therefore export 1.0: exporting the slider
+        halved roughness (default 0.5) and zeroed metallic (default 0.0) on every
+        textured material. Unlinked sockets still export the slider value."""
+        orm = _make_image_node("orm")
+        separate_input = FakeSocket("Color")
+        separate_input.link_from(orm, "Color")
+        separate = FakeNode("ShaderNodeSeparateColor", inputs={"Color": separate_input})
+        separate.name = "Separate Color"
+
+        principled, output = _make_principled_output(_make_image_node("albedo"))
+        metallic = FakeSocket("Metallic")
+        metallic.default_value = 0.0
+        metallic.link_from(separate, "Blue")
+        roughness = FakeSocket("Roughness")
+        roughness.default_value = 0.5
+        roughness.link_from(separate, "Green")
+        principled.inputs["Metallic"] = metallic
+        principled.inputs["Roughness"] = roughness
+        material = _make_material("orm_mat", [output, principled, separate, orm])
+        mesh_object = FakeSceneObject("Zombie", "MESH", FakeData(materials=[material]))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            exported = u.extract_material(mesh_object, Path(tmpdir) / "asset.untold")
+
+        self.assertIsNotNone(exported.metallic_texture)
+        self.assertIsNotNone(exported.roughness_texture)
+        self.assertEqual(exported.metallic_texture.channel, u.TEXTURE_CHANNEL_B)
+        self.assertEqual(exported.roughness_texture.channel, u.TEXTURE_CHANNEL_G)
+        self.assertEqual(exported.metallic_factor, 1.0, "textured metallic must not be scaled by the ignored slider")
+        self.assertEqual(exported.roughness_factor, 1.0, "textured roughness must not be scaled by the ignored slider")
+
+        principled_plain, output_plain = _make_principled_output(None)
+        principled_plain.inputs["Base Color"].default_value = (1.0, 1.0, 1.0, 1.0)
+        metallic_plain = FakeSocket("Metallic")
+        metallic_plain.default_value = 0.25
+        roughness_plain = FakeSocket("Roughness")
+        roughness_plain.default_value = 0.8
+        principled_plain.inputs["Metallic"] = metallic_plain
+        principled_plain.inputs["Roughness"] = roughness_plain
+        plain_material = _make_material("plain_mat", [output_plain, principled_plain])
+        plain_object = FakeSceneObject("Cube", "MESH", FakeData(materials=[plain_material]))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            exported_plain = u.extract_material(plain_object, Path(tmpdir) / "asset.untold")
+
+        self.assertAlmostEqual(exported_plain.metallic_factor, 0.25)
+        self.assertAlmostEqual(exported_plain.roughness_factor, 0.8)
 
     def test_extract_material_reads_height_from_displacement_node(self) -> None:
         """The standard ArchViz/Poliigon authoring pattern: an Image Texture feeds a

--- a/scripts/untoldexplorer.py
+++ b/scripts/untoldexplorer.py
@@ -2042,6 +2042,60 @@ def resolve_texture_from_socket(input_socket: object, asset_path: Path) -> Optio
     return _resolve_texture_from_socket(input_socket, asset_path, visited_nodes=set(), channel=TEXTURE_CHANNEL_R)
 
 
+def _exported_texture_from_image(image: object, asset_path: Path, channel: int = TEXTURE_CHANNEL_R) -> ExportedTexture:
+    """Build the pre-staging ExportedTexture for a Blender image datablock.
+
+    File-backed images are keyed and named by their (resolved) source path. Packed
+    and generated images have an empty filepath and no file on disk at all, so they
+    are keyed and named by the Blender image name instead and written out through
+    Blender at staging time (see stage_texture_for_output / write_blender_image_to_path).
+
+    Deriving a path from the empty filepath is not an option: Path("") resolves to
+    the asset's parent *directory*, which gave every packed image in a material the
+    same source_path, name and uri. texture_staging_key keys on source_path first,
+    so the staging pass collapsed all of them onto the first one written and the
+    normal/roughness/metallic slots ended up pointing at the base color PNG.
+    """
+    source_image_name = getattr(image, "name", None)
+    image_name = source_image_name or "texture"
+    size = getattr(image, "size", ())
+    width = int(size[0]) if len(size) > 0 else 0
+    height = int(size[1]) if len(size) > 1 else 0
+    mip_count = 1 if width > 0 and height > 0 else 0
+
+    filepath = getattr(image, "filepath", "") or ""
+    if not filepath:
+        return ExportedTexture(
+            name=image_name,
+            uri=image_name,
+            width=width,
+            height=height,
+            mip_count=mip_count,
+            source_path=None,
+            source_image_name=source_image_name,
+            channel=channel,
+        )
+
+    raw_path = bpy.path.abspath(filepath, library=getattr(image, "library", None)) if bpy is not None else filepath
+    texture_path = Path(raw_path)
+    if not texture_path.is_absolute():
+        texture_path = (asset_path.parent / texture_path).resolve()
+    try:
+        uri = os.path.relpath(texture_path, asset_path.parent)
+    except ValueError:
+        uri = str(texture_path)
+    return ExportedTexture(
+        name=texture_path.name or image_name,
+        uri=uri,
+        width=width,
+        height=height,
+        mip_count=mip_count,
+        source_path=texture_path,
+        source_image_name=source_image_name,
+        channel=channel,
+    )
+
+
 def _resolve_texture_from_socket(input_socket: object, asset_path: Path, visited_nodes: set[int], channel: int) -> Optional[ExportedTexture]:
     if not getattr(input_socket, "is_linked", False):
         return None
@@ -2056,27 +2110,7 @@ def _resolve_texture_from_socket(input_socket: object, asset_path: Path, visited
 
     if source_node.bl_idname == "ShaderNodeTexImage" and source_node.image is not None:
         texture_channel = texture_channel_from_socket_name(getattr(source_socket, "name", ""), channel)
-        image = source_node.image
-        image_path = bpy.path.abspath(image.filepath, library=image.library) if bpy is not None else image.filepath
-        texture_path = Path(image_path)
-        if not texture_path.is_absolute():
-            texture_path = (asset_path.parent / texture_path).resolve()
-        try:
-            uri = os.path.relpath(texture_path, asset_path.parent)
-        except ValueError:
-            uri = str(texture_path)
-        width = int(image.size[0]) if len(image.size) > 0 else 0
-        height = int(image.size[1]) if len(image.size) > 1 else 0
-        return ExportedTexture(
-            name=texture_path.name or image.name,
-            uri=uri,
-            width=width,
-            height=height,
-            mip_count=1 if width > 0 and height > 0 else 0,
-            source_path=texture_path,
-            source_image_name=getattr(image, "name", None),
-            channel=texture_channel,
-        )
+        return _exported_texture_from_image(source_node.image, asset_path, channel=texture_channel)
 
     if source_node.bl_idname in {"ShaderNodeSeparateColor", "ShaderNodeSeparateRGB"}:
         texture_channel = texture_channel_from_socket_name(getattr(source_socket, "name", ""), channel)
@@ -3460,26 +3494,28 @@ def _detect_occlusion_texture(material: object, asset_path: Path) -> Optional[Ex
         parts = name_lower.split("_")
         if "occlusion" not in name_lower and not any(p == "ao" for p in parts):
             continue
-        raw_path = bpy.path.abspath(filepath, library=image.library) if bpy is not None and filepath else filepath
-        texture_path = Path(raw_path) if raw_path else Path(image.name)
-        if not texture_path.is_absolute() and filepath:
-            texture_path = (asset_path.parent / texture_path).resolve()
-        try:
-            uri = os.path.relpath(texture_path, asset_path.parent)
-        except ValueError:
-            uri = str(texture_path)
-        width = int(image.size[0]) if len(image.size) > 0 else 0
-        height = int(image.size[1]) if len(image.size) > 1 else 0
-        return ExportedTexture(
-            name=texture_path.name or image.name,
-            uri=uri,
-            width=width,
-            height=height,
-            mip_count=1 if width > 0 and height > 0 else 0,
-            source_path=texture_path,
-            source_image_name=getattr(image, "name", None),
-        )
+        return _exported_texture_from_image(image, asset_path)
     return None
+
+
+def _scalar_socket_factor(input_socket: object, texture: Optional[ExportedTexture], default: float) -> float:
+    """Factor exported for a scalar Principled socket (Metallic, Roughness).
+
+    The engine multiplies the channel's texture sample by this factor. Same rule as
+    Base Color in extract_material: once a texture drives the socket, Blender ignores
+    the socket's default_value entirely, so the factor must be 1.0. Exporting the
+    slider value instead halved roughness (Principled default 0.5) and zeroed
+    metallic (default 0.0) on every textured material.
+
+    Unlinked sockets export the slider value itself. A linked socket whose source
+    could not be traced back to a texture (a Value node, node math — see the
+    material fidelity report) keeps the slider value as the best available fallback.
+    """
+    if input_socket is None:
+        return default
+    if texture is not None:
+        return 1.0
+    return float(input_socket.default_value)
 
 
 def extract_material(mesh_object: object, asset_path: Path) -> ExportedMaterial:
@@ -3574,8 +3610,6 @@ def extract_material(mesh_object: object, asset_path: Path) -> ExportedMaterial:
             float(emissive_default[1]) * emission_strength,
             float(emissive_default[2]) * emission_strength,
         )
-    metallic = float(metallic_input.default_value) if metallic_input is not None else 0.0
-    roughness = float(roughness_input.default_value) if roughness_input is not None else 0.5
     alpha = float(alpha_input.default_value) if alpha_input is not None else 1.0
 
     base_color_texture = resolve_texture_from_socket(base_color_input, asset_path) if base_color_input is not None else None
@@ -3583,6 +3617,8 @@ def extract_material(mesh_object: object, asset_path: Path) -> ExportedMaterial:
     emissive_texture = resolve_texture_from_socket(emissive_input, asset_path) if emissive_input is not None else None
     metallic_texture = resolve_texture_from_socket(metallic_input, asset_path) if metallic_input is not None else None
     roughness_texture = resolve_texture_from_socket(roughness_input, asset_path) if roughness_input is not None else None
+    metallic = _scalar_socket_factor(metallic_input, metallic_texture, default=0.0)
+    roughness = _scalar_socket_factor(roughness_input, roughness_texture, default=0.5)
     normal_scale = 1.0
     if normal_input is not None and normal_input.is_linked:
         source = normal_input.links[0].from_node


### PR DESCRIPTION
## Summary
- Packed/generated images (empty `filepath`) resolved to the .blend's parent directory, so every packed texture in a material shared one staging key and collapsed onto the base color PNG. The exported material's normal, metallic and roughness slots all pointed at the albedo, and the engine sampled the albedo as a normal map. Packed images are now keyed and named by their Blender image name via a shared helper (`_exported_texture_from_image`), used by both the socket resolver and the occlusion detector.
- Metallic/roughness factors were exported from the Principled BSDF sliders even when a texture drives the socket. Blender ignores the slider in that case, and the engine multiplies the texture by the factor, so roughness came out halved (Principled default 0.5) and metallic maps were multiplied by zero. Linked sockets with a resolved texture now export 1.0; unlinked sockets keep the slider value.

Found with a character whose textures were packed in the .blend: the export contained two texture records for a three-texture material, with `normal = metallic = roughness = base color`.

## Test plan
- [x] `python3 -m unittest discover -s scripts/tests -t .` (126 tests), including two new regression tests
- [x] Re-exported the packed-texture asset from Blender 5.2: three texture records with the right flags, normal/metallic/roughness pointing at their own files, factors 1.0
- [x] Rendered old vs new export in the engine: fabric wrinkles and facial detail appear once the real normal map is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)
