### PR TITLE
[Feature] Write gaussianAsset links into .untold files: UntoldAssetPatcher and untoldengine gaussian-link

### DIFF
--- a/Sources/UntoldEngine/AssetFormat/UntoldAssetPatcher.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldAssetPatcher.swift
@@ -37,9 +37,11 @@ public enum UntoldAssetPatcher {
         public var flags: UInt32
         /// Valid entries in `lodSplatCounts` / `lodSwitchScreenHeights`, 0...4. Zero means one level.
         public var lodCount: Int
-        /// Splat count per LOD level, coarsest first. At most `lodCount` entries.
+        /// Splat count per LOD level, coarsest first. `lodCount` entries; the initializer pads a
+        /// shorter array with zeros so a link compares equal to what `gaussianAssets(in:)` reads back.
         public var lodSplatCounts: [UInt32]
-        /// Screen height in pixels above which the next finer level is preferred. At most `lodCount` entries.
+        /// Screen height in pixels above which the next finer level is preferred. `lodCount`
+        /// entries, padded like `lodSplatCounts`.
         public var lodSwitchScreenHeights: [Float]
         /// Metres the mesh twin's depth-only occluder shell is shrunk along its normals.
         public var occluderShrinkMeters: Float
@@ -61,8 +63,12 @@ public enum UntoldAssetPatcher {
             self.payloadPath = payloadPath
             self.flags = flags
             self.lodCount = lodCount
-            self.lodSplatCounts = lodSplatCounts
-            self.lodSwitchScreenHeights = lodSwitchScreenHeights
+            // The record stores `maxLODLevels` slots and reads back `lodCount` of them, so a
+            // shorter array would come back zero-padded; pad here so the link round-trips.
+            // Longer arrays are left alone for `validate()` to reject.
+            let levels = min(max(lodCount, 0), UntoldGaussianAssetRecordV1.maxLODLevels)
+            self.lodSplatCounts = Self.padded(lodSplatCounts, to: levels, with: 0)
+            self.lodSwitchScreenHeights = Self.padded(lodSwitchScreenHeights, to: levels, with: 0)
             self.occluderShrinkMeters = occluderShrinkMeters
             self.exposureOffsetEV = exposureOffsetEV
             self.swapDistanceMeters = swapDistanceMeters
@@ -83,13 +89,16 @@ public enum UntoldAssetPatcher {
             )
         }
 
-        /// The record this link is written as, once the path sits in the string table.
+        /// The record this link is written as, once the path sits in the string table. The link
+        /// is expected to pass `validate()`; a link that does not is still turned into a record
+        /// (a negative `lodCount` clamps to zero, arrays are cut or padded to four slots) rather
+        /// than trapping, so a caller may preview the record before validating.
         public func record(entityId: UInt32, payloadPathOffset: UInt32) -> UntoldGaussianAssetRecordV1 {
             UntoldGaussianAssetRecordV1(
                 entityId: entityId,
                 payloadPathOffset: payloadPathOffset,
                 flags: flags,
-                lodCount: UInt32(lodCount),
+                lodCount: UInt32(clamping: lodCount),
                 lodSplatCounts: lodSplatCounts,
                 lodSwitchScreenHeights: lodSwitchScreenHeights,
                 occluderShrinkMeters: occluderShrinkMeters,
@@ -130,6 +139,11 @@ public enum UntoldAssetPatcher {
             guard exposureOffsetEV.isFinite else {
                 throw Error.invalidLink("exposureOffsetEV must be finite")
             }
+        }
+
+        private static func padded<T>(_ values: [T], to count: Int, with fill: T) -> [T] {
+            guard values.count < count else { return values }
+            return values + Array(repeating: fill, count: count - values.count)
         }
     }
 
@@ -312,11 +326,15 @@ public enum UntoldAssetPatcher {
                 guard !gaussianAssets.isEmpty else { continue }
                 payloads.append(gaussianAssetPayload(gaussianAssets, template: chunk))
             default:
-                let start = Int(chunk.fileOffset)
-                let end = start + Int(chunk.compressedSize)
-                guard start >= 0, end <= fileData.count else {
+                // Compared in UInt64 before converting: an entry the reader never touches (an
+                // unknown chunk type) may carry sizes that do not fit an Int.
+                guard chunk.fileOffset <= UInt64(fileData.count),
+                      chunk.compressedSize <= UInt64(fileData.count) - chunk.fileOffset
+                else {
                     throw Error.corruptFile("chunk \(chunk.chunkType.rawValue) points outside the file")
                 }
+                let start = Int(chunk.fileOffset)
+                let end = start + Int(chunk.compressedSize)
                 payloads.append(ChunkPayload(entry: chunk, storedBytes: fileData.subdata(in: start ..< end)))
             }
         }

--- a/Sources/UntoldEngine/AssetFormat/UntoldAssetPatcher.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldAssetPatcher.swift
@@ -1,0 +1,392 @@
+//
+//  UntoldAssetPatcher.swift
+//  UntoldEngine
+//
+//  Rewrites the `gaussianAsset` table of a cooked `.untold` file so a scene author (the
+//  editor, the CLI) can link an entity to a splat payload after the export. Every other
+//  chunk is copied byte for byte; only the string table and the gaussianAsset table are
+//  re-emitted.
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// Sets, removes and lists the `gaussianAsset` records (chunk 25,
+/// `UntoldGaussianAssetRecordV1`) of a `.untold` file without re-encoding anything else.
+///
+/// The `.untold` container has no whole-file writer in Swift; this patcher does not need one.
+/// It reads the file through `UntoldReader`, copies the stored bytes of every chunk it does not
+/// own (compression, element count and uncompressed size preserved), appends the payload path to
+/// the string table when the string is new, emits the new gaussianAsset table, lays the chunks
+/// out again on `UntoldFormat.fileAlignment`, and rewrites the header's chunk count and content
+/// hash. The result is read back through `UntoldReader` before it is returned.
+public enum UntoldAssetPatcher {
+    /// What one entity of a `.untold` file links to: the settings of a
+    /// `UntoldGaussianAssetRecordV1` with the payload path decoded. Paths are stored relative to
+    /// the `.untold` file's directory (see `NativeFormatLoader`'s resolution: an absolute URL, a
+    /// path relative to the file, or the flattened basename).
+    public struct GaussianAssetLink: Sendable, Equatable {
+        /// Path of the `.untoldgs` payload, relative to the `.untold` file's directory.
+        public var payloadPath: String
+        /// See `UntoldGaussianAssetFlags`.
+        public var flags: UInt32
+        /// Valid entries in `lodSplatCounts` / `lodSwitchScreenHeights`, 0...4. Zero means one level.
+        public var lodCount: Int
+        /// Splat count per LOD level, coarsest first. At most `lodCount` entries.
+        public var lodSplatCounts: [UInt32]
+        /// Screen height in pixels above which the next finer level is preferred. At most `lodCount` entries.
+        public var lodSwitchScreenHeights: [Float]
+        /// Metres the mesh twin's depth-only occluder shell is shrunk along its normals.
+        public var occluderShrinkMeters: Float
+        /// Exposure offset in EV, applied on top of the payload's capture exposure.
+        public var exposureOffsetEV: Float
+        /// Camera distance at which the swap and its prefetch arm. Zero means always.
+        public var swapDistanceMeters: Float
+
+        public init(
+            payloadPath: String,
+            flags: UInt32 = UntoldGaussianAssetFlags.meshTwin,
+            lodCount: Int = 0,
+            lodSplatCounts: [UInt32] = [],
+            lodSwitchScreenHeights: [Float] = [],
+            occluderShrinkMeters: Float = 0.02,
+            exposureOffsetEV: Float = 0,
+            swapDistanceMeters: Float = 0
+        ) {
+            self.payloadPath = payloadPath
+            self.flags = flags
+            self.lodCount = lodCount
+            self.lodSplatCounts = lodSplatCounts
+            self.lodSwitchScreenHeights = lodSwitchScreenHeights
+            self.occluderShrinkMeters = occluderShrinkMeters
+            self.exposureOffsetEV = exposureOffsetEV
+            self.swapDistanceMeters = swapDistanceMeters
+        }
+
+        /// The link a file's record describes, with its path read from the string table.
+        public init(record: UntoldGaussianAssetRecordV1, payloadPath: String) {
+            let levels = Int(record.lodCount)
+            self.init(
+                payloadPath: payloadPath,
+                flags: record.flags,
+                lodCount: levels,
+                lodSplatCounts: Array(record.lodSplatCounts.prefix(levels)),
+                lodSwitchScreenHeights: Array(record.lodSwitchScreenHeights.prefix(levels)),
+                occluderShrinkMeters: record.occluderShrinkMeters,
+                exposureOffsetEV: record.exposureOffsetEV,
+                swapDistanceMeters: record.swapDistanceMeters
+            )
+        }
+
+        /// The record this link is written as, once the path sits in the string table.
+        public func record(entityId: UInt32, payloadPathOffset: UInt32) -> UntoldGaussianAssetRecordV1 {
+            UntoldGaussianAssetRecordV1(
+                entityId: entityId,
+                payloadPathOffset: payloadPathOffset,
+                flags: flags,
+                lodCount: UInt32(lodCount),
+                lodSplatCounts: lodSplatCounts,
+                lodSwitchScreenHeights: lodSwitchScreenHeights,
+                occluderShrinkMeters: occluderShrinkMeters,
+                exposureOffsetEV: exposureOffsetEV,
+                swapDistanceMeters: swapDistanceMeters
+            )
+        }
+
+        /// Throws `UntoldAssetPatcher.Error.invalidLink` when the link cannot be written as a
+        /// record `UntoldReader` would accept: an empty path or one containing NUL (the string
+        /// table is NUL-terminated), more than `UntoldGaussianAssetRecordV1.maxLODLevels` levels or
+        /// more LOD entries than levels, negative or non-finite distances, a non-finite exposure.
+        public func validate() throws {
+            guard !payloadPath.isEmpty else {
+                throw Error.invalidLink("payload path is empty")
+            }
+            guard !payloadPath.utf8.contains(0) else {
+                throw Error.invalidLink("payload path contains a NUL byte")
+            }
+            guard (0 ... UntoldGaussianAssetRecordV1.maxLODLevels).contains(lodCount) else {
+                throw Error.invalidLink("lodCount \(lodCount) is not in 0...\(UntoldGaussianAssetRecordV1.maxLODLevels)")
+            }
+            guard lodSplatCounts.count <= lodCount else {
+                throw Error.invalidLink("\(lodSplatCounts.count) lodSplatCounts for \(lodCount) levels")
+            }
+            guard lodSwitchScreenHeights.count <= lodCount else {
+                throw Error.invalidLink("\(lodSwitchScreenHeights.count) lodSwitchScreenHeights for \(lodCount) levels")
+            }
+            guard lodSwitchScreenHeights.allSatisfy(\.isFinite) else {
+                throw Error.invalidLink("lodSwitchScreenHeights must be finite")
+            }
+            guard occluderShrinkMeters.isFinite, occluderShrinkMeters >= 0 else {
+                throw Error.invalidLink("occluderShrinkMeters \(occluderShrinkMeters) must be finite and non-negative")
+            }
+            guard swapDistanceMeters.isFinite, swapDistanceMeters >= 0 else {
+                throw Error.invalidLink("swapDistanceMeters \(swapDistanceMeters) must be finite and non-negative")
+            }
+            guard exposureOffsetEV.isFinite else {
+                throw Error.invalidLink("exposureOffsetEV must be finite")
+            }
+        }
+    }
+
+    public enum Error: Swift.Error, Equatable, CustomStringConvertible {
+        /// The entity id is not in the file's entity table.
+        case unknownEntity(UInt32)
+        /// The link fails `GaussianAssetLink.validate()`; the payload says why.
+        case invalidLink(String)
+        /// The input did not read as a `.untold` file, or the patched output did not read back.
+        case corruptFile(String)
+
+        public var description: String {
+            switch self {
+            case let .unknownEntity(entityId):
+                "entity \(entityId) is not in the entity table"
+            case let .invalidLink(reason):
+                "invalid gaussianAsset link: \(reason)"
+            case let .corruptFile(reason):
+                "corrupt .untold file: \(reason)"
+            }
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Returns `fileData` with the `gaussianAsset` record for `entityId` set to `link`,
+    /// replacing an existing record for that entity. Every other chunk's stored bytes are
+    /// copied unchanged (compression preserved). The payload path is appended to the string
+    /// table unless an identical string already exists, whose offset is reused; the string
+    /// table is otherwise append-only, so every offset the other tables hold stays valid. The
+    /// gaussianAsset table chunk is replaced in place or appended; chunk offsets are laid out
+    /// again on 16-byte alignment, `header.chunkCount` is updated and `header.contentHash` is
+    /// recomputed — or kept all-zero when the input had an all-zero hash, since such a file is
+    /// read without the check.
+    public static func settingGaussianAsset(
+        _ link: GaussianAssetLink,
+        onEntity entityId: UInt32,
+        in fileData: Data
+    ) throws -> Data {
+        try link.validate()
+        let decoded = try decode(fileData)
+        guard decoded.entities.contains(where: { $0.entityId == entityId }) else {
+            throw Error.unknownEntity(entityId)
+        }
+
+        var stringTable = decoded.stringTableData
+        let pathOffset = try appendingStringIfNeeded(link.payloadPath, to: &stringTable)
+        let record = link.record(entityId: entityId, payloadPathOffset: pathOffset)
+
+        var records = decoded.gaussianAssets.filter { $0.entityId != entityId }
+        if let index = decoded.gaussianAssets.firstIndex(where: { $0.entityId == entityId }) {
+            records.insert(record, at: min(index, records.count))
+        } else {
+            records.append(record)
+        }
+
+        let result = try rebuild(decoded, fileData: fileData, stringTable: stringTable, gaussianAssets: records)
+        try verify(result) { asset in
+            asset.gaussianAssets.contains { $0.entityId == entityId && $0.payloadPathOffset == pathOffset }
+        }
+        return result
+    }
+
+    /// Returns `fileData` without the `gaussianAsset` record for `entityId`; the chunk is
+    /// dropped when the table becomes empty. Returns the input unchanged when the file carries
+    /// no record for that entity. The path string stays in the string table, which is
+    /// append-only. Throws `unknownEntity` when the entity is not in the entity table.
+    public static func removingGaussianAsset(onEntity entityId: UInt32, in fileData: Data) throws -> Data {
+        let decoded = try decode(fileData)
+        guard decoded.entities.contains(where: { $0.entityId == entityId }) else {
+            throw Error.unknownEntity(entityId)
+        }
+        guard decoded.gaussianAssets.contains(where: { $0.entityId == entityId }) else {
+            return fileData
+        }
+        let records = decoded.gaussianAssets.filter { $0.entityId != entityId }
+        let result = try rebuild(decoded, fileData: fileData, stringTable: decoded.stringTableData, gaussianAssets: records)
+        try verify(result) { asset in
+            !asset.gaussianAssets.contains { $0.entityId == entityId }
+        }
+        return result
+    }
+
+    /// The links a file carries, by entity id, with paths decoded from the string table. When
+    /// an entity has more than one record the first is kept, as `NativeFormatLoader` does.
+    public static func gaussianAssets(in fileData: Data) throws -> [UInt32: GaussianAssetLink] {
+        let decoded = try decode(fileData)
+        var links: [UInt32: GaussianAssetLink] = [:]
+        for record in decoded.gaussianAssets where links[record.entityId] == nil {
+            guard let path = try decoded.string(at: record.payloadPathOffset) else {
+                throw Error.corruptFile("gaussianAsset record for entity \(record.entityId) has no payload path")
+            }
+            links[record.entityId] = GaussianAssetLink(record: record, payloadPath: path)
+        }
+        return links
+    }
+
+    // MARK: - Reading
+
+    private static func decode(_ fileData: Data) throws -> UntoldDecodedAsset {
+        do {
+            return try UntoldReader().readAsset(from: fileData)
+        } catch {
+            throw Error.corruptFile(String(describing: error))
+        }
+    }
+
+    /// The patched file must read back, and carry what was asked for.
+    private static func verify(_ fileData: Data, _ check: (UntoldDecodedAsset) -> Bool) throws {
+        let asset: UntoldDecodedAsset
+        do {
+            asset = try UntoldReader().readAsset(from: fileData)
+        } catch {
+            throw Error.corruptFile("patched file does not read back: \(error)")
+        }
+        guard check(asset) else {
+            throw Error.corruptFile("patched file does not carry the requested gaussianAsset table")
+        }
+    }
+
+    // MARK: - String table
+
+    /// The offset of `string` in the table: an existing entry's when one is identical, else the
+    /// offset it is appended at. Entries are the NUL-terminated strings of the table, so the
+    /// match is on whole entries, never on the tail of a longer one.
+    static func appendingStringIfNeeded(_ string: String, to stringTable: inout Data) throws -> UInt32 {
+        let bytes = Array(string.utf8)
+        var entryStart = stringTable.startIndex
+        while entryStart < stringTable.endIndex {
+            guard let terminator = stringTable[entryStart...].firstIndex(of: 0) else { break }
+            if stringTable[entryStart ..< terminator].elementsEqual(bytes) {
+                return UInt32(entryStart - stringTable.startIndex)
+            }
+            entryStart = terminator + 1
+        }
+
+        var offset = stringTable.count
+        if entryStart < stringTable.endIndex {
+            // The table ends in an unterminated run of bytes; terminate it so the new entry
+            // does not extend a string that some record already points into.
+            stringTable.append(0)
+            offset = stringTable.count
+        }
+        guard offset <= Int(UInt32.max) - bytes.count - 1 else {
+            throw Error.invalidLink("string table too large for a 32-bit offset")
+        }
+        stringTable.append(contentsOf: bytes)
+        stringTable.append(0)
+        return UInt32(offset)
+    }
+
+    // MARK: - Layout
+
+    private struct ChunkPayload {
+        var entry: UntoldChunkEntryV1
+        var storedBytes: Data
+    }
+
+    /// Re-emits the file: the header, the chunk table, then every chunk payload on 16-byte
+    /// alignment in the input's chunk order. Chunks other than the string table and the
+    /// gaussianAsset table keep their stored bytes and entry fields; the two owned tables are
+    /// written uncompressed.
+    private static func rebuild(
+        _ decoded: UntoldDecodedAsset,
+        fileData: Data,
+        stringTable: Data,
+        gaussianAssets: [UntoldGaussianAssetRecordV1]
+    ) throws -> Data {
+        var payloads: [ChunkPayload] = []
+        payloads.reserveCapacity(decoded.chunks.count + 1)
+        for chunk in decoded.chunks {
+            switch chunk.chunkType {
+            case .stringTable:
+                var entry = chunk
+                entry.compressionType = .none
+                entry.compressedSize = UInt64(stringTable.count)
+                entry.uncompressedSize = UInt64(stringTable.count)
+                payloads.append(ChunkPayload(entry: entry, storedBytes: stringTable))
+            case .gaussianAssetTable:
+                guard !gaussianAssets.isEmpty else { continue }
+                payloads.append(gaussianAssetPayload(gaussianAssets, template: chunk))
+            default:
+                let start = Int(chunk.fileOffset)
+                let end = start + Int(chunk.compressedSize)
+                guard start >= 0, end <= fileData.count else {
+                    throw Error.corruptFile("chunk \(chunk.chunkType.rawValue) points outside the file")
+                }
+                payloads.append(ChunkPayload(entry: chunk, storedBytes: fileData.subdata(in: start ..< end)))
+            }
+        }
+        if !gaussianAssets.isEmpty, !decoded.chunks.contains(where: { $0.chunkType == .gaussianAssetTable }) {
+            payloads.append(gaussianAssetPayload(gaussianAssets, template: nil))
+        }
+
+        var header = decoded.header
+        header.chunkCount = UInt32(payloads.count)
+        let headerSize = encodedSize(of: header)
+        let chunkTableSize = encodedSize(of: UntoldChunkEntryV1(chunkType: .stringTable, fileOffset: 0, compressedSize: 0, uncompressedSize: 0)) * payloads.count
+        let alignment = Int(UntoldFormat.fileAlignment)
+
+        var runningOffset = headerSize + chunkTableSize
+        for index in payloads.indices {
+            runningOffset = aligned(runningOffset, to: alignment)
+            payloads[index].entry.fileOffset = UInt64(runningOffset)
+            payloads[index].entry.compressedSize = UInt64(payloads[index].storedBytes.count)
+            runningOffset += payloads[index].storedBytes.count
+        }
+
+        let file = UntoldBinaryWriter()
+        header.encode(to: file)
+        for payload in payloads {
+            payload.entry.encode(to: file)
+        }
+        for payload in payloads {
+            file.align(to: alignment)
+            file.writeData(payload.storedBytes)
+        }
+
+        // The hash covers the payloads alone, so the header is filled in once they are laid out.
+        guard header.contentHash.contains(where: { $0 != 0 }) else { return file.data }
+        var data = file.data
+        header.contentHash = try Array(UntoldFormat.contentHash(of: payloads.map(\.entry), in: data))
+        let headerWriter = UntoldBinaryWriter()
+        header.encode(to: headerWriter)
+        data.replaceSubrange(0 ..< headerSize, with: headerWriter.data)
+        return data
+    }
+
+    private static func gaussianAssetPayload(
+        _ records: [UntoldGaussianAssetRecordV1],
+        template: UntoldChunkEntryV1?
+    ) -> ChunkPayload {
+        let writer = UntoldBinaryWriter()
+        for record in records {
+            record.encode(to: writer)
+        }
+        var entry = template ?? UntoldChunkEntryV1(
+            chunkType: .gaussianAssetTable,
+            fileOffset: 0,
+            compressedSize: 0,
+            uncompressedSize: 0
+        )
+        entry.compressionType = .none
+        entry.compressedSize = UInt64(writer.count)
+        entry.uncompressedSize = UInt64(writer.count)
+        entry.elementCount = UInt32(records.count)
+        return ChunkPayload(entry: entry, storedBytes: writer.data)
+    }
+
+    private static func encodedSize(of value: some UntoldBinaryEncodable) -> Int {
+        let writer = UntoldBinaryWriter()
+        value.encode(to: writer)
+        return writer.count
+    }
+
+    private static func aligned(_ value: Int, to alignment: Int) -> Int {
+        let remainder = value % alignment
+        return remainder == 0 ? value : value + (alignment - remainder)
+    }
+}

--- a/Sources/UntoldEngine/AssetFormat/UntoldFormat.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldFormat.swift
@@ -13,6 +13,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import CryptoKit
 import Foundation
 import simd
 
@@ -46,6 +47,33 @@ public enum UntoldFormat {
     public static let fileAlignment: UInt64 = 16
     public static let invalidIndex: UInt32 = .max
     public static let hashByteCount = 32
+}
+
+public extension UntoldFormat {
+    /// The content hash of a `.untold` file: SHA-256 over the stored (compressed, when the
+    /// chunk is) payload bytes of every chunk, concatenated in ascending `chunkType` order.
+    /// Alignment padding between payloads is not hashed, and neither are the header or the
+    /// chunk table, so a writer can lay the chunks out first and fill the header in last.
+    /// This is what the exporter writes into `UntoldFileHeaderV1.contentHash`, what
+    /// `UntoldReader` checks on load (an all-zero header hash skips the check), and what
+    /// `UntoldAssetPatcher` recomputes after rewriting a file. Throws
+    /// `UntoldBinaryDecodingError.outOfBounds` when an entry points outside `fileData`.
+    static func contentHash(of chunks: [UntoldChunkEntryV1], in fileData: Data) throws -> Data {
+        var hasher = SHA256()
+        for chunk in chunks.sorted(by: { $0.chunkType.rawValue < $1.chunkType.rawValue }) {
+            let start = Int(chunk.fileOffset)
+            let end = start + Int(chunk.compressedSize)
+            guard start >= 0, end <= fileData.count else {
+                throw UntoldBinaryDecodingError.outOfBounds(
+                    offset: start,
+                    requested: Int(chunk.compressedSize),
+                    available: fileData.count
+                )
+            }
+            hasher.update(data: fileData.subdata(in: start ..< end))
+        }
+        return Data(hasher.finalize())
+    }
 }
 
 public enum UntoldFileType: UInt32, Sendable {

--- a/Sources/UntoldEngine/AssetFormat/UntoldFormat.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldFormat.swift
@@ -61,15 +61,19 @@ public extension UntoldFormat {
     static func contentHash(of chunks: [UntoldChunkEntryV1], in fileData: Data) throws -> Data {
         var hasher = SHA256()
         for chunk in chunks.sorted(by: { $0.chunkType.rawValue < $1.chunkType.rawValue }) {
-            let start = Int(chunk.fileOffset)
-            let end = start + Int(chunk.compressedSize)
-            guard start >= 0, end <= fileData.count else {
+            // Compared in UInt64 before converting so an entry whose offset or size does not
+            // fit an Int throws instead of trapping.
+            guard chunk.fileOffset <= UInt64(fileData.count),
+                  chunk.compressedSize <= UInt64(fileData.count) - chunk.fileOffset
+            else {
                 throw UntoldBinaryDecodingError.outOfBounds(
-                    offset: start,
-                    requested: Int(chunk.compressedSize),
+                    offset: Int(clamping: chunk.fileOffset),
+                    requested: Int(clamping: chunk.compressedSize),
                     available: fileData.count
                 )
             }
+            let start = Int(chunk.fileOffset)
+            let end = start + Int(chunk.compressedSize)
             hasher.update(data: fileData.subdata(in: start ..< end))
         }
         return Data(hasher.finalize())

--- a/Sources/UntoldEngine/AssetFormat/UntoldReader.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldReader.swift
@@ -13,7 +13,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import Compression
-import CryptoKit
 import Foundation
 
 public final class UntoldReader: @unchecked Sendable {
@@ -221,23 +220,7 @@ public final class UntoldReader: @unchecked Sendable {
         // fixtures built in Swift). Skip validation so those files continue to load.
         guard header.contentHash.contains(where: { $0 != 0 }) else { return }
 
-        // The exporter hashes raw chunk payloads concatenated in ascending chunk-type
-        // order. Alignment padding between payloads in the file is NOT included.
-        var hashInput = Data()
-        for chunk in chunks.sorted(by: { $0.chunkType.rawValue < $1.chunkType.rawValue }) {
-            let start = Int(chunk.fileOffset)
-            let end = start + Int(chunk.compressedSize)
-            guard start >= 0, end <= fileData.count else {
-                throw UntoldBinaryDecodingError.outOfBounds(
-                    offset: start,
-                    requested: Int(chunk.compressedSize),
-                    available: fileData.count
-                )
-            }
-            hashInput.append(fileData.subdata(in: start ..< end))
-        }
-
-        let computed = Array(SHA256.hash(data: hashInput))
+        let computed = try Array(UntoldFormat.contentHash(of: chunks, in: fileData))
         guard computed == header.contentHash else {
             throw UntoldValidationError.contentHashMismatch
         }

--- a/Tests/UntoldEngineRenderTests/UntoldAssetPatcherRenderTest.swift
+++ b/Tests/UntoldEngineRenderTests/UntoldAssetPatcherRenderTest.swift
@@ -1,0 +1,69 @@
+//
+//  UntoldAssetPatcherRenderTest.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Metal
+import simd
+@testable import UntoldEngine
+import XCTest
+
+/// A `.untold` the exporter cooked, linked to a splat payload by `UntoldAssetPatcher`, comes
+/// up through `setEntityMesh` with the link on the mesh entity as `GaussianAssetLinkComponent`.
+@MainActor
+final class UntoldAssetPatcherRenderTest: BaseRenderSetup {
+    private var temporaryFiles: [URL] = []
+
+    override func tearDown() async throws {
+        destroyAllEntities()
+        for url in temporaryFiles {
+            try? FileManager.default.removeItem(at: url)
+        }
+        temporaryFiles.removeAll()
+        try await super.tearDown()
+    }
+
+    override func initializeAssets() {}
+
+    func testPatchedCookedAssetArrivesAsALinkComponent() throws {
+        let sourceURL = try XCTUnwrap(Bundle.module.url(forResource: "singlecube", withExtension: "untold"))
+        let original = try Data(contentsOf: sourceURL)
+        let entityId = try XCTUnwrap(UntoldReader().readAsset(from: original).entities.first?.entityId)
+
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("UntoldAssetPatcherRenderTest-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        temporaryFiles.append(directory)
+        let link = UntoldAssetPatcher.GaussianAssetLink(
+            payloadPath: "singlecube.untoldgs",
+            lodCount: 1,
+            lodSplatCounts: [4096],
+            lodSwitchScreenHeights: [0],
+            occluderShrinkMeters: 0.03,
+            exposureOffsetEV: 0.5,
+            swapDistanceMeters: 12
+        )
+        let patched = try UntoldAssetPatcher.settingGaussianAsset(link, onEntity: entityId, in: original)
+        let untoldURL = directory.appendingPathComponent("singlecube.untold")
+        try patched.write(to: untoldURL, options: .atomic)
+
+        let entity = createEntity()
+        setEntityMesh(entityId: entity, filename: untoldURL.deletingPathExtension().path, withExtension: "untold")
+
+        XCTAssertNotNil(scene.get(component: RenderComponent.self, for: entity), "The cube mesh still loads")
+        let component = try XCTUnwrap(scene.get(component: GaussianAssetLinkComponent.self, for: entity), "The patched record arrives as link data")
+        XCTAssertEqual(component.payloadURL?.standardizedFileURL, directory.appendingPathComponent("singlecube.untoldgs").standardizedFileURL, "Payload resolved next to the .untold file")
+        XCTAssertTrue(component.isMeshTwin)
+        XCTAssertEqual(component.lodCount, 1)
+        XCTAssertEqual(component.lodSplatCounts, [4096])
+        XCTAssertEqual(component.lodSwitchScreenHeights, [0])
+        XCTAssertEqual(component.occluderShrinkMeters, 0.03)
+        XCTAssertEqual(component.exposureOffsetEV, 0.5)
+        XCTAssertEqual(component.swapDistanceMeters, 12)
+        XCTAssertNil(scene.get(component: GaussianComponent.self, for: entity), "Linking loads nothing")
+    }
+}

--- a/Tests/UntoldEngineTests/UntoldAssetPatcherTests.swift
+++ b/Tests/UntoldEngineTests/UntoldAssetPatcherTests.swift
@@ -101,14 +101,49 @@ final class UntoldAssetPatcherTests: XCTestCase {
         XCTAssertEqual(try decoded.string(at: decoded.gaussianAssets[0].payloadPathOffset), "chair.untoldgs")
     }
 
+    func testAStringThatIsAPrefixOrHasAPrefixOfAnotherIsNotReused() throws {
+        // Both directions: an entry the path starts ("chair.untoldgs.bak") and an entry that
+        // starts the path ("chair"). Only a whole-entry match may be reused.
+        let fixture = makeFixture(extraStrings: ["chair.untoldgs.bak", "chair"])
+
+        let patched = try UntoldAssetPatcher.settingGaussianAsset(
+            UntoldAssetPatcher.GaussianAssetLink(payloadPath: "chair.untoldgs"),
+            onEntity: 0,
+            in: fixture.fileData
+        )
+        let decoded = try UntoldReader().readAsset(from: patched)
+        let record = try XCTUnwrap(decoded.gaussianAssets.first)
+        XCTAssertEqual(record.payloadPathOffset, UInt32(fixture.stringTableData.count), "Appended as its own entry")
+        XCTAssertEqual(try decoded.string(at: record.payloadPathOffset), "chair.untoldgs")
+
+        // Offsets are byte offsets: a non-ASCII path lands after the bytes already written.
+        let accented = "Möbel/stühle.untoldgs"
+        let again = try UntoldAssetPatcher.settingGaussianAsset(
+            UntoldAssetPatcher.GaussianAssetLink(payloadPath: accented),
+            onEntity: 0,
+            in: patched
+        )
+        let decodedAgain = try UntoldReader().readAsset(from: again)
+        let accentedRecord = try XCTUnwrap(decodedAgain.gaussianAssets.first)
+        XCTAssertEqual(accentedRecord.payloadPathOffset, UInt32(fixture.stringTableData.count + "chair.untoldgs\0".utf8.count))
+        XCTAssertEqual(try decodedAgain.string(at: accentedRecord.payloadPathOffset), accented)
+        XCTAssertEqual(decodedAgain.stringTableData.count, fixture.stringTableData.count + "chair.untoldgs\0".utf8.count + accented.utf8.count + 1)
+    }
+
     func testSettingAgainReplacesTheRecordInPlace() throws {
         let fixture = makeFixture(entityCount: 2)
         let first = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "a.untoldgs", swapDistanceMeters: 5)
         let other = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "b.untoldgs")
         let replacement = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "c.untoldgs", occluderShrinkMeters: 0.1, swapDistanceMeters: 7)
 
-        var data = try UntoldAssetPatcher.settingGaussianAsset(first, onEntity: 0, in: fixture.fileData)
-        data = try UntoldAssetPatcher.settingGaussianAsset(other, onEntity: 1, in: data)
+        let once = try UntoldAssetPatcher.settingGaussianAsset(first, onEntity: 0, in: fixture.fileData)
+        XCTAssertEqual(
+            try UntoldAssetPatcher.settingGaussianAsset(first, onEntity: 0, in: once),
+            once,
+            "Setting an identical link is byte-identical: the path the replaced record points at is reused"
+        )
+
+        var data = try UntoldAssetPatcher.settingGaussianAsset(other, onEntity: 1, in: once)
         data = try UntoldAssetPatcher.settingGaussianAsset(replacement, onEntity: 0, in: data)
         let decoded = try UntoldReader().readAsset(from: data)
 
@@ -117,11 +152,51 @@ final class UntoldAssetPatcherTests: XCTestCase {
         XCTAssertEqual(decoded.chunks.filter { $0.chunkType == .gaussianAssetTable }.count, 1)
         XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: data), [0: replacement, 1: other])
 
-        // Append-only: the superseded path is still in the table, the others' offsets are intact.
+        // Append-only: the superseded path is still in the table, the others' offsets are intact,
+        // and exactly one string per distinct path was appended across the four sets.
         let table = decoded.stringTableData
         XCTAssertNotNil(range(of: "a.untoldgs", in: table))
+        XCTAssertEqual(table.count, fixture.stringTableData.count + "a.untoldgs\0b.untoldgs\0c.untoldgs\0".utf8.count)
         XCTAssertEqual(try decoded.string(at: fixture.entity.nameOffset), "root_entity")
         assertAligned(decoded.chunks)
+    }
+
+    func testALinkWithShortLODArraysRoundTripsEqual() throws {
+        // validate() allows fewer entries than lodCount; the record pads to four slots and the
+        // read-back keeps lodCount of them, so the link must already hold lodCount entries.
+        let short = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "a.untoldgs", lodCount: 2, lodSplatCounts: [1000])
+        XCTAssertEqual(short.lodSplatCounts, [1000, 0])
+        XCTAssertEqual(short.lodSwitchScreenHeights, [0, 0])
+        XCTAssertNoThrow(try short.validate())
+        XCTAssertEqual(
+            UntoldAssetPatcher.GaussianAssetLink(record: short.record(entityId: 0, payloadPathOffset: 0), payloadPath: short.payloadPath),
+            short
+        )
+
+        let fixture = makeFixture()
+        let data = try UntoldAssetPatcher.settingGaussianAsset(short, onEntity: 0, in: fixture.fileData)
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: data), [0: short])
+
+        let oneLevel = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "a.untoldgs", lodCount: 1)
+        XCTAssertEqual(oneLevel.lodSplatCounts, [0])
+        let oneLevelData = try UntoldAssetPatcher.settingGaussianAsset(oneLevel, onEntity: 0, in: fixture.fileData)
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: oneLevelData), [0: oneLevel])
+
+        // Longer arrays are not cut by the initializer; validate() still rejects them.
+        let long = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "a.untoldgs", lodCount: 1, lodSplatCounts: [1, 2])
+        XCTAssertEqual(long.lodSplatCounts, [1, 2])
+        XCTAssertThrowsError(try long.validate())
+    }
+
+    func testRecordOfAnInvalidLinkDoesNotTrap() {
+        let negative = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "a.untoldgs", lodCount: -1)
+        XCTAssertEqual(negative.lodSplatCounts, [])
+        XCTAssertThrowsError(try negative.validate())
+        XCTAssertEqual(negative.record(entityId: 3, payloadPathOffset: 7).lodCount, 0)
+
+        let tooMany = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "a.untoldgs", lodCount: 9)
+        XCTAssertEqual(tooMany.lodSplatCounts.count, UntoldGaussianAssetRecordV1.maxLODLevels)
+        XCTAssertEqual(tooMany.record(entityId: 3, payloadPathOffset: 7).lodCount, 9)
     }
 
     func testSettingOnAFileWithAZeroHashKeepsItZero() throws {
@@ -167,13 +242,24 @@ final class UntoldAssetPatcherTests: XCTestCase {
         )
         let decoded = try UntoldReader().readAsset(from: patched)
 
+        XCTAssertEqual(fixture.chunkEntries.map(\.chunkType.rawValue), [1, 2, 25, 3, 4, 5, 6, 7], "The fixture's table sits mid-file")
         XCTAssertEqual(decoded.chunks.count, fixture.chunkEntries.count, "Replaced, not appended")
+        XCTAssertEqual(decoded.chunks.map(\.chunkType), fixture.chunkEntries.map(\.chunkType), "Input chunk order preserved")
         XCTAssertEqual(decoded.chunks[tableIndex].chunkType, .gaussianAssetTable)
         XCTAssertEqual(decoded.chunks[tableIndex].elementCount, 2)
         XCTAssertEqual(decoded.gaussianAssets.map(\.entityId), [1, 0])
         XCTAssertEqual(decoded.gaussianAssets[0].swapDistanceMeters, 3, "The other entity's record is carried over")
         assertOtherChunksPreserved(original: fixture.fileData, patched: patched, except: [.stringTable, .gaussianAssetTable])
+        assertAligned(decoded.chunks)
         try assertContentHashValid(patched)
+
+        // Dropping the table from the middle keeps the others in order, hash still valid.
+        var removed = try UntoldAssetPatcher.removingGaussianAsset(onEntity: 0, in: patched)
+        removed = try UntoldAssetPatcher.removingGaussianAsset(onEntity: 1, in: removed)
+        let decodedRemoved = try UntoldReader().readAsset(from: removed)
+        XCTAssertEqual(decodedRemoved.chunks.map(\.chunkType.rawValue), [1, 2, 3, 4, 5, 6, 7])
+        assertOtherChunksPreserved(original: fixture.fileData, patched: removed, except: [.stringTable, .gaussianAssetTable])
+        try assertContentHashValid(removed)
     }
 
     // MARK: - Removing a link
