### PR TITLE
[Patch] Apply root translation deltas relative to the root's heading

### DIFF
--- a/Sources/UntoldEngine/Animation/RootMotion.swift
+++ b/Sources/UntoldEngine/Animation/RootMotion.swift
@@ -229,7 +229,14 @@ func applyRootMotion(
             yawDelta += compiledClip.rootYawPerLoop
         }
         yawDelta = wrapAngle(yawDelta)
-        horizontal = simd_float3(delta.x, 0, delta.z)
+        // The clip's travel is authored in model space, but the entity
+        // faces the pose with the root yaw stripped. Express the delta in
+        // the root's own heading frame (as Unreal's extraction does) so a
+        // clip captured facing any direction still moves the entity along
+        // the direction its pose is walking.
+        let headingInverse = simd_quatf(angle: -animationComponent.rootMotion.previousYaw, axis: simd_float3(0, 1, 0))
+        let local = headingInverse.act(delta)
+        horizontal = simd_float3(local.x, 0, local.z)
     }
 
     if drivesAnchor, scene.get(component: LocalTransformComponent.self, for: motionEntity) != nil {

--- a/Tests/UntoldEngineTests/AnimationRootMotionTests.swift
+++ b/Tests/UntoldEngineTests/AnimationRootMotionTests.swift
@@ -474,6 +474,37 @@ final class AnimationRootMotionTests: XCTestCase {
         XCTAssertEqual(alignment, 1.0, accuracy: 1e-3, "Grounded root must keep its rest orientation (body upright)")
     }
 
+    // MARK: - Clips authored off the model axis
+
+    /// A capture whose actor faces +X (root yaw 90°) and walks along +X
+    /// must move the entity along its own forward: the pose is stripped
+    /// of that yaw, so the travel has to be expressed relative to the
+    /// root's heading, not taken raw from model space.
+    func testTravelFollowsRootHeadingForClipsAuthoredOffAxis() {
+        let yaw: Float = .pi / 2
+        let heading = simd_quatf(angle: yaw, axis: simd_float3(0, 1, 0))
+        let key = SIMD4<Float>(heading.imag.x, heading.imag.y, heading.imag.z, heading.real)
+        let rootChannel = RuntimeAnimationChannel(
+            jointPath: "root",
+            translations: [
+                .init(time: 0.0, value: simd_float3(0, 0, 0)),
+                .init(time: 1.0, value: simd_float3(1, 0, 0)), // 1 m along +X in model space
+            ],
+            rotations: [.init(time: 0.0, value: key), .init(time: 1.0, value: key)]
+        )
+        animationComponent.animationClips["sidewaysAuthored"] = AnimationClip(
+            runtimeClip: RuntimeAnimationClip(name: "sidewaysAuthored", duration: 1.0, channels: [rootChannel])
+        )
+
+        setRootMotionEnabled(entityId: entityId, enabled: true)
+        changeAnimation(entityId: entityId, name: "sidewaysAuthored", transitionHalflife: 0)
+        run(frames: 90) // 1 s
+
+        let position = getLocalPosition(entityId: entityId)
+        XCTAssertEqual(position.z, 1.0 - deltaTime, accuracy: 1e-2, "Travel must land on the entity's forward (+Z)")
+        XCTAssertEqual(position.x, 0, accuracy: 1e-2, "No sideways drift from the model-space authoring axis")
+    }
+
     // MARK: - Root joint override
 
     func testRootJointPathOverride() {


### PR DESCRIPTION
## Summary

Root motion applies the extracted per-frame translation delta as `entityRotation.act(delta)`, i.e. in the clip's raw model space. That is only right when the clip's root yaw stays at zero, which happens to hold for clips exported from Unreal but not for captured clips whose actor faces another direction or turns: the entity then travels sideways or backwards relative to the direction its pose is walking, because the pose is displayed with the root yaw stripped.

## Change

Express the delta in the root's previous heading frame before rotating it into the entity's orientation (rotate by the inverse of `previousYaw`). This matches how Unreal extracts root motion (delta relative to the root's start transform) and is a no-op for clips with zero root yaw.

## Test

`testTravelFollowsRootHeadingForClipsAuthoredOffAxis`: a clip whose root faces +X (yaw 90°) and translates 1 m along +X must move the entity 1 m along its own forward (+Z) with no sideways drift. Fails on the current code (the entity moves along +X), passes with the change. The existing root-motion, motion-matching and foot-IK suites are unchanged.

Found while retargeting 100STYLE mocap (actors wander a capture volume) onto the CoolZombie demo: motion matching chose the right clips, but the character walked away from its goal.
