### PR TITLE
[Patch] Re-bake a custom environment from the directory it was loaded from

### DIFF
--- a/Sources/UntoldEngine/Renderer/RenderInitializer.swift
+++ b/Sources/UntoldEngine/Renderer/RenderInitializer.swift
@@ -1191,7 +1191,12 @@ func initIBLResources() {
     // they must have the same dimensions.
     let iblSize = 256
 
-    let cacheKey = iblBakeCacheKey(hdrName: hdrURL, directory: resourceURL, iblSize: iblSize, pixelFormat: wf.ibl, device: renderInfo.device)
+    // An environment set through `setRendering(.environment(.asset(...)))` or
+    // `generateHDR(_:from:)` may live outside the engine bundle; re-bake it
+    // from where it was loaded, or the resize would fail and leave the IBL
+    // textures blank.
+    let hdrDirectory = hdrDirectoryURL ?? resourceURL
+    let cacheKey = iblBakeCacheKey(hdrName: hdrURL, directory: hdrDirectory, iblSize: iblSize, pixelFormat: wf.ibl, device: renderInfo.device)
 
     if let cacheKey {
         iblBakeCacheState.lock.lock()
@@ -1268,7 +1273,7 @@ func initIBLResources() {
     renderInfo.iblOffscreenRenderPassDescriptor.colorAttachments[2].texture =
         textureResources.iblBRDFMap
 
-    generateHDR(hdrURL, from: resourceURL)
+    generateHDR(hdrURL, from: hdrDirectory)
 
     if iblSuccessful, let cacheKey,
        let irradianceMap = textureResources.irradianceMap,

--- a/Sources/UntoldEngine/Utils/FuncUtils.swift
+++ b/Sources/UntoldEngine/Utils/FuncUtils.swift
@@ -372,6 +372,7 @@ public func generateHDR(_ hdrName: String, from directory: URL? = nil) {
 
         iblSuccessful = true
         hdrURL = hdrName
+        hdrDirectoryURL = directory
 
     } catch {
         handleError(.iBLCreationFailed)

--- a/Sources/UntoldEngine/Utils/Globals.swift
+++ b/Sources/UntoldEngine/Utils/Globals.swift
@@ -847,6 +847,7 @@ private final class RuntimeGlobalsStore: @unchecked Sendable {
     private var ambientIntensityValue: Float = 0.4
     private var hdrURLValue: String = "teatro_massimo_2k.hdr"
     private var resourceURLValue: URL?
+    private var hdrDirectoryURLValue: URL?
     private var assetBasePathValue: URL?
     private var activeEntityValue: EntityID = .invalid
     private var enableEngineMetricsValue: Bool = false
@@ -1272,6 +1273,20 @@ private final class RuntimeGlobalsStore: @unchecked Sendable {
         }
     }
 
+    var hdrDirectoryURL: URL? {
+        get {
+            lock.lock()
+            let value = hdrDirectoryURLValue
+            lock.unlock()
+            return value
+        }
+        set {
+            lock.lock()
+            hdrDirectoryURLValue = newValue
+            lock.unlock()
+        }
+    }
+
     var assetBasePath: URL? {
         get {
             lock.lock()
@@ -1638,6 +1653,14 @@ public var hdrURL: String {
 public var resourceURL: URL? {
     get { RuntimeGlobalsStore.shared.resourceURL }
     set { RuntimeGlobalsStore.shared.resourceURL = newValue }
+}
+
+/// Directory the current `hdrURL` environment was loaded from, so a later
+/// IBL re-bake (viewport resize, `initSizeableResources()`) finds the same
+/// file. `nil` means the engine's own resource search (`resourceURL`).
+public var hdrDirectoryURL: URL? {
+    get { RuntimeGlobalsStore.shared.hdrDirectoryURL }
+    set { RuntimeGlobalsStore.shared.hdrDirectoryURL = newValue }
 }
 
 var currentGlobalTime: Float {

--- a/Tests/UntoldEngineRenderTests/BaseRenderSetup.swift
+++ b/Tests/UntoldEngineRenderTests/BaseRenderSetup.swift
@@ -105,6 +105,7 @@ class BaseRenderSetup: XCTestCase {
         // textures blank, regardless of what that test's own scene actually wants.
         hdrURL = "teatro_massimo_2k.hdr"
         resourceURL = nil
+        hdrDirectoryURL = nil
     }
 
     private func psnrThreshold(for targetName: String, default defaultValue: String) -> String {

--- a/Tests/UntoldEngineRenderTests/EnvironmentAssetRebakeTests.swift
+++ b/Tests/UntoldEngineRenderTests/EnvironmentAssetRebakeTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+@testable import UntoldEngine
+import XCTest
+
+/// An environment loaded from outside the engine bundle must survive the
+/// IBL re-bake that `initSizeableResources()` runs on every viewport change.
+final class EnvironmentAssetRebakeTests: BaseRenderSetup {
+    override func initializeAssets() {}
+
+    private var customDirectory: URL?
+
+    override func tearDown() {
+        if let customDirectory {
+            try? FileManager.default.removeItem(at: customDirectory)
+        }
+        super.tearDown()
+    }
+
+    func testViewportRebakeKeepsEnvironmentLoadedFromCustomDirectory() throws {
+        // A copy of a bundled HDR under a name the engine bundle does not have.
+        let source = try XCTUnwrap(
+            LoadingSystem.shared.resourceURL(forResource: "teatro_massimo_2k", withExtension: "hdr", subResource: nil)
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("untold-env-rebake-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        customDirectory = directory
+        try FileManager.default.copyItem(at: source, to: directory.appendingPathComponent("custom_room.hdr"))
+
+        setRendering(.environment(.asset("custom_room.hdr", directory: directory)))
+        XCTAssertTrue(iblSuccessful, "The custom environment must load")
+        XCTAssertEqual(hdrURL, "custom_room.hdr")
+        XCTAssertEqual(hdrDirectoryURL, directory)
+
+        // What the XR layer (and any window resize) does next.
+        initIBLResources()
+
+        XCTAssertTrue(iblSuccessful, "The re-bake must find the environment where it was loaded from")
+        XCTAssertEqual(hdrURL, "custom_room.hdr", "The re-bake must not fall back to the default environment")
+        XCTAssertNotNil(textureResources.irradianceMap)
+    }
+}


### PR DESCRIPTION
## Summary

An environment set through `setRendering(.environment(.asset(_:directory:)))` or `generateHDR(_:from:)` can live outside the engine bundle, but the IBL re-bake that `initSizeableResources()` runs on every viewport change looked the current HDR name up through the engine's resource search only (`resourceURL`).

On visionOS the XR layer sizes the viewport shortly after the scene sets its environment, so the re-bake failed with error 1018 (`iBLCreationFailed`) and the frame was lit by freshly created, blank IBL textures. The same happens on any window resize once a custom environment is active.

## Change

- `generateHDR(_:from:)` now records the directory it loaded from in a new `hdrDirectoryURL` global next to `hdrURL`.
- `initIBLResources()` uses that directory (falling back to `resourceURL`) for both the bake cache key and the re-bake.
- `BaseRenderSetup` resets the new global between tests, like it already does for `hdrURL`/`resourceURL`.

## Test

`EnvironmentAssetRebakeTests` copies a bundled HDR into a temporary directory under a name the engine bundle does not have, loads it through the settings API, runs `initIBLResources()` as a viewport change would, and asserts the environment survives (`iblSuccessful` stays true, `hdrURL` unchanged). Without the fix the re-bake fails and `iblSuccessful` flips to false.

Found while giving the CoolZombie visionOS demo a neutral environment: the load succeeded, the XR viewport update dropped it, and the shirt kept the default theatre HDRI's blue cast.