@@ -280,6 +366,39 @@ final class UntoldAssetPatcherTests: XCTestCase {
         }
     }
 
+    /// The reader ignores a chunk of an unknown core type and skips the hash on a zero-hash file,
+    /// so it accepts entries the patcher then has to copy; sizes that do not fit an Int must throw,
+    /// not trap.
+    func testAnUnknownChunkPointingOutsideTheFileThrowsCorruptFile() throws {
+        let unknown = UntoldChunkType(rawValue: 0x7FFF)
+        let phantoms: [UntoldChunkEntryV1] = [
+            .init(chunkType: unknown, fileOffset: 1 << 20, compressedSize: 16, uncompressedSize: 16),
+            .init(chunkType: unknown, fileOffset: 0, compressedSize: .max, uncompressedSize: 0),
+            .init(chunkType: unknown, fileOffset: 16, compressedSize: UInt64(Int.max), uncompressedSize: 0),
+            .init(chunkType: unknown, fileOffset: 1 << 63, compressedSize: 0, uncompressedSize: 0),
+        ]
+        for phantom in phantoms {
+            let fixture = makeFixture(phantomEntries: [phantom], computeHash: false)
+            XCTAssertNoThrow(try UntoldReader().readAsset(from: fixture.fileData), "the reader accepts the entry")
+            XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: fixture.fileData), [:])
+            XCTAssertThrowsError(try UntoldAssetPatcher.settingGaussianAsset(.init(payloadPath: "chair.untoldgs"), onEntity: 0, in: fixture.fileData), "\(phantom)") { error in
+                XCTAssertEqual(error as? UntoldAssetPatcher.Error, .corruptFile("chunk 32767 points outside the file"))
+            }
+            let linked = makeFixture(gaussianRecords: [.init(entityId: 0, payloadPathOffset: 0)], phantomEntries: [phantom])
+            XCTAssertThrowsError(try UntoldAssetPatcher.removingGaussianAsset(onEntity: 0, in: linked.fileData), "\(phantom)") { error in
+                XCTAssertEqual(error as? UntoldAssetPatcher.Error, .corruptFile("chunk 32767 points outside the file"))
+            }
+        }
+
+        // An in-range entry of an unknown type is copied like any other chunk.
+        let inRange = UntoldChunkEntryV1(chunkType: unknown, fileOffset: 0, compressedSize: 16, uncompressedSize: 16)
+        let fixture = makeFixture(phantomEntries: [inRange])
+        let patched = try UntoldAssetPatcher.settingGaussianAsset(.init(payloadPath: "chair.untoldgs"), onEntity: 0, in: fixture.fileData)
+        let decoded = try UntoldReader().readAsset(from: patched)
+        let copied = try XCTUnwrap(decoded.chunks.first { $0.chunkType == unknown })
+        XCTAssertEqual(patched.subdata(in: Int(copied.fileOffset) ..< Int(copied.fileOffset) + 16), fixture.fileData.prefix(16))
+    }
+
     // MARK: - Content hash
 
     func testContentHashMatchesTheExporterConvention() throws {
@@ -294,6 +413,11 @@ final class UntoldAssetPatcherTests: XCTestCase {
 
         var outOfBounds = decoded.chunks
         outOfBounds[0].compressedSize = UInt64(fixture.fileData.count)
+        XCTAssertThrowsError(try UntoldFormat.contentHash(of: outOfBounds, in: fixture.fileData))
+        outOfBounds[0].compressedSize = .max
+        XCTAssertThrowsError(try UntoldFormat.contentHash(of: outOfBounds, in: fixture.fileData), "sizes beyond Int throw, not trap")
+        outOfBounds[0].compressedSize = 0
+        outOfBounds[0].fileOffset = 1 << 63
         XCTAssertThrowsError(try UntoldFormat.contentHash(of: outOfBounds, in: fixture.fileData))
     }
 
@@ -437,11 +561,16 @@ final class UntoldAssetPatcherTests: XCTestCase {
 
     /// A tile with `entityCount` one-triangle entities, LZ4-compressed vertex and index chunks
     /// (to prove the patcher copies stored bytes rather than re-encoding), optional extra strings
-    /// and an optional pre-existing gaussianAsset table.
+    /// and an optional pre-existing gaussianAsset table. That table sits right after the entity
+    /// table — chunk order [1, 2, 25, 3, 4, 5, 6, 7] — so the file order differs from the
+    /// ascending-type order the hash uses and a patcher that re-sorted or appended would show.
+    /// `phantomEntries` are chunk-table entries written without a payload (the reader ignores
+    /// unknown core chunk types), for entries that point outside the file.
     private func makeFixture(
         entityCount: Int = 1,
         extraStrings: [String] = [],
         gaussianRecords: [UntoldGaussianAssetRecordV1] = [],
+        phantomEntries: [UntoldChunkEntryV1] = [],
         computeHash: Bool = false
     ) -> Fixture {
         var strings = ["root_entity", "mesh_0", "mat_0", "albedo.ktx2"]
@@ -526,15 +655,15 @@ final class UntoldAssetPatcherTests: XCTestCase {
         ]
         if !gaussianRecords.isEmpty {
             let table = encodeRecords(gaussianRecords)
-            payloads.append((.gaussianAssetTable, table, .none, UInt64(table.count), UInt32(gaussianRecords.count)))
+            payloads.insert((.gaussianAssetTable, table, .none, UInt64(table.count), UInt32(gaussianRecords.count)), at: 2)
         }
-        header.chunkCount = UInt32(payloads.count)
+        header.chunkCount = UInt32(payloads.count + phantomEntries.count)
         if computeHash {
             let sorted = payloads.sorted { $0.0.rawValue < $1.0.rawValue }
             header.contentHash = Array(SHA256.hash(data: sorted.reduce(Data()) { $0 + $1.1 }))
         }
 
-        let (fileData, entries) = buildFileData(header: header, payloads: payloads)
+        let (fileData, entries) = buildFileData(header: header, payloads: payloads, phantomEntries: phantomEntries)
         return Fixture(
             fileData: fileData,
             header: header,
@@ -565,7 +694,8 @@ final class UntoldAssetPatcherTests: XCTestCase {
 
     private func buildFileData(
         header: UntoldFileHeaderV1,
-        payloads: [(UntoldChunkType, Data, UntoldCompressionType, UInt64, UInt32)]
+        payloads: [(UntoldChunkType, Data, UntoldCompressionType, UInt64, UInt32)],
+        phantomEntries: [UntoldChunkEntryV1] = []
     ) -> (Data, [UntoldChunkEntryV1]) {
         let headerWriter = UntoldBinaryWriter()
         header.encode(to: headerWriter)
@@ -575,7 +705,7 @@ final class UntoldAssetPatcherTests: XCTestCase {
             return remainder == 0 ? value : value + (alignment - remainder)
         }
 
-        var runningOffset = headerWriter.count + 40 * payloads.count
+        var runningOffset = headerWriter.count + 40 * (payloads.count + phantomEntries.count)
         var entries: [UntoldChunkEntryV1] = []
         for (chunkType, storedBytes, compression, uncompressedSize, elementCount) in payloads {
             runningOffset = aligned(runningOffset)
@@ -589,6 +719,7 @@ final class UntoldAssetPatcherTests: XCTestCase {
             ))
             runningOffset += storedBytes.count
         }
+        entries.append(contentsOf: phantomEntries)
 
         let writer = UntoldBinaryWriter()
         header.encode(to: writer)

--- a/Tests/UntoldEngineTests/UntoldAssetPatcherTests.swift
+++ b/Tests/UntoldEngineTests/UntoldAssetPatcherTests.swift
@@ -1,0 +1,623 @@
+//
+//  UntoldAssetPatcherTests.swift
+//  UntoldEngineTests
+//
+//  `UntoldAssetPatcher` rewrites the gaussianAsset table of a `.untold` file and nothing
+//  else: every other chunk keeps its stored bytes, the string table only grows, offsets stay
+//  16-byte aligned and the content hash follows.
+//
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Compression
+import CryptoKit
+import simd
+@testable import UntoldEngine
+import XCTest
+
+final class UntoldAssetPatcherTests: XCTestCase {
+    private var temporaryDirectories: [URL] = []
+
+    override func tearDown() {
+        for url in temporaryDirectories {
+            try? FileManager.default.removeItem(at: url)
+        }
+        temporaryDirectories.removeAll()
+        super.tearDown()
+    }
+
+    // MARK: - Setting a link
+
+    func testSettingALinkAppendsTheRecordAndKeepsEveryOtherChunk() throws {
+        let fixture = makeFixture(computeHash: true)
+        let link = UntoldAssetPatcher.GaussianAssetLink(
+            payloadPath: "Gaussians/chair.untoldgs",
+            lodCount: 2,
+            lodSplatCounts: [20000, 180_000],
+            lodSwitchScreenHeights: [120, 720],
+            occluderShrinkMeters: 0.03,
+            exposureOffsetEV: -0.5,
+            swapDistanceMeters: 12
+        )
+
+        let patched = try UntoldAssetPatcher.settingGaussianAsset(link, onEntity: 0, in: fixture.fileData)
+        let decoded = try UntoldReader().readAsset(from: patched)
+
+        XCTAssertEqual(decoded.gaussianAssets.count, 1)
+        let record = try XCTUnwrap(decoded.gaussianAssets.first)
+        XCTAssertEqual(record.entityId, 0)
+        XCTAssertEqual(try decoded.string(at: record.payloadPathOffset), "Gaussians/chair.untoldgs")
+        XCTAssertEqual(record.flags, UntoldGaussianAssetFlags.meshTwin)
+        XCTAssertEqual(record.lodCount, 2)
+        XCTAssertEqual(record.lodSplatCounts, [20000, 180_000, 0, 0])
+        XCTAssertEqual(record.lodSwitchScreenHeights, [120, 720, 0, 0])
+        XCTAssertEqual(record.occluderShrinkMeters, 0.03)
+        XCTAssertEqual(record.exposureOffsetEV, -0.5)
+        XCTAssertEqual(record.swapDistanceMeters, 12)
+        XCTAssertEqual(decoded.header.chunkCount, UInt32(fixture.chunkEntries.count + 1))
+        XCTAssertEqual(decoded.chunks.last?.chunkType, .gaussianAssetTable, "The new table is appended after the existing chunks")
+
+        // The path was appended to the string table; everything that was there is untouched.
+        XCTAssertEqual(decoded.stringTableData.prefix(fixture.stringTableData.count), fixture.stringTableData)
+        XCTAssertEqual(try decoded.string(at: fixture.entity.nameOffset), "root_entity")
+
+        assertOtherChunksPreserved(original: fixture.fileData, patched: patched, except: [.stringTable, .gaussianAssetTable])
+        assertAligned(decoded.chunks)
+        try assertContentHashValid(patched)
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: patched), [0: link])
+    }
+
+    func testSettingALinkReusesAnIdenticalString() throws {
+        let fixture = makeFixture(extraStrings: ["chair.untoldgs"])
+        let expectedOffset = try XCTUnwrap(fixture.stringOffsets["chair.untoldgs"])
+
+        let patched = try UntoldAssetPatcher.settingGaussianAsset(
+            UntoldAssetPatcher.GaussianAssetLink(payloadPath: "chair.untoldgs"),
+            onEntity: 0,
+            in: fixture.fileData
+        )
+        let decoded = try UntoldReader().readAsset(from: patched)
+
+        XCTAssertEqual(decoded.gaussianAssets.first?.payloadPathOffset, expectedOffset)
+        XCTAssertEqual(decoded.stringTableData, fixture.stringTableData, "No string appended")
+        assertOtherChunksPreserved(original: fixture.fileData, patched: patched, except: [.gaussianAssetTable])
+    }
+
+    func testAStringMatchingTheTailOfAnotherIsNotReused() throws {
+        let fixture = makeFixture(extraStrings: ["big_chair.untoldgs"])
+
+        let patched = try UntoldAssetPatcher.settingGaussianAsset(
+            UntoldAssetPatcher.GaussianAssetLink(payloadPath: "chair.untoldgs"),
+            onEntity: 0,
+            in: fixture.fileData
+        )
+        let decoded = try UntoldReader().readAsset(from: patched)
+
+        XCTAssertEqual(decoded.gaussianAssets.first?.payloadPathOffset, UInt32(fixture.stringTableData.count), "Appended as its own entry")
+        XCTAssertEqual(try decoded.string(at: decoded.gaussianAssets[0].payloadPathOffset), "chair.untoldgs")
+    }
+
+    func testSettingAgainReplacesTheRecordInPlace() throws {
+        let fixture = makeFixture(entityCount: 2)
+        let first = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "a.untoldgs", swapDistanceMeters: 5)
+        let other = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "b.untoldgs")
+        let replacement = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "c.untoldgs", occluderShrinkMeters: 0.1, swapDistanceMeters: 7)
+
+        var data = try UntoldAssetPatcher.settingGaussianAsset(first, onEntity: 0, in: fixture.fileData)
+        data = try UntoldAssetPatcher.settingGaussianAsset(other, onEntity: 1, in: data)
+        data = try UntoldAssetPatcher.settingGaussianAsset(replacement, onEntity: 0, in: data)
+        let decoded = try UntoldReader().readAsset(from: data)
+
+        XCTAssertEqual(decoded.gaussianAssets.count, 2, "One record per entity")
+        XCTAssertEqual(decoded.gaussianAssets.map(\.entityId), [0, 1], "The replaced record keeps its position")
+        XCTAssertEqual(decoded.chunks.filter { $0.chunkType == .gaussianAssetTable }.count, 1)
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: data), [0: replacement, 1: other])
+
+        // Append-only: the superseded path is still in the table, the others' offsets are intact.
+        let table = decoded.stringTableData
+        XCTAssertNotNil(range(of: "a.untoldgs", in: table))
+        XCTAssertEqual(try decoded.string(at: fixture.entity.nameOffset), "root_entity")
+        assertAligned(decoded.chunks)
+    }
+
+    func testSettingOnAFileWithAZeroHashKeepsItZero() throws {
+        let fixture = makeFixture(computeHash: false)
+        let patched = try UntoldAssetPatcher.settingGaussianAsset(
+            UntoldAssetPatcher.GaussianAssetLink(payloadPath: "chair.untoldgs"),
+            onEntity: 0,
+            in: fixture.fileData
+        )
+        let decoded = try UntoldReader().readAsset(from: patched)
+        XCTAssertEqual(decoded.header.contentHash, Array(repeating: 0, count: UntoldFormat.hashByteCount))
+    }
+
+    func testSettingRecomputesTheHashWhenTheInputHadOne() throws {
+        let fixture = makeFixture(computeHash: true)
+        let patched = try UntoldAssetPatcher.settingGaussianAsset(
+            UntoldAssetPatcher.GaussianAssetLink(payloadPath: "chair.untoldgs"),
+            onEntity: 0,
+            in: fixture.fileData
+        )
+        let decoded = try UntoldReader().readAsset(from: patched)
+        XCTAssertNotEqual(decoded.header.contentHash, fixture.header.contentHash, "The payloads changed, so did the hash")
+        try assertContentHashValid(patched)
+
+        // A flipped payload byte is caught by the reader, so the hash written is the one checked.
+        var corrupted = patched
+        let vertexChunk = try XCTUnwrap(decoded.chunks.first { $0.chunkType == .vertexData })
+        corrupted[Int(vertexChunk.fileOffset)] ^= 0xFF
+        XCTAssertThrowsError(try UntoldReader().readAsset(from: corrupted)) { error in
+            XCTAssertEqual(error as? UntoldValidationError, .contentHashMismatch)
+        }
+    }
+
+    func testSettingOnAFileThatAlreadyHasATableKeepsItsChunkPosition() throws {
+        let existing = UntoldGaussianAssetRecordV1(entityId: 1, payloadPathOffset: 0, flags: 0, swapDistanceMeters: 3)
+        let fixture = makeFixture(entityCount: 2, gaussianRecords: [existing], computeHash: true)
+        let tableIndex = try XCTUnwrap(fixture.chunkEntries.firstIndex { $0.chunkType == .gaussianAssetTable })
+
+        let patched = try UntoldAssetPatcher.settingGaussianAsset(
+            UntoldAssetPatcher.GaussianAssetLink(payloadPath: "chair.untoldgs"),
+            onEntity: 0,
+            in: fixture.fileData
+        )
+        let decoded = try UntoldReader().readAsset(from: patched)
+
+        XCTAssertEqual(decoded.chunks.count, fixture.chunkEntries.count, "Replaced, not appended")
+        XCTAssertEqual(decoded.chunks[tableIndex].chunkType, .gaussianAssetTable)
+        XCTAssertEqual(decoded.chunks[tableIndex].elementCount, 2)
+        XCTAssertEqual(decoded.gaussianAssets.map(\.entityId), [1, 0])
+        XCTAssertEqual(decoded.gaussianAssets[0].swapDistanceMeters, 3, "The other entity's record is carried over")
+        assertOtherChunksPreserved(original: fixture.fileData, patched: patched, except: [.stringTable, .gaussianAssetTable])
+        try assertContentHashValid(patched)
+    }
+
+    // MARK: - Removing a link
+
+    func testRemovingTheOnlyRecordDropsTheChunk() throws {
+        let fixture = makeFixture(computeHash: true)
+        let linked = try UntoldAssetPatcher.settingGaussianAsset(
+            UntoldAssetPatcher.GaussianAssetLink(payloadPath: "chair.untoldgs"),
+            onEntity: 0,
+            in: fixture.fileData
+        )
+
+        let removed = try UntoldAssetPatcher.removingGaussianAsset(onEntity: 0, in: linked)
+        let decoded = try UntoldReader().readAsset(from: removed)
+
+        XCTAssertTrue(decoded.gaussianAssets.isEmpty)
+        XCTAssertFalse(decoded.chunks.contains { $0.chunkType == .gaussianAssetTable })
+        XCTAssertEqual(decoded.header.chunkCount, UInt32(fixture.chunkEntries.count))
+        XCTAssertNotNil(range(of: "chair.untoldgs", in: decoded.stringTableData), "The string table is append-only")
+        assertOtherChunksPreserved(original: fixture.fileData, patched: removed, except: [.stringTable])
+        assertAligned(decoded.chunks)
+        try assertContentHashValid(removed)
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: removed), [:])
+    }
+
+    func testRemovingOneOfTwoRecordsKeepsTheOther() throws {
+        let fixture = makeFixture(entityCount: 2)
+        var data = try UntoldAssetPatcher.settingGaussianAsset(.init(payloadPath: "a.untoldgs"), onEntity: 0, in: fixture.fileData)
+        data = try UntoldAssetPatcher.settingGaussianAsset(.init(payloadPath: "b.untoldgs"), onEntity: 1, in: data)
+
+        let removed = try UntoldAssetPatcher.removingGaussianAsset(onEntity: 0, in: data)
+        let decoded = try UntoldReader().readAsset(from: removed)
+
+        XCTAssertEqual(decoded.gaussianAssets.map(\.entityId), [1])
+        XCTAssertEqual(decoded.chunks.first { $0.chunkType == .gaussianAssetTable }?.elementCount, 1)
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: removed), [1: .init(payloadPath: "b.untoldgs")])
+    }
+
+    func testRemovingWhenThereIsNoRecordReturnsTheInput() throws {
+        let fixture = makeFixture(computeHash: true)
+        XCTAssertEqual(try UntoldAssetPatcher.removingGaussianAsset(onEntity: 0, in: fixture.fileData), fixture.fileData)
+    }
+
+    // MARK: - Validation
+
+    func testUnknownEntityThrows() throws {
+        let fixture = makeFixture()
+        XCTAssertThrowsError(try UntoldAssetPatcher.settingGaussianAsset(.init(payloadPath: "chair.untoldgs"), onEntity: 42, in: fixture.fileData)) { error in
+            XCTAssertEqual(error as? UntoldAssetPatcher.Error, .unknownEntity(42))
+        }
+        XCTAssertThrowsError(try UntoldAssetPatcher.removingGaussianAsset(onEntity: 42, in: fixture.fileData)) { error in
+            XCTAssertEqual(error as? UntoldAssetPatcher.Error, .unknownEntity(42))
+        }
+    }
+
+    func testInvalidLinksThrow() throws {
+        let fixture = makeFixture()
+        var links: [UntoldAssetPatcher.GaussianAssetLink] = []
+        links.append(.init(payloadPath: ""))
+        links.append(.init(payloadPath: "chair\0.untoldgs"))
+        links.append(.init(payloadPath: "chair.untoldgs", lodCount: 5))
+        links.append(.init(payloadPath: "chair.untoldgs", lodCount: -1))
+        links.append(.init(payloadPath: "chair.untoldgs", lodCount: 1, lodSplatCounts: [1, 2]))
+        links.append(.init(payloadPath: "chair.untoldgs", lodCount: 1, lodSwitchScreenHeights: [1, 2]))
+        links.append(.init(payloadPath: "chair.untoldgs", lodCount: 1, lodSwitchScreenHeights: [.nan]))
+        links.append(.init(payloadPath: "chair.untoldgs", occluderShrinkMeters: -0.01))
+        links.append(.init(payloadPath: "chair.untoldgs", occluderShrinkMeters: .infinity))
+        links.append(.init(payloadPath: "chair.untoldgs", exposureOffsetEV: .nan))
+        links.append(.init(payloadPath: "chair.untoldgs", swapDistanceMeters: -1))
+        links.append(.init(payloadPath: "chair.untoldgs", swapDistanceMeters: .infinity))
+
+        for link in links {
+            XCTAssertThrowsError(try UntoldAssetPatcher.settingGaussianAsset(link, onEntity: 0, in: fixture.fileData), "\(link)") { error in
+                guard case .invalidLink? = error as? UntoldAssetPatcher.Error else {
+                    return XCTFail("unexpected error \(error) for \(link)")
+                }
+            }
+        }
+
+        // The edges of the ranges are fine.
+        let edge = UntoldAssetPatcher.GaussianAssetLink(
+            payloadPath: "chair.untoldgs",
+            lodCount: 4,
+            lodSplatCounts: [1, 2, 3, 4],
+            lodSwitchScreenHeights: [1, 2, 3, 4],
+            occluderShrinkMeters: 0,
+            exposureOffsetEV: -4,
+            swapDistanceMeters: 0
+        )
+        XCTAssertNoThrow(try UntoldAssetPatcher.settingGaussianAsset(edge, onEntity: 0, in: fixture.fileData))
+    }
+
+    func testCorruptInputThrows() throws {
+        let fixture = makeFixture()
+        XCTAssertThrowsError(try UntoldAssetPatcher.settingGaussianAsset(.init(payloadPath: "chair.untoldgs"), onEntity: 0, in: fixture.fileData.prefix(100))) { error in
+            guard case .corruptFile? = error as? UntoldAssetPatcher.Error else {
+                return XCTFail("unexpected error \(error)")
+            }
+        }
+        XCTAssertThrowsError(try UntoldAssetPatcher.gaussianAssets(in: Data("not an untold file".utf8))) { error in
+            guard case .corruptFile? = error as? UntoldAssetPatcher.Error else {
+                return XCTFail("unexpected error \(error)")
+            }
+        }
+    }
+
+    // MARK: - Content hash
+
+    func testContentHashMatchesTheExporterConvention() throws {
+        let fixture = makeFixture(computeHash: true)
+        let decoded = try UntoldReader().readAsset(from: fixture.fileData)
+        let hash = try UntoldFormat.contentHash(of: decoded.chunks, in: fixture.fileData)
+        XCTAssertEqual(Array(hash), fixture.header.contentHash)
+
+        // Ascending chunk type, whatever the table order: the same hash from a shuffled table.
+        let shuffled = try UntoldFormat.contentHash(of: decoded.chunks.reversed(), in: fixture.fileData)
+        XCTAssertEqual(shuffled, hash)
+
+        var outOfBounds = decoded.chunks
+        outOfBounds[0].compressedSize = UInt64(fixture.fileData.count)
+        XCTAssertThrowsError(try UntoldFormat.contentHash(of: outOfBounds, in: fixture.fileData))
+    }
+
+    // MARK: - Through the loader
+
+    func testPatchedFileLoadsWithTheLinkOnItsNode() throws {
+        let directory = try makeTemporaryDirectory()
+        let fixture = makeFixture(computeHash: true)
+        let link = UntoldAssetPatcher.GaussianAssetLink(
+            payloadPath: "Gaussians/chair.untoldgs",
+            lodCount: 1,
+            lodSplatCounts: [150_000],
+            lodSwitchScreenHeights: [0],
+            occluderShrinkMeters: 0.03,
+            exposureOffsetEV: 0.5,
+            swapDistanceMeters: 12
+        )
+        let patched = try UntoldAssetPatcher.settingGaussianAsset(link, onEntity: 0, in: fixture.fileData)
+        let untoldURL = directory.appendingPathComponent("chair.untold")
+        try patched.write(to: untoldURL)
+        let payloadDirectory = directory.appendingPathComponent("Gaussians")
+        try FileManager.default.createDirectory(at: payloadDirectory, withIntermediateDirectories: true)
+        try Data([0]).write(to: payloadDirectory.appendingPathComponent("chair.untoldgs"))
+
+        let asset = try NativeFormatLoader().loadAssetSync(from: untoldURL)
+        let node = try XCTUnwrap(asset.nodes.first { $0.id == 0 })
+        let runtimeLink = try XCTUnwrap(node.gaussianAsset)
+        XCTAssertEqual(runtimeLink.payloadURL.standardizedFileURL, payloadDirectory.appendingPathComponent("chair.untoldgs").standardizedFileURL)
+        XCTAssertEqual(runtimeLink.flags, UntoldGaussianAssetFlags.meshTwin)
+        XCTAssertEqual(runtimeLink.lodCount, 1)
+        XCTAssertEqual(runtimeLink.lodSplatCounts, [150_000])
+        XCTAssertEqual(runtimeLink.lodSwitchScreenHeights, [0])
+        XCTAssertEqual(runtimeLink.occluderShrinkMeters, 0.03)
+        XCTAssertEqual(runtimeLink.exposureOffsetEV, 0.5)
+        XCTAssertEqual(runtimeLink.swapDistanceMeters, 12)
+    }
+
+    /// A file the real exporter wrote (with a content hash) survives the round trip: every chunk
+    /// but the two the patcher owns is byte-identical, the hash is valid and the loader sees the link.
+    func testRealCookedFixtureRoundTrips() throws {
+        let sourceURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("UntoldEngineRenderTests/Resources/Models/singlecube/singlecube.untold")
+        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
+            throw XCTSkip("cooked fixture not found at \(sourceURL.path)")
+        }
+        let original = try Data(contentsOf: sourceURL)
+        let originalAsset = try UntoldReader().readAsset(from: original)
+        XCTAssertTrue(originalAsset.header.contentHash.contains { $0 != 0 }, "The exporter writes a hash")
+        XCTAssertTrue(originalAsset.gaussianAssets.isEmpty)
+        let entityId = try XCTUnwrap(originalAsset.entities.first?.entityId)
+
+        let link = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "singlecube.untoldgs", lodCount: 1, lodSplatCounts: [4096], lodSwitchScreenHeights: [0], swapDistanceMeters: 8)
+        let patched = try UntoldAssetPatcher.settingGaussianAsset(link, onEntity: entityId, in: original)
+        let decoded = try UntoldReader().readAsset(from: patched)
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: patched), [entityId: link])
+        XCTAssertEqual(decoded.entities, originalAsset.entities)
+        XCTAssertEqual(decoded.meshes, originalAsset.meshes)
+        XCTAssertEqual(decoded.materials, originalAsset.materials)
+        XCTAssertEqual(decoded.textures, originalAsset.textures)
+        assertOtherChunksPreserved(original: original, patched: patched, except: [.stringTable, .gaussianAssetTable])
+        assertAligned(decoded.chunks)
+        try assertContentHashValid(patched)
+
+        let directory = try makeTemporaryDirectory()
+        let untoldURL = directory.appendingPathComponent("singlecube.untold")
+        try patched.write(to: untoldURL)
+        let asset = try NativeFormatLoader().loadAssetSync(from: untoldURL)
+        let node = try XCTUnwrap(asset.nodes.first { $0.id == entityId })
+        XCTAssertEqual(node.gaussianAsset?.payloadURL.lastPathComponent, "singlecube.untoldgs")
+        XCTAssertEqual(node.gaussianAsset?.swapDistanceMeters, 8)
+
+        let removed = try UntoldAssetPatcher.removingGaussianAsset(onEntity: entityId, in: patched)
+        XCTAssertEqual(try UntoldReader().readAsset(from: removed).chunks.count, originalAsset.chunks.count)
+        try assertContentHashValid(removed)
+    }
+
+    // MARK: - Assertions
+
+    /// Every chunk not in `except` has the same stored bytes (and entry fields other than the
+    /// offset) before and after the patch.
+    private func assertOtherChunksPreserved(original: Data, patched: Data, except: Set<UntoldChunkType>, file: StaticString = #filePath, line: UInt = #line) {
+        guard let before = try? UntoldReader().readAsset(from: original), let after = try? UntoldReader().readAsset(from: patched) else {
+            return XCTFail("both files must read", file: file, line: line)
+        }
+        for entry in before.chunks where !except.contains(entry.chunkType) {
+            guard let counterpart = after.chunks.first(where: { $0.chunkType == entry.chunkType }) else {
+                XCTFail("chunk \(entry.chunkType.rawValue) is missing after the patch", file: file, line: line)
+                continue
+            }
+            XCTAssertEqual(counterpart.compressionType, entry.compressionType, "chunk \(entry.chunkType.rawValue)", file: file, line: line)
+            XCTAssertEqual(counterpart.compressedSize, entry.compressedSize, "chunk \(entry.chunkType.rawValue)", file: file, line: line)
+            XCTAssertEqual(counterpart.uncompressedSize, entry.uncompressedSize, "chunk \(entry.chunkType.rawValue)", file: file, line: line)
+            XCTAssertEqual(counterpart.elementCount, entry.elementCount, "chunk \(entry.chunkType.rawValue)", file: file, line: line)
+            let beforeBytes = original.subdata(in: Int(entry.fileOffset) ..< Int(entry.fileOffset + entry.compressedSize))
+            let afterBytes = patched.subdata(in: Int(counterpart.fileOffset) ..< Int(counterpart.fileOffset + counterpart.compressedSize))
+            XCTAssertEqual(afterBytes, beforeBytes, "stored bytes of chunk \(entry.chunkType.rawValue)", file: file, line: line)
+        }
+    }
+
+    private func assertAligned(_ chunks: [UntoldChunkEntryV1], file: StaticString = #filePath, line: UInt = #line) {
+        for chunk in chunks {
+            XCTAssertEqual(chunk.fileOffset % UntoldFormat.fileAlignment, 0, "chunk \(chunk.chunkType.rawValue) at \(chunk.fileOffset)", file: file, line: line)
+        }
+    }
+
+    /// The header hash is non-zero and is the SHA-256 the exporter convention defines, computed
+    /// here independently of `UntoldFormat.contentHash`.
+    private func assertContentHashValid(_ fileData: Data, file: StaticString = #filePath, line: UInt = #line) throws {
+        let decoded = try UntoldReader().readAsset(from: fileData)
+        XCTAssertTrue(decoded.header.contentHash.contains { $0 != 0 }, "hash present", file: file, line: line)
+        var input = Data()
+        for chunk in decoded.chunks.sorted(by: { $0.chunkType.rawValue < $1.chunkType.rawValue }) {
+            input.append(fileData.subdata(in: Int(chunk.fileOffset) ..< Int(chunk.fileOffset + chunk.compressedSize)))
+        }
+        XCTAssertEqual(decoded.header.contentHash, Array(SHA256.hash(data: input)), file: file, line: line)
+    }
+
+    private func range(of string: String, in table: Data) -> Range<Data.Index>? {
+        table.range(of: Data(string.utf8) + [0])
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("UntoldAssetPatcherTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        temporaryDirectories.append(url)
+        return url
+    }
+
+    // MARK: - Fixture
+
+    private struct Fixture {
+        var fileData: Data
+        var header: UntoldFileHeaderV1
+        var chunkEntries: [UntoldChunkEntryV1]
+        var stringTableData: Data
+        var stringOffsets: [String: UInt32]
+        var entity: UntoldEntityRecordV1
+    }
+
+    /// A tile with `entityCount` one-triangle entities, LZ4-compressed vertex and index chunks
+    /// (to prove the patcher copies stored bytes rather than re-encoding), optional extra strings
+    /// and an optional pre-existing gaussianAsset table.
+    private func makeFixture(
+        entityCount: Int = 1,
+        extraStrings: [String] = [],
+        gaussianRecords: [UntoldGaussianAssetRecordV1] = [],
+        computeHash: Bool = false
+    ) -> Fixture {
+        var strings = ["root_entity", "mesh_0", "mat_0", "albedo.ktx2"]
+        strings.append(contentsOf: (1 ..< entityCount).map { "entity_\($0)" })
+        strings.append(contentsOf: extraStrings)
+        let stringTable = makeStringTable(strings)
+        let bounds = UntoldAABB(min: SIMD3<Float>(-1, -1, -1), max: SIMD3<Float>(1, 1, 1))
+
+        let vertexWriter = UntoldBinaryWriter()
+        for position in [SIMD3<Float>(-1, -1, 0), SIMD3<Float>(1, -1, 0), SIMD3<Float>(0, 1, 0)] {
+            UntoldPBRStaticVertexV1(
+                position: position,
+                normalPacked: UntoldVertexPacking.packNormal(SIMD3<Float>(0, 0, 1)),
+                tangentPacked: UntoldVertexPacking.packTangent(SIMD3<Float>(1, 0, 0), handedness: 1)
+            ).encode(to: vertexWriter)
+        }
+        let vertexData = vertexWriter.data
+        let indexWriter = UntoldBinaryWriter()
+        for index in [0, 1, 2] as [UInt16] {
+            indexWriter.writeUInt16LE(index)
+        }
+        let indexData = indexWriter.data
+
+        var entities: [UntoldEntityRecordV1] = []
+        var meshes: [UntoldMeshRecordV1] = []
+        for index in 0 ..< entityCount {
+            let name = index == 0 ? "root_entity" : "entity_\(index)"
+            entities.append(UntoldEntityRecordV1(
+                entityId: UInt32(index),
+                nameOffset: stringTable.offsets[name]!,
+                firstMeshRecordIndex: UInt32(index),
+                meshRecordCount: 1,
+                localBounds: bounds,
+                worldBounds: bounds
+            ))
+            meshes.append(UntoldMeshRecordV1(
+                entityId: UInt32(index),
+                meshNameOffset: stringTable.offsets["mesh_0"]!,
+                materialIndex: 0,
+                indexType: .uint16,
+                vertexCount: 3,
+                indexCount: 3,
+                vertexStrideBytes: 32,
+                vertexDataOffset: 0,
+                indexDataOffset: 0,
+                vertexDataSizeBytes: UInt64(vertexData.count),
+                indexDataSizeBytes: UInt64(indexData.count),
+                estimatedGPUBytes: UInt64(vertexData.count + indexData.count),
+                localBounds: bounds
+            ))
+        }
+        let material = UntoldMaterialRecordV1(nameOffset: stringTable.offsets["mat_0"]!, baseColorTextureIndex: 0)
+        let texture = UntoldTextureRefRecordV1(
+            nameOffset: stringTable.offsets["albedo.ktx2"]!,
+            uriOffset: stringTable.offsets["albedo.ktx2"]!,
+            textureFormat: .rgba8,
+            width: 16,
+            height: 16,
+            mipCount: 1
+        )
+
+        var header = UntoldFileHeaderV1(
+            fileType: .tile,
+            chunkCount: 0,
+            meshCount: UInt32(meshes.count),
+            materialCount: 1,
+            textureRefCount: 1,
+            entityCount: UInt32(entities.count),
+            vertexLayout: .pbrStaticV1,
+            worldBounds: bounds
+        )
+
+        // (type, stored bytes, compression, uncompressed size, element count)
+        var payloads: [(UntoldChunkType, Data, UntoldCompressionType, UInt64, UInt32)] = [
+            (.stringTable, stringTable.data, .none, UInt64(stringTable.data.count), 0),
+            (.entityTable, encodeRecords(entities), .none, UInt64(encodeRecords(entities).count), UInt32(entities.count)),
+            (.meshTable, encodeRecords(meshes), .none, UInt64(encodeRecords(meshes).count), UInt32(meshes.count)),
+            (.materialTable, encodeRecords([material]), .none, UInt64(encodeRecords([material]).count), 1),
+            (.textureTable, encodeRecords([texture]), .none, UInt64(encodeRecords([texture]).count), 1),
+            (.vertexData, lz4Compress(vertexData), .lz4, UInt64(vertexData.count), 0),
+            (.indexData, lz4Compress(indexData), .lz4, UInt64(indexData.count), 0),
+        ]
+        if !gaussianRecords.isEmpty {
+            let table = encodeRecords(gaussianRecords)
+            payloads.append((.gaussianAssetTable, table, .none, UInt64(table.count), UInt32(gaussianRecords.count)))
+        }
+        header.chunkCount = UInt32(payloads.count)
+        if computeHash {
+            let sorted = payloads.sorted { $0.0.rawValue < $1.0.rawValue }
+            header.contentHash = Array(SHA256.hash(data: sorted.reduce(Data()) { $0 + $1.1 }))
+        }
+
+        let (fileData, entries) = buildFileData(header: header, payloads: payloads)
+        return Fixture(
+            fileData: fileData,
+            header: header,
+            chunkEntries: entries,
+            stringTableData: stringTable.data,
+            stringOffsets: stringTable.offsets,
+            entity: entities[0]
+        )
+    }
+
+    private func encodeRecords(_ records: [some UntoldBinaryEncodable]) -> Data {
+        let writer = UntoldBinaryWriter()
+        for record in records {
+            record.encode(to: writer)
+        }
+        return writer.data
+    }
+
+    private func makeStringTable(_ strings: [String]) -> (data: Data, offsets: [String: UInt32]) {
+        let writer = UntoldBinaryWriter()
+        var offsets: [String: UInt32] = [:]
+        for string in strings {
+            offsets[string] = UInt32(writer.count)
+            writer.writeNullTerminatedUTF8(string)
+        }
+        return (writer.data, offsets)
+    }
+
+    private func buildFileData(
+        header: UntoldFileHeaderV1,
+        payloads: [(UntoldChunkType, Data, UntoldCompressionType, UInt64, UInt32)]
+    ) -> (Data, [UntoldChunkEntryV1]) {
+        let headerWriter = UntoldBinaryWriter()
+        header.encode(to: headerWriter)
+        let alignment = Int(UntoldFormat.fileAlignment)
+        func aligned(_ value: Int) -> Int {
+            let remainder = value % alignment
+            return remainder == 0 ? value : value + (alignment - remainder)
+        }
+
+        var runningOffset = headerWriter.count + 40 * payloads.count
+        var entries: [UntoldChunkEntryV1] = []
+        for (chunkType, storedBytes, compression, uncompressedSize, elementCount) in payloads {
+            runningOffset = aligned(runningOffset)
+            entries.append(UntoldChunkEntryV1(
+                chunkType: chunkType,
+                compressionType: compression,
+                fileOffset: UInt64(runningOffset),
+                compressedSize: UInt64(storedBytes.count),
+                uncompressedSize: uncompressedSize,
+                elementCount: elementCount
+            ))
+            runningOffset += storedBytes.count
+        }
+
+        let writer = UntoldBinaryWriter()
+        header.encode(to: writer)
+        for entry in entries {
+            entry.encode(to: writer)
+        }
+        for (_, storedBytes, _, _, _) in payloads {
+            writer.align(to: alignment)
+            writer.writeData(storedBytes)
+        }
+        return (writer.data, entries)
+    }
+
+    /// COMPRESSION_LZ4_RAW, the algorithm the runtime decompresses.
+    private func lz4Compress(_ input: Data) -> Data {
+        let maxSize = max(input.count + 64, 128)
+        var output = Data(count: maxSize)
+        let written: Int = output.withUnsafeMutableBytes { outBuf in
+            input.withUnsafeBytes { inBuf in
+                compression_encode_buffer(
+                    outBuf.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                    maxSize,
+                    inBuf.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                    input.count,
+                    nil,
+                    COMPRESSION_LZ4_RAW
+                )
+            }
+        }
+        return output.prefix(written)
+    }
+}

