### PR TITLE
[Chores] Give the renderer test sweep 45 minutes on CI

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -71,7 +71,9 @@ jobs:
       # ✅ Run renderer tests (non-async suites)
       #
       - name: Run renderer tests (non-async suites)
-        timeout-minutes: 30
+        # The sweep takes 26-30 minutes on the hosted macOS runners and grows with
+        # every render suite; leave headroom so a slow runner is not a red build.
+        timeout-minutes: 45
         env:
           CI: true
           UNTOLD_PSNR_THRESHOLD: "33.5"   # tweak per suite/scene


### PR DESCRIPTION
The "Run renderer tests (non-async suites)" step has been finishing in 26 to 30 minutes on the hosted macOS runners: the recent `develop` runs took 28 and 26 minutes, and a slightly slower runner hits the 30-minute limit with every test green (1270 passed, 0 failed, then "timed out after 30 minutes"). The two `.untoldpack` render suites add to the sweep. This raises the step's `timeout-minutes` from 30 to 45; no other change.