### PR TITLE
Reset SceneRootTransform between StreamingGateTests runs

### DIFF
--- a/Tests/UntoldEngineRenderTests/StreamingGateTests.swift
+++ b/Tests/UntoldEngineRenderTests/StreamingGateTests.swift
@@ -24,6 +24,13 @@ final class StreamingGateTests: BaseRenderSetup {
     override func setUp() async throws {
         try await super.setUp()
         destroyAllEntities()
+        // A test elsewhere in this target (e.g. GaussianRenderingTest's scene-root-offset
+        // culling test) can leave SceneRootTransform.shared non-identity if it doesn't get
+        // torn down cleanly in the same process. update(cameraPosition:) below runs it through
+        // SceneRootTransform.shared.effectiveCameraPosition, so a stale offset silently shifts
+        // every distance/zone check in this file away from the camera position the test thinks
+        // it's using -- reset it alongside the other shared singletons this suite depends on.
+        SceneRootTransform.shared.reset()
         GeometryStreamingSystem.shared.reset()
         GeometryStreamingSystem.shared.enabled = true
         GeometryStreamingSystem.shared.maxConcurrentLoads = 3
@@ -51,6 +58,7 @@ final class StreamingGateTests: BaseRenderSetup {
     }
 
     override func tearDown() async throws {
+        SceneRootTransform.shared.reset()
         GeometryStreamingSystem.shared.reset()
         GeometryStreamingSystem.shared.enabled = false
         GeometryStreamingSystem.shared.maxConcurrentLoads = 3


### PR DESCRIPTION
## What

`StreamingGateTests` resets `GeometryStreamingSystem`, `OctreeSystem`, and `MemoryBudgetManager` in `setUp()`/`tearDown()`, but never resets `SceneRootTransform`.

This matters because `GeometryStreamingSystem.update()` resolves its camera position through:

`SceneRootTransform.shared.effectiveCameraPosition`

If another test in the same CI worker process leaves `SceneRootTransform.shared` in a non-identity state — for example, `GaussianRenderingTest`'s scene-root-offset culling test sets `position = (500, 0, 0)` — every distance and interior-zone check in `StreamingGateTests` can silently run against the wrong camera position.

## Why

Found while investigating three consecutive CI failures on #1185. Each attempt failed at a *different* interior-zone test, including:

- `testInteriorZoneGate_allowsEntityWhenCameraIsInside`
- `testInteriorZoneGate_doesNotApplyToNonInteriorEntities`

Each failure had the same symptom:

> `XCTAssertNotEqual failed: ("unloaded") is equal to ("unloaded")`

Different tests failing across runs with the same failure pattern strongly points to shared/global state leaking between tests rather than a bug in any individual assertion.

#1185 doesn't modify this file, `GeometryStreamingSystem.swift`, or `SceneRootTransform`. It simply adds enough test volume to change how tests are scheduled in CI, which was enough to expose this pre-existing isolation gap.

## Fix

Add:

`SceneRootTransform.shared.reset()`

to both `setUp()` and `tearDown()`, alongside the existing singleton/system resets.