--- a/Tools/UntoldEngineCLI/Package.swift
+++ b/Tools/UntoldEngineCLI/Package.swift
@@ -44,5 +44,11 @@ let package = Package(
             resources: [.process("Resources")],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
+        .testTarget(
+            name: "UntoldEngineCLITests",
+            dependencies: ["UntoldEngineCLI"],
+            path: "Tests/UntoldEngineCLITests",
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        ),
     ]
 )

--- a/Tools/UntoldEngineCLI/README.md
+++ b/Tools/UntoldEngineCLI/README.md
@@ -83,6 +83,20 @@ untoldengine export \
   --compress-geometry
 ```
 
+### `gaussian-link` - Link an entity to a splat payload
+
+Writes, removes or lists the `gaussianAsset` records of a `.untold` asset so an
+entity's mesh gets a cooked `.untoldgs` twin. Every other chunk of the file is
+copied unchanged. The payload path is stored relative to the `.untold` file's
+directory; keep the payload inside or beside it.
+
+```bash
+untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \
+  --payload Chair/chair.untoldgs --swap-distance 8 --occluder-shrink 0.02 --in-place
+untoldengine gaussian-link --untold Chair/chair.untold --entity 0 --remove --output Chair/chair_plain.untold
+untoldengine gaussian-link --untold Chair/chair.untold --list
+```
+
 ### `create` - Create a new project
 
 Creates a new UntoldEngine game project.

--- a/Tools/UntoldEngineCLI/README.md
+++ b/Tools/UntoldEngineCLI/README.md
@@ -87,13 +87,17 @@ untoldengine export \
 
 Writes, removes or lists the `gaussianAsset` records of a `.untold` asset so an
 entity's mesh gets a cooked `.untoldgs` twin. Every other chunk of the file is
-copied unchanged. The payload path is stored relative to the `.untold` file's
-directory; keep the payload inside or beside it.
+copied unchanged. The payload path is stored relative to the directory of the
+file that is written (the input with `--in-place`, the `--output` file
+otherwise), which is where the runtime resolves it; keep the payload inside or
+beside that file. A `meshTwin` link on an entity without a mesh (the root of a
+multi-node asset) is written with a warning that lists the mesh-bearing entities.
 
 ```bash
 untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \
   --payload Chair/chair.untoldgs --swap-distance 8 --occluder-shrink 0.02 --in-place
-untoldengine gaussian-link --untold Chair/chair.untold --entity 0 --remove --output Chair/chair_plain.untold
+untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \
+  --remove --output Chair/chair_plain.untold
 untoldengine gaussian-link --untold Chair/chair.untold --list
 ```
 

--- a/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/GaussianLinkCommand.swift
+++ b/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/GaussianLinkCommand.swift
@@ -1,0 +1,233 @@
+//
+//  GaussianLinkCommand.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import ArgumentParser
+import Foundation
+import UntoldEngine
+
+struct GaussianLinkCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "gaussian-link",
+        abstract: "Link an entity of a .untold asset to a cooked .untoldgs splat payload",
+        discussion: """
+        Writes, removes or lists the gaussianAsset records of a .untold file (chunk 25,
+        UntoldGaussianAssetRecordV1) through UntoldAssetPatcher. Every other chunk of the
+        file is copied byte for byte; the string table only grows.
+
+        The payload path is stored relative to the .untold file's directory when the
+        payload sits inside or beside it, otherwise as the bare file name (with a
+        warning) — the runtime resolves it next to the .untold file. The payload must be
+        a version 3 .untoldgs; its splat count fills the record's single LOD level.
+
+        Examples:
+          untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \\
+            --payload Chair/chair.untoldgs --swap-distance 8 --in-place
+          untoldengine gaussian-link --untold Chair/chair.untold --entity 0 --remove --output Chair/chair_plain.untold
+          untoldengine gaussian-link --untold Chair/chair.untold --list
+        """
+    )
+
+    @Option(name: .long, help: "The .untold asset to patch or list")
+    var untold: String
+
+    @Option(name: .long, help: "Entity id (the entity table's entityId) the link is set on or removed from")
+    var entity: UInt32?
+
+    @Option(name: .long, help: "The cooked .untoldgs payload to link")
+    var payload: String?
+
+    @Option(name: .customLong("swap-distance"), help: "Camera distance in metres at which the swap arms (0 = always)")
+    var swapDistance: Float = 0
+
+    @Option(name: .customLong("occluder-shrink"), help: "Metres the mesh twin's depth-only occluder shell is shrunk along its normals")
+    var occluderShrink: Float = 0.02
+
+    @Option(name: .customLong("exposure-offset"), help: "Exposure offset in EV on top of the payload's capture exposure")
+    var exposureOffset: Float = 0
+
+    @Flag(name: .customLong("in-place"), help: "Overwrite the .untold file")
+    var inPlace = false
+
+    @Option(name: .long, help: "Write the patched file here instead of overwriting the input")
+    var output: String?
+
+    @Flag(name: .long, help: "Remove the entity's link instead of setting one")
+    var remove = false
+
+    @Flag(name: .long, help: "Print the links the file carries and exit")
+    var list = false
+
+    func validate() throws {
+        if list {
+            guard !remove, payload == nil, !inPlace, output == nil else {
+                throw ValidationError("--list takes no other option than --untold.")
+            }
+            return
+        }
+        guard entity != nil else {
+            throw ValidationError("Provide --entity (or --list).")
+        }
+        guard inPlace != (output != nil) else {
+            throw ValidationError("Provide exactly one of --in-place or --output.")
+        }
+        if remove {
+            guard payload == nil else {
+                throw ValidationError("--remove takes no --payload.")
+            }
+        } else {
+            guard payload != nil else {
+                throw ValidationError("Provide --payload, --remove or --list.")
+            }
+        }
+    }
+
+    func run() throws {
+        let untoldURL = resolvePath(untold).standardizedFileURL
+        guard FileManager.default.fileExists(atPath: untoldURL.path) else {
+            throw GaussianLinkError.untoldNotFound(untoldURL.path)
+        }
+        let fileData = try Data(contentsOf: untoldURL)
+
+        if list {
+            for line in try Self.listing(of: fileData) {
+                print(line)
+            }
+            return
+        }
+
+        guard let entity else { return } // validate() guarantees it
+        let patched: Data
+        if remove {
+            patched = try Self.removing(entity: entity, from: fileData)
+            printInfo("Removed the gaussianAsset link of entity \(entity)")
+        } else {
+            guard let payload else { return } // validate() guarantees it
+            let payloadURL = resolvePath(payload).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: payloadURL.path) else {
+                throw GaussianLinkError.payloadNotFound(payloadURL.path)
+            }
+            let stored = Self.storedPayloadPath(payloadURL: payloadURL, untoldURL: untoldURL)
+            if !stored.isRelative {
+                printWarning("\(payloadURL.path) is not inside \(untoldURL.deletingLastPathComponent().path); storing the file name \(stored.path) — keep the payload next to the .untold file")
+            }
+            let link = try Self.makeLink(
+                payloadURL: payloadURL,
+                storedPath: stored.path,
+                swapDistance: swapDistance,
+                occluderShrink: occluderShrink,
+                exposureOffset: exposureOffset
+            )
+            patched = try Self.setting(link, entity: entity, in: fileData)
+            printInfo("Linked entity \(entity) to \(stored.path) (\(link.lodSplatCounts.first ?? 0) splats, swap at \(swapDistance) m, shrink \(occluderShrink) m, \(exposureOffset) EV)")
+        }
+
+        let destination = output.map { resolvePath($0).standardizedFileURL } ?? untoldURL
+        try patched.write(to: destination, options: .atomic)
+        printSuccess("Wrote \(destination.path)")
+    }
+
+    // MARK: - Logic (kept free of ArgumentParser so tests can call it)
+
+    /// The path written into the record: relative to the `.untold` file's directory when the
+    /// payload is inside or beside it, else the bare file name.
+    static func storedPayloadPath(payloadURL: URL, untoldURL: URL) -> (path: String, isRelative: Bool) {
+        let directory = untoldURL.deletingLastPathComponent().standardizedFileURL.resolvingSymlinksInPath().pathComponents
+        let payload = payloadURL.standardizedFileURL.resolvingSymlinksInPath().pathComponents
+        guard payload.count > directory.count, Array(payload.prefix(directory.count)) == directory else {
+            return (payloadURL.lastPathComponent, false)
+        }
+        return (payload.dropFirst(directory.count).joined(separator: "/"), true)
+    }
+
+    /// The link for a payload: its header (which must be version 3) fills one LOD level with
+    /// the file's splat count.
+    static func makeLink(
+        payloadURL: URL,
+        storedPath: String,
+        swapDistance: Float,
+        occluderShrink: Float,
+        exposureOffset: Float
+    ) throws -> UntoldAssetPatcher.GaussianAssetLink {
+        let header: UntoldGSHeaderV3
+        do {
+            header = try UntoldGSFormat.readHeaderV3(from: payloadURL)
+        } catch let error as UntoldGSError {
+            throw GaussianLinkError.invalidPayload(payloadURL.path, error.description)
+        }
+        return UntoldAssetPatcher.GaussianAssetLink(
+            payloadPath: storedPath,
+            flags: UntoldGaussianAssetFlags.meshTwin,
+            lodCount: 1,
+            lodSplatCounts: [header.splatCount],
+            lodSwitchScreenHeights: [0],
+            occluderShrinkMeters: occluderShrink,
+            exposureOffsetEV: exposureOffset,
+            swapDistanceMeters: swapDistance
+        )
+    }
+
+    static func setting(_ link: UntoldAssetPatcher.GaussianAssetLink, entity: UInt32, in fileData: Data) throws -> Data {
+        do {
+            return try UntoldAssetPatcher.settingGaussianAsset(link, onEntity: entity, in: fileData)
+        } catch let error as UntoldAssetPatcher.Error {
+            throw GaussianLinkError.patchFailed(error.description)
+        }
+    }
+
+    static func removing(entity: UInt32, from fileData: Data) throws -> Data {
+        do {
+            return try UntoldAssetPatcher.removingGaussianAsset(onEntity: entity, in: fileData)
+        } catch let error as UntoldAssetPatcher.Error {
+            throw GaussianLinkError.patchFailed(error.description)
+        }
+    }
+
+    /// One line per link, by entity id, or a single "no gaussianAsset links" line.
+    static func listing(of fileData: Data) throws -> [String] {
+        let links: [UInt32: UntoldAssetPatcher.GaussianAssetLink]
+        do {
+            links = try UntoldAssetPatcher.gaussianAssets(in: fileData)
+        } catch let error as UntoldAssetPatcher.Error {
+            throw GaussianLinkError.patchFailed(error.description)
+        }
+        guard !links.isEmpty else { return ["no gaussianAsset links"] }
+        return links.keys.sorted().map { entity in
+            let link = links[entity]!
+            let names: [(UInt32, String)] = [
+                (UntoldGaussianAssetFlags.meshTwin, "meshTwin"),
+                (UntoldGaussianAssetFlags.environment, "environment"),
+                (UntoldGaussianAssetFlags.windowWorld, "windowWorld"),
+            ]
+            let flags = names.filter { link.flags & $0.0 != 0 }.map(\.1)
+            let levels = link.lodCount == 0 ? "1 level" : "\(link.lodCount) level\(link.lodCount == 1 ? "" : "s") \(link.lodSplatCounts)"
+            return "entity \(entity): \(link.payloadPath) [\(flags.joined(separator: ","))] \(levels), swap \(link.swapDistanceMeters) m, shrink \(link.occluderShrinkMeters) m, \(link.exposureOffsetEV) EV"
+        }
+    }
+}
+
+enum GaussianLinkError: LocalizedError {
+    case untoldNotFound(String)
+    case payloadNotFound(String)
+    case invalidPayload(String, String)
+    case patchFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .untoldNotFound(path):
+            return ".untold file does not exist: \(path)"
+        case let .payloadNotFound(path):
+            return "Payload does not exist: \(path)"
+        case let .invalidPayload(path, reason):
+            return "\(path) is not a usable .untoldgs payload: \(reason)"
+        case let .patchFailed(reason):
+            return reason
+        }
+    }
+}

--- a/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/GaussianLinkCommand.swift
+++ b/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/GaussianLinkCommand.swift
@@ -17,19 +17,25 @@ struct GaussianLinkCommand: ParsableCommand {
         commandName: "gaussian-link",
         abstract: "Link an entity of a .untold asset to a cooked .untoldgs splat payload",
         discussion: """
-        Writes, removes or lists the gaussianAsset records of a .untold file (chunk 25,
-        UntoldGaussianAssetRecordV1) through UntoldAssetPatcher. Every other chunk of the
-        file is copied byte for byte; the string table only grows.
+        Writes, removes or lists the gaussianAsset records of a .untold file
+        (chunk 25, UntoldGaussianAssetRecordV1) through UntoldAssetPatcher. Every
+        other chunk of the file is copied byte for byte; the string table only
+        grows.
 
-        The payload path is stored relative to the .untold file's directory when the
-        payload sits inside or beside it, otherwise as the bare file name (with a
-        warning) — the runtime resolves it next to the .untold file. The payload must be
-        a version 3 .untoldgs; its splat count fills the record's single LOD level.
+        The payload path is stored relative to the directory of the file that is
+        written (the input with --in-place, the --output file otherwise) when the
+        payload sits inside or beside it, else as the bare file name with a
+        warning — the runtime resolves it next to the .untold file it loads. The
+        payload must be a version 3 .untoldgs; its splat count fills the record's
+        single LOD level. The link is set on the entity table's entityId; a
+        meshTwin link on an entity without a mesh has nothing to swap from, so the
+        command warns and lists the entities that carry meshes.
 
         Examples:
           untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \\
             --payload Chair/chair.untoldgs --swap-distance 8 --in-place
-          untoldengine gaussian-link --untold Chair/chair.untold --entity 0 --remove --output Chair/chair_plain.untold
+          untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \\
+            --remove --output Chair/chair_plain.untold
           untoldengine gaussian-link --untold Chair/chair.untold --list
         """
     )
@@ -43,13 +49,15 @@ struct GaussianLinkCommand: ParsableCommand {
     @Option(name: .long, help: "The cooked .untoldgs payload to link")
     var payload: String?
 
-    @Option(name: .customLong("swap-distance"), help: "Camera distance in metres at which the swap arms (0 = always)")
+    // `.unconditional`: the next token is the value even when it starts with a minus sign, so
+    // `--exposure-offset -0.5` parses without the `--option=value` form.
+    @Option(name: .customLong("swap-distance"), parsing: .unconditional, help: "Camera distance in metres at which the swap arms (0 = always)")
     var swapDistance: Float = 0
 
-    @Option(name: .customLong("occluder-shrink"), help: "Metres the mesh twin's depth-only occluder shell is shrunk along its normals")
+    @Option(name: .customLong("occluder-shrink"), parsing: .unconditional, help: "Metres the mesh twin's depth-only occluder shell is shrunk along its normals")
     var occluderShrink: Float = 0.02
 
-    @Option(name: .customLong("exposure-offset"), help: "Exposure offset in EV on top of the payload's capture exposure")
+    @Option(name: .customLong("exposure-offset"), parsing: .unconditional, help: "Exposure offset in EV on top of the payload's capture exposure (negative darkens)")
     var exposureOffset: Float = 0
 
     @Flag(name: .customLong("in-place"), help: "Overwrite the .untold file")
@@ -103,6 +111,9 @@ struct GaussianLinkCommand: ParsableCommand {
         }
 
         guard let entity else { return } // validate() guarantees it
+        // The runtime resolves the stored path next to the file it loads, which is the
+        // destination — not the input — when --output points elsewhere.
+        let destination = output.map { resolvePath($0).standardizedFileURL } ?? untoldURL
         let patched: Data
         if remove {
             patched = try Self.removing(entity: entity, from: fileData)
@@ -113,9 +124,9 @@ struct GaussianLinkCommand: ParsableCommand {
             guard FileManager.default.fileExists(atPath: payloadURL.path) else {
                 throw GaussianLinkError.payloadNotFound(payloadURL.path)
             }
-            let stored = Self.storedPayloadPath(payloadURL: payloadURL, untoldURL: untoldURL)
+            let stored = Self.storedPayloadPath(payloadURL: payloadURL, untoldURL: destination)
             if !stored.isRelative {
-                printWarning("\(payloadURL.path) is not inside \(untoldURL.deletingLastPathComponent().path); storing the file name \(stored.path) — keep the payload next to the .untold file")
+                printWarning("\(payloadURL.path) is not inside \(destination.deletingLastPathComponent().path); storing the file name \(stored.path) — keep the payload next to the .untold file that is written")
             }
             let link = try Self.makeLink(
                 payloadURL: payloadURL,
@@ -124,26 +135,67 @@ struct GaussianLinkCommand: ParsableCommand {
                 occluderShrink: occluderShrink,
                 exposureOffset: exposureOffset
             )
+            if let warning = try Self.meshlessEntityWarning(entity: entity, link: link, in: fileData) {
+                printWarning(warning)
+            }
             patched = try Self.setting(link, entity: entity, in: fileData)
             printInfo("Linked entity \(entity) to \(stored.path) (\(link.lodSplatCounts.first ?? 0) splats, swap at \(swapDistance) m, shrink \(occluderShrink) m, \(exposureOffset) EV)")
         }
 
-        let destination = output.map { resolvePath($0).standardizedFileURL } ?? untoldURL
         try patched.write(to: destination, options: .atomic)
         printSuccess("Wrote \(destination.path)")
     }
 
     // MARK: - Logic (kept free of ArgumentParser so tests can call it)
 
-    /// The path written into the record: relative to the `.untold` file's directory when the
-    /// payload is inside or beside it, else the bare file name.
+    /// The path written into the record: relative to the directory of `untoldURL` — the file
+    /// the record will be loaded from, so the `--output` destination when there is one — when
+    /// the payload is inside or beside it, else the bare file name. The paths are compared as
+    /// given first, so a payload reached through a symlinked directory inside the asset folder
+    /// keeps that working relative path; only when that fails are symlinks resolved on both
+    /// sides, for an asset folder reached through a link.
     static func storedPayloadPath(payloadURL: URL, untoldURL: URL) -> (path: String, isRelative: Bool) {
-        let directory = untoldURL.deletingLastPathComponent().standardizedFileURL.resolvingSymlinksInPath().pathComponents
-        let payload = payloadURL.standardizedFileURL.resolvingSymlinksInPath().pathComponents
-        guard payload.count > directory.count, Array(payload.prefix(directory.count)) == directory else {
-            return (payloadURL.lastPathComponent, false)
+        let directory = untoldURL.deletingLastPathComponent().standardizedFileURL
+        let payload = payloadURL.standardizedFileURL
+        if let relative = relativePath(of: payload, inside: directory) {
+            return (relative, true)
         }
-        return (payload.dropFirst(directory.count).joined(separator: "/"), true)
+        if let relative = relativePath(of: payload.resolvingSymlinksInPath(), inside: directory.resolvingSymlinksInPath()) {
+            return (relative, true)
+        }
+        return (payloadURL.lastPathComponent, false)
+    }
+
+    private static func relativePath(of file: URL, inside directory: URL) -> String? {
+        let directory = directory.pathComponents
+        let file = file.pathComponents
+        guard file.count > directory.count, Array(file.prefix(directory.count)) == directory else {
+            return nil
+        }
+        return file.dropFirst(directory.count).joined(separator: "/")
+    }
+
+    /// A warning when `link` is a meshTwin and `entity` carries no mesh record — the root of a
+    /// multi-node asset, say — naming the entities that do, so the link can be moved to one of
+    /// them. Nil when the entity has a mesh, the link is not a meshTwin, or the entity is
+    /// unknown (the patcher reports that one).
+    static func meshlessEntityWarning(entity: UInt32, link: UntoldAssetPatcher.GaussianAssetLink, in fileData: Data) throws -> String? {
+        guard link.flags & UntoldGaussianAssetFlags.meshTwin != 0 else { return nil }
+        let decoded: UntoldDecodedAsset
+        do {
+            decoded = try UntoldReader().readAsset(from: fileData)
+        } catch {
+            throw GaussianLinkError.patchFailed(UntoldAssetPatcher.Error.corruptFile(String(describing: error)).description)
+        }
+        guard let record = decoded.entities.first(where: { $0.entityId == entity }), record.meshRecordCount == 0 else {
+            return nil
+        }
+        let withMeshes = decoded.entities.filter { $0.meshRecordCount > 0 }.map { record in
+            let name = try? decoded.string(at: record.nameOffset)
+            return name.map { "\(record.entityId) (\($0))" } ?? "\(record.entityId)"
+        }
+        let candidates = withMeshes.isEmpty ? "no entity of this file carries a mesh" : "entities with meshes: \(withMeshes.joined(separator: ", "))"
+        return "entity \(entity) has no mesh to swap from; the meshTwin link will load but GaussianTwinSystem has nothing to hide — \(candidates)"
     }
 
     /// The link for a payload: its header (which must be version 3) fills one LOD level with

--- a/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/UntoldEngineCLI.swift
+++ b/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/UntoldEngineCLI.swift
@@ -16,6 +16,6 @@ struct UntoldEngineCLI: AsyncParsableCommand {
         commandName: "untoldengine",
         abstract: "UntoldEngine command-line tools",
         version: "0.1.0",
-        subcommands: [CreateCommand.self, UpdateCommand.self, AssetsCommand.self, ExportCommand.self, ExportTilesCommand.self, TexbakeCommand.self, BootstrapCommand.self, BlenderAddonCommand.self, StudioCommand.self]
+        subcommands: [CreateCommand.self, UpdateCommand.self, AssetsCommand.self, ExportCommand.self, ExportTilesCommand.self, GaussianLinkCommand.self, TexbakeCommand.self, BootstrapCommand.self, BlenderAddonCommand.self, StudioCommand.self]
     )
 }

--- a/Tools/UntoldEngineCLI/Tests/UntoldEngineCLITests/GaussianLinkCommandTests.swift
+++ b/Tools/UntoldEngineCLI/Tests/UntoldEngineCLITests/GaussianLinkCommandTests.swift
@@ -1,0 +1,230 @@
+//
+//  GaussianLinkCommandTests.swift
+//  UntoldEngineCLI
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import ArgumentParser
+import Foundation
+import simd
+import UntoldEngine
+@testable import UntoldEngineCLI
+import XCTest
+
+final class GaussianLinkCommandTests: XCTestCase {
+    private var temporaryDirectories: [URL] = []
+
+    override func tearDown() {
+        for url in temporaryDirectories {
+            try? FileManager.default.removeItem(at: url)
+        }
+        temporaryDirectories.removeAll()
+        super.tearDown()
+    }
+
+    // MARK: - Stored path
+
+    func testPayloadInsideTheAssetDirectoryIsStoredRelative() {
+        let untold = URL(fileURLWithPath: "/Game/GameData/Models/Chair/chair.untold")
+        XCTAssertEqual(
+            GaussianLinkCommand.storedPayloadPath(payloadURL: URL(fileURLWithPath: "/Game/GameData/Models/Chair/chair.untoldgs"), untoldURL: untold).path,
+            "chair.untoldgs"
+        )
+        let nested = GaussianLinkCommand.storedPayloadPath(payloadURL: URL(fileURLWithPath: "/Game/GameData/Models/Chair/Gaussians/chair.untoldgs"), untoldURL: untold)
+        XCTAssertEqual(nested.path, "Gaussians/chair.untoldgs")
+        XCTAssertTrue(nested.isRelative)
+        let dotted = GaussianLinkCommand.storedPayloadPath(payloadURL: URL(fileURLWithPath: "/Game/GameData/Models/Chair/./Gaussians/../chair.untoldgs"), untoldURL: untold)
+        XCTAssertEqual(dotted.path, "chair.untoldgs")
+    }
+
+    func testPayloadOutsideTheAssetDirectoryFallsBackToTheBasename() {
+        let untold = URL(fileURLWithPath: "/Game/GameData/Models/Chair/chair.untold")
+        let outside = GaussianLinkCommand.storedPayloadPath(payloadURL: URL(fileURLWithPath: "/Game/GameData/Gaussians/chair.untoldgs"), untoldURL: untold)
+        XCTAssertEqual(outside.path, "chair.untoldgs")
+        XCTAssertFalse(outside.isRelative)
+        // A sibling directory whose name starts the same is not "inside".
+        let lookalike = GaussianLinkCommand.storedPayloadPath(payloadURL: URL(fileURLWithPath: "/Game/GameData/Models/ChairOld/chair.untoldgs"), untoldURL: untold)
+        XCTAssertFalse(lookalike.isRelative)
+    }
+
+    // MARK: - Argument validation
+
+    func testArgumentCombinations() {
+        XCTAssertNoThrow(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--in-place"]))
+        XCTAssertNoThrow(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--remove", "--output", "b.untold"]))
+        XCTAssertNoThrow(try GaussianLinkCommand.parse(["--untold", "a.untold", "--list"]))
+        XCTAssertNoThrow(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--swap-distance", "8", "--exposure-offset=-0.5", "--output", "b.untold"]))
+
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs"]), "needs --in-place or --output")
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--in-place", "--output", "b.untold"]), "not both")
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--payload", "a.untoldgs", "--in-place"]), "needs --entity")
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--in-place"]), "needs --payload or --remove")
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--remove", "--payload", "a.untoldgs", "--in-place"]), "remove takes no payload")
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--list", "--remove"]), "list is alone")
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--entity", "0", "--list"]), "untold is required")
+    }
+
+    // MARK: - Set, list, remove
+
+    func testLinkSetListAndRemoveOnAFixture() throws {
+        let directory = try makeTemporaryDirectory()
+        let untoldURL = directory.appendingPathComponent("chair.untold")
+        try makeUntoldFixture().write(to: untoldURL)
+        let payloadURL = directory.appendingPathComponent("Gaussians").appendingPathComponent("chair.untoldgs")
+        try FileManager.default.createDirectory(at: payloadURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try makePayload(splatCount: 300).write(to: payloadURL)
+
+        XCTAssertEqual(try GaussianLinkCommand.listing(of: Data(contentsOf: untoldURL)), ["no gaussianAsset links"])
+
+        let stored = GaussianLinkCommand.storedPayloadPath(payloadURL: payloadURL, untoldURL: untoldURL)
+        XCTAssertEqual(stored.path, "Gaussians/chair.untoldgs")
+        let link = try GaussianLinkCommand.makeLink(payloadURL: payloadURL, storedPath: stored.path, swapDistance: 8, occluderShrink: 0.03, exposureOffset: -0.5)
+        XCTAssertEqual(link.lodCount, 1)
+        XCTAssertEqual(link.lodSplatCounts, [300])
+        XCTAssertEqual(link.lodSwitchScreenHeights, [0])
+        XCTAssertEqual(link.flags, UntoldGaussianAssetFlags.meshTwin)
+
+        let patched = try GaussianLinkCommand.setting(link, entity: 0, in: Data(contentsOf: untoldURL))
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: patched), [0: link])
+        let lines = try GaussianLinkCommand.listing(of: patched)
+        XCTAssertEqual(lines.count, 1)
+        XCTAssertTrue(lines[0].hasPrefix("entity 0: Gaussians/chair.untoldgs [meshTwin] 1 level [300], swap 8.0 m"), lines[0])
+
+        // The loader resolves the stored path next to the file.
+        try patched.write(to: untoldURL)
+        let asset = try NativeFormatLoader().loadAssetSync(from: untoldURL)
+        XCTAssertEqual(asset.nodes.first { $0.id == 0 }?.gaussianAsset?.payloadURL.standardizedFileURL, payloadURL.standardizedFileURL)
+
+        let removed = try GaussianLinkCommand.removing(entity: 0, from: patched)
+        XCTAssertEqual(try GaussianLinkCommand.listing(of: removed), ["no gaussianAsset links"])
+
+        XCTAssertThrowsError(try GaussianLinkCommand.setting(link, entity: 7, in: patched)) { error in
+            XCTAssertEqual((error as? GaussianLinkError)?.errorDescription, "entity 7 is not in the entity table")
+        }
+    }
+
+    func testAPayloadThatIsNotAVersion3UntoldgsIsRejected() throws {
+        let directory = try makeTemporaryDirectory()
+        let payloadURL = directory.appendingPathComponent("chair.untoldgs")
+        var bytes = try makePayload(splatCount: 10)
+        bytes.replaceSubrange(4 ..< 8, with: [2, 0, 0, 0])
+        try bytes.write(to: payloadURL)
+
+        XCTAssertThrowsError(try GaussianLinkCommand.makeLink(payloadURL: payloadURL, storedPath: "chair.untoldgs", swapDistance: 0, occluderShrink: 0.02, exposureOffset: 0)) { error in
+            guard case .invalidPayload? = error as? GaussianLinkError else {
+                return XCTFail("unexpected error \(error)")
+            }
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("GaussianLinkCommandTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        temporaryDirectories.append(url)
+        return url
+    }
+
+    private func makePayload(splatCount: Int) throws -> Data {
+        let splats = (0 ..< splatCount).map { index in
+            UntoldGSSplat(
+                position: SIMD3<Float>(Float(index) * 0.01, Float(index % 7) * 0.02, 0),
+                scale: SIMD3<Float>(repeating: 0.05),
+                rotation: simd_quatf(ix: 0, iy: 0, iz: 0, r: 1),
+                color: SIMD3<Float>(0.5, 0.5, 0.5),
+                opacity: 1
+            )
+        }
+        var options = UntoldGSWriteOptions()
+        options.log2ChunkSplats = 8
+        return try UntoldGSFormat.write(splats: splats, options: options)
+    }
+
+    /// A one-entity, one-triangle tile with a zero content hash.
+    private func makeUntoldFixture() -> Data {
+        let stringWriter = UntoldBinaryWriter()
+        var offsets: [String: UInt32] = [:]
+        for string in ["root_entity", "mesh_0", "mat_0", "albedo.ktx2"] {
+            offsets[string] = UInt32(stringWriter.count)
+            stringWriter.writeNullTerminatedUTF8(string)
+        }
+        let bounds = UntoldAABB(min: SIMD3<Float>(-1, -1, -1), max: SIMD3<Float>(1, 1, 1))
+        let entity = UntoldEntityRecordV1(entityId: 0, nameOffset: offsets["root_entity"]!, firstMeshRecordIndex: 0, meshRecordCount: 1, localBounds: bounds, worldBounds: bounds)
+        let material = UntoldMaterialRecordV1(nameOffset: offsets["mat_0"]!, baseColorTextureIndex: 0)
+        let texture = UntoldTextureRefRecordV1(nameOffset: offsets["albedo.ktx2"]!, uriOffset: offsets["albedo.ktx2"]!, textureFormat: .rgba8, width: 16, height: 16, mipCount: 1)
+        let vertexWriter = UntoldBinaryWriter()
+        for position in [SIMD3<Float>(-1, -1, 0), SIMD3<Float>(1, -1, 0), SIMD3<Float>(0, 1, 0)] {
+            UntoldPBRStaticVertexV1(
+                position: position,
+                normalPacked: UntoldVertexPacking.packNormal(SIMD3<Float>(0, 0, 1)),
+                tangentPacked: UntoldVertexPacking.packTangent(SIMD3<Float>(1, 0, 0), handedness: 1)
+            ).encode(to: vertexWriter)
+        }
+        let indexWriter = UntoldBinaryWriter()
+        for index in [0, 1, 2] as [UInt16] {
+            indexWriter.writeUInt16LE(index)
+        }
+        let mesh = UntoldMeshRecordV1(
+            entityId: 0,
+            meshNameOffset: offsets["mesh_0"]!,
+            materialIndex: 0,
+            indexType: .uint16,
+            vertexCount: 3,
+            indexCount: 3,
+            vertexStrideBytes: 32,
+            vertexDataOffset: 0,
+            indexDataOffset: 0,
+            vertexDataSizeBytes: UInt64(vertexWriter.count),
+            indexDataSizeBytes: UInt64(indexWriter.count),
+            estimatedGPUBytes: UInt64(vertexWriter.count + indexWriter.count),
+            localBounds: bounds
+        )
+
+        func encode(_ records: [some UntoldBinaryEncodable]) -> Data {
+            let writer = UntoldBinaryWriter()
+            for record in records {
+                record.encode(to: writer)
+            }
+            return writer.data
+        }
+        let payloads: [(UntoldChunkType, Data, UInt32)] = [
+            (.stringTable, stringWriter.data, 0),
+            (.entityTable, encode([entity]), 1),
+            (.meshTable, encode([mesh]), 1),
+            (.materialTable, encode([material]), 1),
+            (.textureTable, encode([texture]), 1),
+            (.vertexData, vertexWriter.data, 0),
+            (.indexData, indexWriter.data, 0),
+        ]
+        var header = UntoldFileHeaderV1(fileType: .tile, chunkCount: UInt32(payloads.count), meshCount: 1, materialCount: 1, textureRefCount: 1, entityCount: 1, vertexLayout: .pbrStaticV1, worldBounds: bounds)
+        header.chunkCount = UInt32(payloads.count)
+
+        let headerWriter = UntoldBinaryWriter()
+        header.encode(to: headerWriter)
+        let alignment = Int(UntoldFormat.fileAlignment)
+        var runningOffset = headerWriter.count + 40 * payloads.count
+        var entries: [UntoldChunkEntryV1] = []
+        for (chunkType, data, elementCount) in payloads {
+            if runningOffset % alignment != 0 {
+                runningOffset += alignment - runningOffset % alignment
+            }
+            entries.append(UntoldChunkEntryV1(chunkType: chunkType, fileOffset: UInt64(runningOffset), compressedSize: UInt64(data.count), uncompressedSize: UInt64(data.count), elementCount: elementCount))
+            runningOffset += data.count
+        }
+        let writer = UntoldBinaryWriter()
+        header.encode(to: writer)
+        for entry in entries {
+            entry.encode(to: writer)
+        }
+        for (_, data, _) in payloads {
+            writer.align(to: alignment)
+            writer.writeData(data)
+        }
+        return writer.data
+    }
+}

--- a/Tools/UntoldEngineCLI/Tests/UntoldEngineCLITests/GaussianLinkCommandTests.swift
+++ b/Tools/UntoldEngineCLI/Tests/UntoldEngineCLITests/GaussianLinkCommandTests.swift
@@ -51,6 +51,104 @@ final class GaussianLinkCommandTests: XCTestCase {
         XCTAssertFalse(lookalike.isRelative)
     }
 
+    /// A payload reached through a symlinked directory inside the asset folder keeps that
+    /// relative path (the loader follows the link); an asset folder reached through a symlink
+    /// still finds a payload given by its real path.
+    func testPayloadThroughASymlinkedSubdirectoryIsStoredRelative() throws {
+        let root = try makeTemporaryDirectory()
+        let chair = root.appendingPathComponent("Models/Chair", isDirectory: true)
+        let shared = root.appendingPathComponent("Shared/Gaussians", isDirectory: true)
+        try FileManager.default.createDirectory(at: chair, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: shared, withIntermediateDirectories: true)
+        let untoldURL = chair.appendingPathComponent("chair.untold")
+        try makeUntoldFixture().write(to: untoldURL)
+        try makePayload(splatCount: 5).write(to: shared.appendingPathComponent("chair.untoldgs"))
+        try FileManager.default.createSymbolicLink(atPath: chair.appendingPathComponent("Gaussians").path, withDestinationPath: "../../Shared/Gaussians")
+
+        let throughLink = chair.appendingPathComponent("Gaussians/chair.untoldgs")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: throughLink.path))
+        let stored = GaussianLinkCommand.storedPayloadPath(payloadURL: throughLink, untoldURL: untoldURL)
+        XCTAssertEqual(stored.path, "Gaussians/chair.untoldgs")
+        XCTAssertTrue(stored.isRelative)
+
+        // The loader resolves what was stored.
+        let link = try GaussianLinkCommand.makeLink(payloadURL: throughLink, storedPath: stored.path, swapDistance: 0, occluderShrink: 0.02, exposureOffset: 0)
+        try GaussianLinkCommand.setting(link, entity: 0, in: Data(contentsOf: untoldURL)).write(to: untoldURL)
+        let asset = try NativeFormatLoader().loadAssetSync(from: untoldURL)
+        let resolved = try XCTUnwrap(asset.nodes.first { $0.id == 0 }?.gaussianAsset?.payloadURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: resolved.path), resolved.path)
+
+        // The real path of the same payload is outside the asset folder.
+        let real = GaussianLinkCommand.storedPayloadPath(payloadURL: shared.appendingPathComponent("chair.untoldgs"), untoldURL: untoldURL)
+        XCTAssertFalse(real.isRelative)
+
+        // The asset folder itself reached through a symlink, the payload by its real path.
+        try FileManager.default.createSymbolicLink(atPath: root.appendingPathComponent("ChairLink").path, withDestinationPath: "Models/Chair")
+        let linkedFolder = GaussianLinkCommand.storedPayloadPath(
+            payloadURL: chair.appendingPathComponent("Gaussians/chair.untoldgs").resolvingSymlinksInPath(),
+            untoldURL: root.appendingPathComponent("ChairLink/chair.untold")
+        )
+        XCTAssertFalse(linkedFolder.isRelative, "Shared/Gaussians is not inside Models/Chair however it is reached")
+        let viaLinkedFolder = GaussianLinkCommand.storedPayloadPath(
+            payloadURL: chair.appendingPathComponent("chair.untold").resolvingSymlinksInPath(),
+            untoldURL: root.appendingPathComponent("ChairLink/other.untold")
+        )
+        XCTAssertEqual(viaLinkedFolder.path, "chair.untold", "resolved on both sides when the plain comparison fails")
+        XCTAssertTrue(viaLinkedFolder.isRelative)
+    }
+
+    /// With `--output` in another directory the record is loaded from that file, so the stored
+    /// path is measured from the destination, not from the input.
+    func testStoredPathIsRelativeToTheWrittenFile() throws {
+        let root = try makeTemporaryDirectory()
+        let chair = root.appendingPathComponent("Chair", isDirectory: true)
+        let build = root.appendingPathComponent("Build", isDirectory: true)
+        try FileManager.default.createDirectory(at: chair, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: build.appendingPathComponent("Gaussians"), withIntermediateDirectories: true)
+        let untoldURL = chair.appendingPathComponent("chair.untold")
+        try makeUntoldFixture().write(to: untoldURL)
+        let destination = build.appendingPathComponent("chair.untold")
+
+        // Beside the input but not beside the output: basename with a warning.
+        let besideInput = chair.appendingPathComponent("chair.untoldgs")
+        try makePayload(splatCount: 5).write(to: besideInput)
+        XCTAssertTrue(GaussianLinkCommand.storedPayloadPath(payloadURL: besideInput, untoldURL: untoldURL).isRelative, "relative to the input")
+        let stored = GaussianLinkCommand.storedPayloadPath(payloadURL: besideInput, untoldURL: destination)
+        XCTAssertEqual(stored.path, "chair.untoldgs")
+        XCTAssertFalse(stored.isRelative, "not relative to the written file")
+
+        // Beside the output: relative, and the loader finds it from the written file.
+        let besideOutput = build.appendingPathComponent("Gaussians/chair.untoldgs")
+        try makePayload(splatCount: 5).write(to: besideOutput)
+        let storedBesideOutput = GaussianLinkCommand.storedPayloadPath(payloadURL: besideOutput, untoldURL: destination)
+        XCTAssertEqual(storedBesideOutput.path, "Gaussians/chair.untoldgs")
+        XCTAssertTrue(storedBesideOutput.isRelative)
+        let link = try GaussianLinkCommand.makeLink(payloadURL: besideOutput, storedPath: storedBesideOutput.path, swapDistance: 0, occluderShrink: 0.02, exposureOffset: 0)
+        try GaussianLinkCommand.setting(link, entity: 0, in: Data(contentsOf: untoldURL)).write(to: destination)
+        let asset = try NativeFormatLoader().loadAssetSync(from: destination)
+        XCTAssertEqual(asset.nodes.first { $0.id == 0 }?.gaussianAsset?.payloadURL.standardizedFileURL, besideOutput.standardizedFileURL)
+    }
+
+    // MARK: - Mesh-less entities
+
+    func testAMeshTwinLinkOnAnEntityWithoutAMeshWarns() throws {
+        let fileData = makeUntoldFixture(meshlessRoot: true)
+        let link = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "chair.untoldgs", lodCount: 1, lodSplatCounts: [5])
+
+        let warning = try XCTUnwrap(GaussianLinkCommand.meshlessEntityWarning(entity: 0, link: link, in: fileData))
+        XCTAssertTrue(warning.hasPrefix("entity 0 has no mesh to swap from"), warning)
+        XCTAssertTrue(warning.hasSuffix("entities with meshes: 1 (child_entity)"), warning)
+        XCTAssertNil(try GaussianLinkCommand.meshlessEntityWarning(entity: 1, link: link, in: fileData), "the mesh-bearing child")
+        XCTAssertNil(try GaussianLinkCommand.meshlessEntityWarning(entity: 7, link: link, in: fileData), "unknown entities are the patcher's error")
+        var environment = link
+        environment.flags = UntoldGaussianAssetFlags.environment
+        XCTAssertNil(try GaussianLinkCommand.meshlessEntityWarning(entity: 0, link: environment, in: fileData), "only meshTwin links need a mesh")
+
+        // A warning, not an error: the record is still written.
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: GaussianLinkCommand.setting(link, entity: 0, in: fileData)), [0: link])
+        XCTAssertNil(try GaussianLinkCommand.meshlessEntityWarning(entity: 0, link: link, in: makeUntoldFixture()))
+    }
+
     // MARK: - Argument validation
 
     func testArgumentCombinations() {
@@ -58,6 +156,10 @@ final class GaussianLinkCommandTests: XCTestCase {
         XCTAssertNoThrow(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--remove", "--output", "b.untold"]))
         XCTAssertNoThrow(try GaussianLinkCommand.parse(["--untold", "a.untold", "--list"]))
         XCTAssertNoThrow(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--swap-distance", "8", "--exposure-offset=-0.5", "--output", "b.untold"]))
+        // A negative value as its own token: the option takes the next token unconditionally.
+        let negative = try? GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--exposure-offset", "-0.5", "--in-place"])
+        XCTAssertEqual(negative?.exposureOffset, -0.5)
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--exposure-offset", "--in-place"]), "the next token must be a number")
 
         XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs"]), "needs --in-place or --output")
         XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--in-place", "--output", "b.untold"]), "not both")
@@ -145,16 +247,23 @@ final class GaussianLinkCommandTests: XCTestCase {
         return try UntoldGSFormat.write(splats: splats, options: options)
     }
 
-    /// A one-entity, one-triangle tile with a zero content hash.
-    private func makeUntoldFixture() -> Data {
+    /// A one-entity, one-triangle tile with a zero content hash. With `meshlessRoot` the root
+    /// entity 0 is a transform node and the triangle sits on a child entity 1, as a multi-node
+    /// export lays it out.
+    private func makeUntoldFixture(meshlessRoot: Bool = false) -> Data {
         let stringWriter = UntoldBinaryWriter()
         var offsets: [String: UInt32] = [:]
-        for string in ["root_entity", "mesh_0", "mat_0", "albedo.ktx2"] {
+        for string in ["root_entity", "mesh_0", "mat_0", "albedo.ktx2", "child_entity"] {
             offsets[string] = UInt32(stringWriter.count)
             stringWriter.writeNullTerminatedUTF8(string)
         }
         let bounds = UntoldAABB(min: SIMD3<Float>(-1, -1, -1), max: SIMD3<Float>(1, 1, 1))
-        let entity = UntoldEntityRecordV1(entityId: 0, nameOffset: offsets["root_entity"]!, firstMeshRecordIndex: 0, meshRecordCount: 1, localBounds: bounds, worldBounds: bounds)
+        var entities = [UntoldEntityRecordV1(entityId: 0, nameOffset: offsets["root_entity"]!, firstMeshRecordIndex: 0, meshRecordCount: 1, localBounds: bounds, worldBounds: bounds)]
+        if meshlessRoot {
+            entities[0].meshRecordCount = 0
+            entities.append(UntoldEntityRecordV1(entityId: 1, nameOffset: offsets["child_entity"]!, firstMeshRecordIndex: 0, meshRecordCount: 1, localBounds: bounds, worldBounds: bounds))
+        }
+        let meshEntity = entities.last!.entityId
         let material = UntoldMaterialRecordV1(nameOffset: offsets["mat_0"]!, baseColorTextureIndex: 0)
         let texture = UntoldTextureRefRecordV1(nameOffset: offsets["albedo.ktx2"]!, uriOffset: offsets["albedo.ktx2"]!, textureFormat: .rgba8, width: 16, height: 16, mipCount: 1)
         let vertexWriter = UntoldBinaryWriter()
@@ -170,7 +279,7 @@ final class GaussianLinkCommandTests: XCTestCase {
             indexWriter.writeUInt16LE(index)
         }
         let mesh = UntoldMeshRecordV1(
-            entityId: 0,
+            entityId: meshEntity,
             meshNameOffset: offsets["mesh_0"]!,
             materialIndex: 0,
             indexType: .uint16,
@@ -194,14 +303,14 @@ final class GaussianLinkCommandTests: XCTestCase {
         }
         let payloads: [(UntoldChunkType, Data, UInt32)] = [
             (.stringTable, stringWriter.data, 0),
-            (.entityTable, encode([entity]), 1),
+            (.entityTable, encode(entities), UInt32(entities.count)),
             (.meshTable, encode([mesh]), 1),
             (.materialTable, encode([material]), 1),
             (.textureTable, encode([texture]), 1),
             (.vertexData, vertexWriter.data, 0),
             (.indexData, indexWriter.data, 0),
         ]
-        var header = UntoldFileHeaderV1(fileType: .tile, chunkCount: UInt32(payloads.count), meshCount: 1, materialCount: 1, textureRefCount: 1, entityCount: 1, vertexLayout: .pbrStaticV1, worldBounds: bounds)
+        var header = UntoldFileHeaderV1(fileType: .tile, chunkCount: UInt32(payloads.count), meshCount: 1, materialCount: 1, textureRefCount: 1, entityCount: UInt32(entities.count), vertexLayout: .pbrStaticV1, worldBounds: bounds)
         header.chunkCount = UInt32(payloads.count)
 
         let headerWriter = UntoldBinaryWriter()

--- a/docs/API/UsingGaussianSystem.md
+++ b/docs/API/UsingGaussianSystem.md
@@ -153,6 +153,20 @@ application-side system built on these pieces (see the proposal's §4.5).
   few frames, during which the batch still draws the mesh.
 - `GaussianDebugOptions.shared.disableOccluderShell` turns the shells off for bisecting.
 
+**Writing the link.** No whole-file `.untold` writer exists in Swift, and none is needed to
+author a link after the export: `UntoldAssetPatcher` (Sources/UntoldEngine/AssetFormat) rewrites
+just the gaussianAsset table. `settingGaussianAsset(_:onEntity:in:)` takes the file's bytes and a
+`GaussianAssetLink` (payload path relative to the `.untold` file's directory, flags, LOD table,
+occluder shrink, exposure offset, swap distance) and returns the patched bytes with every other
+chunk copied unchanged, the path appended to the string table (or an identical string reused),
+offsets re-laid out on 16-byte alignment and the content hash recomputed;
+`removingGaussianAsset(onEntity:in:)` drops a record (and the chunk when empty);
+`gaussianAssets(in:)` lists them. The result is read back through `UntoldReader` before it is
+returned. The same operation from the shell is `untoldengine gaussian-link --untold chair.untold
+--entity 0 --payload chair.untoldgs [--swap-distance m] [--occluder-shrink m] [--exposure-offset ev]
+--in-place | --output file`, with `--remove` and `--list`; the CLI reads the `.untoldgs` header to
+fill one LOD level with the payload's splat count.
+
 A typical swap: load the payload with `opacityScale: 0` when the camera is near; add a
 `MeshOccluderComponent`; add a `MeshFadeComponent` with `direction = .fadeOut` and raise its
 `progress` and the splat's `opacityScale` together to 1 over 250 ms; then set `drawsColor =

--- a/docs/API/UsingUntoldEngineCLI.md
+++ b/docs/API/UsingUntoldEngineCLI.md
@@ -260,7 +260,7 @@ path is stored relative to the directory of the file that is written (the input 
 `--in-place`, the `--output` file otherwise), which is where the runtime resolves it, so
 keep the payload inside or beside that file. The `.untoldgs` header fills the record's
 single LOD level with the payload's splat count. See [Writing the
-link](UsingGaussianSystem.md#a-splat-standing-in-for-a-mesh-the-twin-swap) for the
+link](UsingGaussianSystem.md#a-splat-standing-in-for-a-mesh-shells-fades-and-scene-links) for the
 patcher API.
 
 ```bash

--- a/docs/API/UsingUntoldEngineCLI.md
+++ b/docs/API/UsingUntoldEngineCLI.md
@@ -251,6 +251,31 @@ everywhere is cooked with `--splat-max-count 5242880`; one that only has to run 
 can go up to the Mac figure. Captures beyond that belong to the streamed environment
 path, which decodes and sorts only the visible chunks (part 6 of the series).
 
+### Linking a splat twin
+
+`untoldengine gaussian-link` attaches a cooked `.untoldgs` to an entity of a `.untold`
+asset after the export: it writes the asset's `gaussianAsset` record (chunk 25, flag
+`meshTwin`) through `UntoldAssetPatcher`, copying every other chunk unchanged. The payload
+path is stored relative to the directory of the file that is written (the input with
+`--in-place`, the `--output` file otherwise), which is where the runtime resolves it, so
+keep the payload inside or beside that file. The `.untoldgs` header fills the record's
+single LOD level with the payload's splat count. See [Writing the
+link](UsingGaussianSystem.md#a-splat-standing-in-for-a-mesh-the-twin-swap) for the
+patcher API.
+
+```bash
+untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \
+  --payload Chair/chair.untoldgs --swap-distance 8 --occluder-shrink 0.02 --in-place
+untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \
+  --remove --output Chair/chair_plain.untold
+untoldengine gaussian-link --untold Chair/chair.untold --list
+```
+
+`--entity` is the entity table's `entityId` (`--list` prints the ids that already carry a
+link); a `meshTwin` link on an entity without a mesh — the root of a multi-node asset —
+is written with a warning that names the mesh-bearing entities. Negative values are
+accepted as they are (`--exposure-offset -0.5`).
+
 ---
 
 ## Partitioning Scenes into Streaming Tiles

--- a/docs/Architecture/assetFormat.md
+++ b/docs/Architecture/assetFormat.md
@@ -519,6 +519,12 @@ Rules:
   not here; this record holds what the scene author tunes
 - a file whose only geometry is a splat may omit the vertex and index chunks
 
+The exporter does not write this chunk; a link is authored after the export by
+`UntoldAssetPatcher` (Sources/UntoldEngine/AssetFormat/UntoldAssetPatcher.swift) or
+`untoldengine gaussian-link`, which re-emit only the string table (append-only) and this
+table, copy every other chunk's stored bytes, re-lay out the chunk offsets on the file
+alignment and recompute the content hash (`UntoldFormat.contentHash(of:in:)`).
+
 ## Compression Rules
 
 Supported compression types:


### PR DESCRIPTION
Replay of miolabs/UntoldEngine#32 (with its review follow-up), developed and verified end to end on the fork and used by the editor's Splat Twin inspector.

Follow-up to #1185 (part 7b of the Gaussian splat streaming series, proposal: #1176). Three commits: the feature, the review fixes, a docs anchor.

The `.untold` `gaussianAsset` record (#1178) could be read by the loader and carried as `GaussianAssetLinkComponent` (#1185), but nothing in Swift could write one: the exporter is Python and the editor only patched same-size tables in place. This adds the writer so an editor and the CLI can link a cooked splat to a mesh.

## What

- **`UntoldAssetPatcher`** (`AssetFormat/UntoldAssetPatcher.swift`): `settingGaussianAsset(_:onEntity:in:)`, `removingGaussianAsset(onEntity:in:)` and `gaussianAssets(in:)` on the bytes of a `.untold` file. Every chunk other than the string table and the `gaussianAssetTable` is copied raw (compression, element counts and order preserved); the string table is append-only (an identical entry is reused); the table chunk is replaced in place or appended; offsets are re-laid out on the 16-byte alignment; `chunkCount` is updated and the content hash recomputed unless the input had the all-zero hash of a Swift-built fixture. The result is read back through `UntoldReader` before it is returned, so a bad rewrite throws instead of producing a file the loader rejects later. `GaussianAssetLink` is the value type (payload path relative to the file's directory, flags, LOD table, occluder shrink, exposure offset, swap distance) with `validate()`.
- **`UntoldFormat.contentHash(of:in:)`**: the SHA-256 the format defines (stored payloads in ascending chunk-type order), shared by the reader's validation and the patcher, and available to the editor instead of its private copy.
- **`untoldengine gaussian-link`** (`Tools/UntoldEngineCLI`): `--untold file --entity id --payload file.untoldgs [--swap-distance m] [--occluder-shrink m] [--exposure-offset ev] [--in-place | --output file]`, `--remove`, `--list`. Reads the `.untoldgs` v3 header to fill the one-level LOD table, stores the payload path relative to the file that is written (basename with a warning when the payload lives elsewhere), warns when the entity carries no mesh (a `meshTwin` link on a transform-only root is the common mistake) and lists the mesh-bearing entities.
- Docs: `docs/API/UsingGaussianSystem.md` ("Writing the link"), `docs/API/UsingUntoldEngineCLI.md` ("Linking a splat twin"), `docs/Architecture/assetFormat.md`, the CLI README.

## Review

Four reviewers (format rules, loader semantics, test strength, conventions) with one refutation pass per finding on the fork; 13 confirmed and fixed in the second commit: `--output` in another directory measured the payload path against the input instead of the written file; symlinked asset folders were judged "outside"; LOD arrays shorter than `lodCount` did not round-trip `Equatable`; `record(entityId:payloadPathOffset:)` trapped on a negative `lodCount`; a chunk entry pointing outside the file trapped instead of throwing; `--exposure-offset -0.5` was rejected by ArgumentParser; help text wider than 80 columns; plus the test gaps below.

## Verification

- `UntoldAssetPatcherTests` (20): every other chunk byte-identical (including LZ4-compressed vertex/index chunks), alignment and hash validity, string reuse (whole entries only; suffix and prefix collisions), replace in place with the table kept at its original chunk position, idempotent second set, remove drops the chunk when empty, unknown entity and every invalid-link case, corrupt input, phantom chunk entries outside the file, content hash matches the exporter's convention, patched files load through `NativeFormatLoader` with the payload resolved next to the file, and the cooked `singlecube.untold` fixture round-trips with a valid hash.
- `UntoldAssetPatcherRenderTest`: a patched copy placed with `setEntityMesh` carries `GaussianAssetLinkComponent` with every field and loads no splat.
- `GaussianLinkCommandTests` (8, new CLI test target): relative paths inside, nested, symlinked and outside the asset folder, `--output` elsewhere, argument combinations, set/list/remove on a real v3 payload, non-v3 rejected, mesh-less entity warning.
- Independent read-back of the CLI's output with a pure-Python struct parser (header, chunk table, alignment, hash) matched.
- Clean strict-concurrency build: no warning sites in the new code. SwiftFormat lint clean on the changed files. No metallib changes.
