### PR TITLE
[Feature] Gaussian twin alignment: offset, yaw and scale in the scene link

### DIFF
--- a/Sources/UntoldEngine/AssetFormat/UntoldAssetPatcher.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldAssetPatcher.swift
@@ -33,8 +33,13 @@ public enum UntoldAssetPatcher {
     public struct GaussianAssetLink: Sendable, Equatable {
         /// Path of the `.untoldgs` payload, relative to the `.untold` file's directory.
         public var payloadPath: String
-        /// See `UntoldGaussianAssetFlags`.
-        public var flags: UInt32
+        /// See `UntoldGaussianAssetFlags`. The alignment bit is never held here — it follows
+        /// `alignment` — so a value that carries it, copied from a decoded record say, is
+        /// stored without it.
+        public var flags: UInt32 {
+            didSet { flags &= ~UntoldGaussianAssetFlags.alignment }
+        }
+
         /// Valid entries in `lodSplatCounts` / `lodSwitchScreenHeights`, 0...4. Zero means one level.
         public var lodCount: Int
         /// Splat count per LOD level, coarsest first. `lodCount` entries; the initializer pads a
@@ -105,7 +110,7 @@ public enum UntoldAssetPatcher {
             UntoldGaussianAssetRecordV1(
                 entityId: entityId,
                 payloadPathOffset: payloadPathOffset,
-                flags: flags,
+                flags: flags & ~UntoldGaussianAssetFlags.alignment,
                 lodCount: UInt32(clamping: lodCount),
                 lodSplatCounts: lodSplatCounts,
                 lodSwitchScreenHeights: lodSwitchScreenHeights,

--- a/Sources/UntoldEngine/AssetFormat/UntoldAssetPatcher.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldAssetPatcher.swift
@@ -49,6 +49,11 @@ public enum UntoldAssetPatcher {
         public var exposureOffsetEV: Float
         /// Camera distance at which the swap and its prefetch arm. Zero means always.
         public var swapDistanceMeters: Float
+        /// How the splat sits in the entity's local space (`GaussianComponent.splatToEntity`),
+        /// or nil for identity. Written as the record's alignment fields with
+        /// `UntoldGaussianAssetFlags.alignment` set when non-nil; that flag is derived from this
+        /// property and never kept in `flags`.
+        public var alignment: GaussianSplatAlignment?
 
         public init(
             payloadPath: String,
@@ -58,10 +63,12 @@ public enum UntoldAssetPatcher {
             lodSwitchScreenHeights: [Float] = [],
             occluderShrinkMeters: Float = 0.02,
             exposureOffsetEV: Float = 0,
-            swapDistanceMeters: Float = 0
+            swapDistanceMeters: Float = 0,
+            alignment: GaussianSplatAlignment? = nil
         ) {
             self.payloadPath = payloadPath
-            self.flags = flags
+            self.flags = flags & ~UntoldGaussianAssetFlags.alignment
+            self.alignment = alignment
             self.lodCount = lodCount
             // The record stores `maxLODLevels` slots and reads back `lodCount` of them, so a
             // shorter array would come back zero-padded; pad here so the link round-trips.
@@ -85,7 +92,8 @@ public enum UntoldAssetPatcher {
                 lodSwitchScreenHeights: Array(record.lodSwitchScreenHeights.prefix(levels)),
                 occluderShrinkMeters: record.occluderShrinkMeters,
                 exposureOffsetEV: record.exposureOffsetEV,
-                swapDistanceMeters: record.swapDistanceMeters
+                swapDistanceMeters: record.swapDistanceMeters,
+                alignment: record.alignment
             )
         }
 
@@ -103,14 +111,16 @@ public enum UntoldAssetPatcher {
                 lodSwitchScreenHeights: lodSwitchScreenHeights,
                 occluderShrinkMeters: occluderShrinkMeters,
                 exposureOffsetEV: exposureOffsetEV,
-                swapDistanceMeters: swapDistanceMeters
+                swapDistanceMeters: swapDistanceMeters,
+                alignment: alignment
             )
         }
 
         /// Throws `UntoldAssetPatcher.Error.invalidLink` when the link cannot be written as a
         /// record `UntoldReader` would accept: an empty path or one containing NUL (the string
         /// table is NUL-terminated), more than `UntoldGaussianAssetRecordV1.maxLODLevels` levels or
-        /// more LOD entries than levels, negative or non-finite distances, a non-finite exposure.
+        /// more LOD entries than levels, negative or non-finite distances, a non-finite exposure,
+        /// an alignment that is not finite or whose scale is not greater than zero.
         public func validate() throws {
             guard !payloadPath.isEmpty else {
                 throw Error.invalidLink("payload path is empty")
@@ -138,6 +148,9 @@ public enum UntoldAssetPatcher {
             }
             guard exposureOffsetEV.isFinite else {
                 throw Error.invalidLink("exposureOffsetEV must be finite")
+            }
+            if let alignment, !alignment.isValid {
+                throw Error.invalidLink("alignment must be finite with a scale greater than zero (\(alignment))")
             }
         }
 

--- a/Sources/UntoldEngine/AssetFormat/UntoldBinaryCodable.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldBinaryCodable.swift
@@ -866,7 +866,8 @@ extension UntoldPBRStaticVertexV1: UntoldBinaryEncodable, UntoldBinaryDecodable 
 }
 
 extension UntoldGaussianAssetRecordV1: UntoldBinaryEncodable, UntoldBinaryDecodable {
-    /// Serialized size in bytes: 4 words, 4 + 4 LOD entries, 3 floats, 5 reserved words.
+    /// Serialized size in bytes: 4 words, 4 + 4 LOD entries, 3 floats, 5 alignment floats
+    /// (translation, yaw, scale — the former reserved words).
     public static let encodedSize = 80
 
     public func encode(to writer: UntoldBinaryWriter) {
@@ -883,9 +884,11 @@ extension UntoldGaussianAssetRecordV1: UntoldBinaryEncodable, UntoldBinaryDecoda
         writer.writeFloat32LE(occluderShrinkMeters)
         writer.writeFloat32LE(exposureOffsetEV)
         writer.writeFloat32LE(swapDistanceMeters)
-        for index in 0 ..< Self.reservedWordCount {
-            writer.writeUInt32LE(reserved0[index])
-        }
+        writer.writeFloat32LE(alignmentTranslation.x)
+        writer.writeFloat32LE(alignmentTranslation.y)
+        writer.writeFloat32LE(alignmentTranslation.z)
+        writer.writeFloat32LE(alignmentYawDegrees)
+        writer.writeFloat32LE(alignmentScale)
     }
 
     public static func decode(from reader: UntoldBinaryReader) throws -> UntoldGaussianAssetRecordV1 {
@@ -904,11 +907,14 @@ extension UntoldGaussianAssetRecordV1: UntoldBinaryEncodable, UntoldBinaryDecoda
         let occluderShrinkMeters = try reader.readFloat32LE()
         let exposureOffsetEV = try reader.readFloat32LE()
         let swapDistanceMeters = try reader.readFloat32LE()
-        var reserved0: [UInt32] = []
-        for _ in 0 ..< reservedWordCount {
-            try reserved0.append(reader.readUInt32LE())
-        }
-        return UntoldGaussianAssetRecordV1(
+        let translationX = try reader.readFloat32LE()
+        let translationY = try reader.readFloat32LE()
+        let translationZ = try reader.readFloat32LE()
+        let yawDegrees = try reader.readFloat32LE()
+        let scale = try reader.readFloat32LE()
+        // The alignment words are read as stored, flag or not: a record round-trips byte for
+        // byte, and `alignment` reports nil while the flag is clear.
+        var record = UntoldGaussianAssetRecordV1(
             entityId: entityId,
             payloadPathOffset: payloadPathOffset,
             flags: flags,
@@ -917,9 +923,12 @@ extension UntoldGaussianAssetRecordV1: UntoldBinaryEncodable, UntoldBinaryDecoda
             lodSwitchScreenHeights: lodSwitchScreenHeights,
             occluderShrinkMeters: occluderShrinkMeters,
             exposureOffsetEV: exposureOffsetEV,
-            swapDistanceMeters: swapDistanceMeters,
-            reserved0: reserved0
+            swapDistanceMeters: swapDistanceMeters
         )
+        record.alignmentTranslation = SIMD3<Float>(translationX, translationY, translationZ)
+        record.alignmentYawDegrees = yawDegrees
+        record.alignmentScale = scale
+        return record
     }
 }
 

--- a/Sources/UntoldEngine/AssetFormat/UntoldFormat.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldFormat.swift
@@ -703,6 +703,51 @@ public enum UntoldGaussianAssetFlags {
     public static let environment: UInt32 = 1 << 1
     /// The payload is a world seen through a window from a fixed view cell.
     public static let windowWorld: UInt32 = 1 << 2
+    /// The record's `alignmentTranslation`, `alignmentYawDegrees` and `alignmentScale` are
+    /// valid: the splat is drawn with that transform composed onto the entity's. Clear (the
+    /// words are zero) in files written before the alignment existed, which means identity.
+    public static let alignment: UInt32 = 1 << 3
+}
+
+/// How a splat sits in its entity's local space without a re-cook: `matrix` is
+/// `T(translation) · R_y(yawDegrees) · S(scale)`, applied to the splat positions before the
+/// entity's world transform (`GaussianComponent.splatToEntity`). Yaw turns about the entity's
+/// +Y axis (right-handed, like `rotateTo(entityId:angle:axis:)`); the scale is uniform. Stored
+/// in the scene's `gaussianAsset` record (`UntoldGaussianAssetRecordV1`, flag
+/// `UntoldGaussianAssetFlags.alignment`), so the cook transform baked into the `.untoldgs`
+/// header (`splatToMesh`) stays what it is and this is an edit on top of it.
+public struct GaussianSplatAlignment: Sendable, Equatable, Codable {
+    public static let identity = GaussianSplatAlignment()
+
+    /// Offset in the entity's local space, metres.
+    public var translation: SIMD3<Float>
+    /// Rotation about the entity's +Y axis, degrees.
+    public var yawDegrees: Float
+    /// Uniform scale; must be greater than zero.
+    public var scale: Float
+
+    public init(translation: SIMD3<Float> = .zero, yawDegrees: Float = 0, scale: Float = 1) {
+        self.translation = translation
+        self.yawDegrees = yawDegrees
+        self.scale = scale
+    }
+
+    /// `T · R_y · S` as the splat-to-entity matrix.
+    public var matrix: simd_float4x4 {
+        let radians = yawDegrees * .pi / 180
+        var result = simd_float4x4(simd_quatf(angle: radians, axis: SIMD3<Float>(0, 1, 0)))
+        result.columns.0 *= scale
+        result.columns.1 *= scale
+        result.columns.2 *= scale
+        result.columns.3 = SIMD4<Float>(translation.x, translation.y, translation.z, 1)
+        return result
+    }
+
+    /// Every field finite and the scale positive: what `UntoldReader` and the patcher accept.
+    public var isValid: Bool {
+        translation.x.isFinite && translation.y.isFinite && translation.z.isFinite
+            && yawDegrees.isFinite && scale.isFinite && scale > 0
+    }
 }
 
 /// Links an entity to a cooked Gaussian splat payload (`.untoldgs`, see
@@ -712,7 +757,6 @@ public enum UntoldGaussianAssetFlags {
 /// header; this record holds what the scene author tunes.
 public struct UntoldGaussianAssetRecordV1: Sendable, Equatable {
     public static let maxLODLevels = 4
-    public static let reservedWordCount = 5
 
     public var entityId: UInt32
     /// String-table offset of the payload path, relative to this asset's directory.
@@ -731,9 +775,17 @@ public struct UntoldGaussianAssetRecordV1: Sendable, Equatable {
     public var exposureOffsetEV: Float
     /// Camera distance at which the swap and its prefetch arm. Zero means always.
     public var swapDistanceMeters: Float
-    /// Always 5 words. Write as zero.
-    public var reserved0: [UInt32]
+    /// Offset of the splat in the entity's local space, metres. Valid only with
+    /// `UntoldGaussianAssetFlags.alignment`; written as zero otherwise (these three fields were
+    /// the record's reserved words, so a file written before them reads as no alignment).
+    public var alignmentTranslation: SIMD3<Float>
+    /// Rotation of the splat about the entity's +Y axis, degrees. Valid with the `alignment` flag.
+    public var alignmentYawDegrees: Float
+    /// Uniform scale of the splat, greater than zero. Valid with the `alignment` flag.
+    public var alignmentScale: Float
 
+    /// `alignment` non-nil sets `UntoldGaussianAssetFlags.alignment` in `flags` and fills the
+    /// alignment fields; nil leaves `flags` as given and the fields zero.
     public init(
         entityId: UInt32,
         payloadPathOffset: UInt32,
@@ -744,18 +796,43 @@ public struct UntoldGaussianAssetRecordV1: Sendable, Equatable {
         occluderShrinkMeters: Float = 0.02,
         exposureOffsetEV: Float = 0,
         swapDistanceMeters: Float = 0,
-        reserved0: [UInt32] = []
+        alignment: GaussianSplatAlignment? = nil
     ) {
         self.entityId = entityId
         self.payloadPathOffset = payloadPathOffset
-        self.flags = flags
+        self.flags = alignment == nil ? flags : flags | UntoldGaussianAssetFlags.alignment
         self.lodCount = lodCount
         self.lodSplatCounts = Self.fixed(lodSplatCounts, count: Self.maxLODLevels, fill: 0)
         self.lodSwitchScreenHeights = Self.fixed(lodSwitchScreenHeights, count: Self.maxLODLevels, fill: 0)
         self.occluderShrinkMeters = occluderShrinkMeters
         self.exposureOffsetEV = exposureOffsetEV
         self.swapDistanceMeters = swapDistanceMeters
-        self.reserved0 = Self.fixed(reserved0, count: Self.reservedWordCount, fill: 0)
+        alignmentTranslation = alignment?.translation ?? .zero
+        alignmentYawDegrees = alignment?.yawDegrees ?? 0
+        alignmentScale = alignment?.scale ?? 0
+    }
+
+    /// The alignment the record carries: the three fields when `flags` has
+    /// `UntoldGaussianAssetFlags.alignment`, nil otherwise. Setting it sets or clears the flag
+    /// and, when cleared, zeroes the fields.
+    public var alignment: GaussianSplatAlignment? {
+        get {
+            guard flags & UntoldGaussianAssetFlags.alignment != 0 else { return nil }
+            return GaussianSplatAlignment(translation: alignmentTranslation, yawDegrees: alignmentYawDegrees, scale: alignmentScale)
+        }
+        set {
+            if let newValue {
+                flags |= UntoldGaussianAssetFlags.alignment
+                alignmentTranslation = newValue.translation
+                alignmentYawDegrees = newValue.yawDegrees
+                alignmentScale = newValue.scale
+            } else {
+                flags &= ~UntoldGaussianAssetFlags.alignment
+                alignmentTranslation = .zero
+                alignmentYawDegrees = 0
+                alignmentScale = 0
+            }
+        }
     }
 
     private static func fixed<T>(_ values: [T], count: Int, fill: T) -> [T] {

--- a/Sources/UntoldEngine/AssetFormat/UntoldReader.swift
+++ b/Sources/UntoldEngine/AssetFormat/UntoldReader.swift
@@ -249,6 +249,12 @@ public final class UntoldReader: @unchecked Sendable {
             guard record.occluderShrinkMeters >= 0, record.swapDistanceMeters >= 0 else {
                 throw UntoldValidationError.invalidGaussianAssetRecord(index: index, reason: "negative distance")
             }
+            if let alignment = record.alignment, !alignment.isValid {
+                throw UntoldValidationError.invalidGaussianAssetRecord(
+                    index: index,
+                    reason: "alignment must be finite with a scale greater than zero"
+                )
+            }
         }
     }
 

--- a/Sources/UntoldEngine/ECS/Components.swift
+++ b/Sources/UntoldEngine/ECS/Components.swift
@@ -162,6 +162,12 @@ public class GaussianComponent: Component {
     /// entry and the entity keeps the mesh's bounding box; this box is the splat's own.
     public internal(set) var estimatedGPUBytes = 0
     public internal(set) var localBoundingBox: (min: simd_float3, max: simd_float3)?
+    /// Where the splat sits in the entity's local space: the splat is drawn with
+    /// `worldTransform × splatToEntity`, so moving, turning or scaling this is the same as
+    /// moving the entity, without touching the mesh a twin stands in for. Identity by default;
+    /// `GaussianSplatAlignment.matrix` builds it from a scene link's alignment. Survives tier
+    /// swaps and reloads of the same entity.
+    public var splatToEntity: simd_float4x4 = matrix_identity_float4x4
 
     public required init() {}
 }
@@ -227,6 +233,9 @@ public class GaussianAssetLinkComponent: Component {
     public var exposureOffsetEV: Float = 0
     /// Camera distance at which a twin swap arms; 0 means always.
     public var swapDistanceMeters: Float = 0
+    /// How the splat sits in the entity's local space, to be applied as
+    /// `GaussianComponent.splatToEntity` by whoever loads the payload; nil means identity.
+    public var alignment: GaussianSplatAlignment?
 
     public var isMeshTwin: Bool {
         flags & UntoldGaussianAssetFlags.meshTwin != 0

--- a/Sources/UntoldEngine/ECS/Components.swift
+++ b/Sources/UntoldEngine/ECS/Components.swift
@@ -165,9 +165,11 @@ public class GaussianComponent: Component {
     /// Where the splat sits in the entity's local space: the splat is drawn with
     /// `worldTransform × splatToEntity`, so moving, turning or scaling this is the same as
     /// moving the entity, without touching the mesh a twin stands in for. Identity by default;
-    /// `GaussianSplatAlignment.matrix` builds it from a scene link's alignment. Survives tier
-    /// swaps and reloads of the same entity.
-    public var splatToEntity: simd_float4x4 = matrix_identity_float4x4
+    /// `GaussianSplatAlignment.matrix` builds it from a scene link's alignment. Set through
+    /// `setGaussianSplatToEntity(entityId:_:)`, which also carries a splat-only entity's
+    /// bounding box through the new value. Survives tier swaps, reloads of the same entity and
+    /// a streaming eviction (`StreamingComponent` keeps it while the splat is out).
+    public internal(set) var splatToEntity: simd_float4x4 = matrix_identity_float4x4
 
     public required init() {}
 }
@@ -1084,6 +1086,12 @@ public class StreamingComponent: Component {
 
     /// Task handle for cancellation
     var loadTask: Task<Void, Never>?
+
+    /// A streamed splat's `GaussianComponent.splatToEntity` while it is evicted: stashed by
+    /// `unloadGaussian` before the component goes and put back on the component the reload
+    /// builds, so the entity's alignment outlives the residency cycle like it does a reload of
+    /// a resident entity. Nil until a splat with one has been evicted.
+    var retainedSplatToEntity: simd_float4x4?
 
     public required init() {}
 

--- a/Sources/UntoldEngine/Renderer/RenderPasses.swift
+++ b/Sources/UntoldEngine/Renderer/RenderPasses.swift
@@ -4807,7 +4807,9 @@ public enum RenderPasses {
                     // this frame's preprocess wrote, read by the indirect draw.
                     activeSplatTotal += min(Int(gaussianComponent.visibleSplatCountForRendering), Int(gaussianComponent.splatCount))
 
-                    let modelMatrix = simd_mul(worldTransformComponent.space, .identity)
+                    // The same product the cull and preprocess used (GaussianEntityFrameMatrices):
+                    // the entity's world transform with the splat's placement inside it.
+                    let modelMatrix = simd_mul(worldTransformComponent.space, gaussianComponent.splatToEntity)
                     constants[entityIndex] = GaussianEntityDrawConstants(
                         projectionMatrix: renderInfo.perspectiveSpace,
                         modelViewMatrix: simd_mul(effectiveViewMatrix, modelMatrix)

--- a/Sources/UntoldEngine/RuntimeAssets/NativeFormatLoader.swift
+++ b/Sources/UntoldEngine/RuntimeAssets/NativeFormatLoader.swift
@@ -174,7 +174,8 @@ public struct NativeFormatLoader: NamedRuntimeAssetLoading {
                 lodSwitchScreenHeights: Array(record.lodSwitchScreenHeights.prefix(Int(record.lodCount))),
                 occluderShrinkMeters: record.occluderShrinkMeters,
                 exposureOffsetEV: record.exposureOffsetEV,
-                swapDistanceMeters: record.swapDistanceMeters
+                swapDistanceMeters: record.swapDistanceMeters,
+                alignment: record.alignment
             )
         }
         return links

--- a/Sources/UntoldEngine/RuntimeAssets/RuntimeAsset.swift
+++ b/Sources/UntoldEngine/RuntimeAssets/RuntimeAsset.swift
@@ -417,6 +417,9 @@ public struct RuntimeGaussianAssetLink: Sendable, Equatable {
     public var occluderShrinkMeters: Float
     public var exposureOffsetEV: Float
     public var swapDistanceMeters: Float
+    /// How the splat sits in the entity's local space (`GaussianComponent.splatToEntity`); nil
+    /// when the record carries none, which is identity.
+    public var alignment: GaussianSplatAlignment?
 
     public init(
         payloadURL: URL,
@@ -426,7 +429,8 @@ public struct RuntimeGaussianAssetLink: Sendable, Equatable {
         lodSwitchScreenHeights: [Float] = [],
         occluderShrinkMeters: Float = 0.02,
         exposureOffsetEV: Float = 0,
-        swapDistanceMeters: Float = 0
+        swapDistanceMeters: Float = 0,
+        alignment: GaussianSplatAlignment? = nil
     ) {
         self.payloadURL = payloadURL
         self.flags = flags
@@ -436,6 +440,7 @@ public struct RuntimeGaussianAssetLink: Sendable, Equatable {
         self.occluderShrinkMeters = occluderShrinkMeters
         self.exposureOffsetEV = exposureOffsetEV
         self.swapDistanceMeters = swapDistanceMeters
+        self.alignment = alignment
     }
 }
 

--- a/Sources/UntoldEngine/Systems/GaussianSystem.swift
+++ b/Sources/UntoldEngine/Systems/GaussianSystem.swift
@@ -192,8 +192,11 @@ private struct GaussianEntityFrameMatrices {
     let effectiveCameraPosition: simd_float3
     let uniforms: Uniforms
 
-    init(worldTransform: WorldTransformComponent, cameraComponent: CameraComponent) {
-        modelMatrix = simd_mul(worldTransform.space, .identity)
+    init(worldTransform: WorldTransformComponent, gaussianComponent: GaussianComponent, cameraComponent: CameraComponent) {
+        // The splat's model matrix: the entity's world transform with the splat's own placement
+        // inside the entity composed on the right (GaussianComponent.splatToEntity). The draw
+        // pass (RenderPasses.gaussianExecution) composes the same product per eye.
+        modelMatrix = simd_mul(worldTransform.space, gaussianComponent.splatToEntity)
         // Entity transforms are never modified when the scene root moves (SceneRootTransform
         // applies its offset to the camera instead, as a "virtual camera" trick — see
         // SceneRootTransform.swift). worldTransform.space above is therefore in entity space,
@@ -314,7 +317,7 @@ public func executeGaussianFrustumCulling(_ commandBuffer: MTLCommandBuffer) {
         }
         profileTotals.include(component: gaussianComponent)
         activeSplatTotal += activeGaussianSortCount(gaussianComponent)
-        let matrices = GaussianEntityFrameMatrices(worldTransform: worldTransformComponent, cameraComponent: cameraComponent)
+        let matrices = GaussianEntityFrameMatrices(worldTransform: worldTransformComponent, gaussianComponent: gaussianComponent, cameraComponent: cameraComponent)
 
         if gaussianComponent.isChunked {
             guard let chunkPipelines, let budgetState, let chunkTable = gaussianComponent.chunkTable,
@@ -635,7 +638,7 @@ public func executeGaussianPreprocess(_ commandBuffer: MTLCommandBuffer) {
         // Same effectiveViewMatrix/effectiveCameraPosition requirement as the cull pass — see
         // GaussianEntityFrameMatrices. This is the head-centre view: the footprint and colour
         // are computed once; the draw re-projects the centre per eye.
-        let matrices = GaussianEntityFrameMatrices(worldTransform: worldTransformComponent, cameraComponent: cameraComponent)
+        let matrices = GaussianEntityFrameMatrices(worldTransform: worldTransformComponent, gaussianComponent: gaussianComponent, cameraComponent: cameraComponent)
         var gaussianUniform = matrices.uniforms
         var localNumGaussians = UInt32(splatCount)
         var viewportBytes = viewport

--- a/Sources/UntoldEngine/Systems/GeometryStreamingSystem+GaussianStreaming.swift
+++ b/Sources/UntoldEngine/Systems/GeometryStreamingSystem+GaussianStreaming.swift
@@ -209,19 +209,27 @@ extension GeometryStreamingSystem {
                 // marks hasExplicitBoundingBox, so this never overwrites it), auto-populate one
                 // from this tier's actual splat data instead of leaving the entity on its
                 // default placeholder box forever.
+                // The entity's alignment: the resident component's, else the one a streaming
+                // eviction stashed, else identity.
+                let streaming = scene.get(component: StreamingComponent.self, for: entityId)
+                let splatToEntity = scene.get(component: GaussianComponent.self, for: entityId)?.splatToEntity
+                    ?? streaming?.retainedSplatToEntity
+                    ?? matrix_identity_float4x4
                 if !lod.hasExplicitBoundingBox,
                    let local = scene.get(component: LocalTransformComponent.self, for: entityId)
                 {
-                    let splatToEntity = scene.get(component: GaussianComponent.self, for: entityId)?.splatToEntity ?? matrix_identity_float4x4
                     local.boundingBox = gaussianEntityBoundingBox(built.boundingBox, splatToEntity: splatToEntity)
                 }
 
                 // Reuse the entity's existing GaussianComponent if it already has one — scene.assign
                 // unconditionally re-initializes the component slot, which would drop the previous
                 // instance (and every Metal buffer it retained) without releasing it.
-                if let live = scene.get(component: GaussianComponent.self, for: entityId)
-                    ?? scene.assign(to: entityId, component: GaussianComponent.self)
-                {
+                if let live = scene.get(component: GaussianComponent.self, for: entityId) {
+                    copyGaussianComponentBuffers(from: built.component, to: live)
+                    lod.currentLOD = lodIndex
+                } else if let live = scene.assign(to: entityId, component: GaussianComponent.self) {
+                    live.splatToEntity = splatToEntity
+                    streaming?.retainedSplatToEntity = nil
                     copyGaussianComponentBuffers(from: built.component, to: live)
                     lod.currentLOD = lodIndex
                 }
@@ -264,6 +272,11 @@ extension GeometryStreamingSystem {
                 lod.desiredLOD = max(0, lod.lodLevels.count - 1)
             }
 
+            // The alignment is the entity's, not the payload's: keep it for the reload, which
+            // builds a fresh component (`applyGaussianLoadResult`).
+            if let gaussian = scene.get(component: GaussianComponent.self, for: entityId) {
+                streaming.retainedSplatToEntity = gaussian.splatToEntity
+            }
             removeEntityGaussian(entityId: entityId)
 
             // removeEntityGaussian already unregisters from MemoryBudgetManager, but the call

--- a/Sources/UntoldEngine/Systems/GeometryStreamingSystem+GaussianStreaming.swift
+++ b/Sources/UntoldEngine/Systems/GeometryStreamingSystem+GaussianStreaming.swift
@@ -14,6 +14,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import Foundation
+import simd
 
 extension GeometryStreamingSystem {
     /// Dispatches the async load for a streamed Gaussian-splat entity and installs the
@@ -211,7 +212,8 @@ extension GeometryStreamingSystem {
                 if !lod.hasExplicitBoundingBox,
                    let local = scene.get(component: LocalTransformComponent.self, for: entityId)
                 {
-                    local.boundingBox = built.boundingBox
+                    let splatToEntity = scene.get(component: GaussianComponent.self, for: entityId)?.splatToEntity ?? matrix_identity_float4x4
+                    local.boundingBox = gaussianEntityBoundingBox(built.boundingBox, splatToEntity: splatToEntity)
                 }
 
                 // Reuse the entity's existing GaussianComponent if it already has one — scene.assign

--- a/Sources/UntoldEngine/Systems/RegistrationSystem.swift
+++ b/Sources/UntoldEngine/Systems/RegistrationSystem.swift
@@ -687,6 +687,7 @@ private func attachGaussianAssetLinkIfPresent(entityId: EntityID, node: RuntimeA
     component.occluderShrinkMeters = link.occluderShrinkMeters
     component.exposureOffsetEV = link.exposureOffsetEV
     component.swapDistanceMeters = link.swapDistanceMeters
+    component.alignment = link.alignment
 }
 
 /// Register all renderable nodes in a .untold RuntimeAsset as OCC stub entities.
@@ -3260,7 +3261,7 @@ func removeEntityMesh(entityId: EntityID) {
         MemoryBudgetManager.shared.setAuxiliaryMeshBytes(entityId: entityId, bytes: 0)
         MemoryBudgetManager.shared.registerMesh(entityId: entityId, meshSizeBytes: gaussian.estimatedGPUBytes)
         if let box = gaussian.localBoundingBox, let localTransform = scene.get(component: LocalTransformComponent.self, for: entityId) {
-            localTransform.boundingBox = box
+            localTransform.boundingBox = gaussianEntityBoundingBox(box, splatToEntity: gaussian.splatToEntity)
         }
     }
 }
@@ -4084,7 +4085,10 @@ func buildGaussianComponentFromUntoldGS(url: URL) -> (
 private func applyGaussianLoadResult(_ result: GaussianLoadResult, to entityId: EntityID, opacityScale: Float = 1) {
     // Release a splat already on the entity first: re-assigning the component slot would
     // leave the old instance and its Metal buffers alive (see `copyGaussianComponentBuffers`).
-    if scene.get(component: GaussianComponent.self, for: entityId) != nil {
+    // Its alignment is the entity's, not the payload's, and carries over to the reload.
+    var splatToEntity = matrix_identity_float4x4
+    if let previous = scene.get(component: GaussianComponent.self, for: entityId) {
+        splatToEntity = previous.splatToEntity
         removeEntityGaussian(entityId: entityId)
     }
     registerComponent(entityId: entityId, componentType: GaussianComponent.self)
@@ -4096,6 +4100,7 @@ private func applyGaussianLoadResult(_ result: GaussianLoadResult, to entityId: 
 
     copyGaussianLoadResult(result, to: gaussianComponent)
     gaussianComponent.opacityScale = max(0, opacityScale)
+    gaussianComponent.splatToEntity = splatToEntity
 
     if entityHasMesh(entityId) {
         MemoryBudgetManager.shared.setAuxiliaryMeshBytes(entityId: entityId, bytes: result.estimatedGPUBytes)
@@ -4105,8 +4110,33 @@ private func applyGaussianLoadResult(_ result: GaussianLoadResult, to entityId: 
     MemoryBudgetManager.shared.registerMesh(entityId: entityId, meshSizeBytes: result.estimatedGPUBytes)
 
     if let localTransform = scene.get(component: LocalTransformComponent.self, for: entityId) {
-        localTransform.boundingBox = result.boundingBox
+        localTransform.boundingBox = gaussianEntityBoundingBox(result.boundingBox, splatToEntity: gaussianComponent.splatToEntity)
     }
+}
+
+/// The splat's own box carried into the entity's local space through `splatToEntity`: the box
+/// of its eight transformed corners. What the entity's bounding box becomes when the splat is
+/// the entity's only representation.
+func gaussianEntityBoundingBox(
+    _ box: (min: simd_float3, max: simd_float3),
+    splatToEntity: simd_float4x4
+) -> (min: simd_float3, max: simd_float3) {
+    if splatToEntity == matrix_identity_float4x4 {
+        return box
+    }
+    var result = (min: simd_float3(repeating: .greatestFiniteMagnitude), max: simd_float3(repeating: -.greatestFiniteMagnitude))
+    for corner in 0 ..< 8 {
+        let local = simd_float3(
+            corner & 1 == 0 ? box.min.x : box.max.x,
+            corner & 2 == 0 ? box.min.y : box.max.y,
+            corner & 4 == 0 ? box.min.z : box.max.z
+        )
+        let transformed = simd_mul(splatToEntity, simd_float4(local, 1))
+        let point = simd_float3(transformed.x, transformed.y, transformed.z)
+        result.min = simd_min(result.min, point)
+        result.max = simd_max(result.max, point)
+    }
+    return result
 }
 
 /// Whether the entity draws a mesh (a `RenderComponent` with geometry) — the splat on such an

--- a/Sources/UntoldEngine/Systems/RegistrationSystem.swift
+++ b/Sources/UntoldEngine/Systems/RegistrationSystem.swift
@@ -4085,11 +4085,17 @@ func buildGaussianComponentFromUntoldGS(url: URL) -> (
 private func applyGaussianLoadResult(_ result: GaussianLoadResult, to entityId: EntityID, opacityScale: Float = 1) {
     // Release a splat already on the entity first: re-assigning the component slot would
     // leave the old instance and its Metal buffers alive (see `copyGaussianComponentBuffers`).
-    // Its alignment is the entity's, not the payload's, and carries over to the reload.
+    // Its alignment is the entity's, not the payload's, and carries over to the reload — from
+    // the resident component, or from the stash a streaming eviction left behind.
     var splatToEntity = matrix_identity_float4x4
     if let previous = scene.get(component: GaussianComponent.self, for: entityId) {
         splatToEntity = previous.splatToEntity
         removeEntityGaussian(entityId: entityId)
+    } else if let streaming = scene.get(component: StreamingComponent.self, for: entityId),
+              let retained = streaming.retainedSplatToEntity
+    {
+        splatToEntity = retained
+        streaming.retainedSplatToEntity = nil
     }
     registerComponent(entityId: entityId, componentType: GaussianComponent.self)
 
@@ -4112,6 +4118,28 @@ private func applyGaussianLoadResult(_ result: GaussianLoadResult, to entityId: 
     if let localTransform = scene.get(component: LocalTransformComponent.self, for: entityId) {
         localTransform.boundingBox = gaussianEntityBoundingBox(result.boundingBox, splatToEntity: gaussianComponent.splatToEntity)
     }
+}
+
+/// Places the entity's splat inside the entity: `GaussianComponent.splatToEntity` becomes
+/// `splatToEntity` (`GaussianSplatAlignment.matrix` for a scene link's alignment; identity puts
+/// the splat back where the payload has it). When the splat is the entity's only representation
+/// its bounding box is carried through the new value as well, so the LOD selection and the
+/// bounds tools see the splat where it is drawn; a twin entity keeps its mesh's box, and a
+/// progressive entity whose box the caller supplied keeps that one. Cheap to call every tick
+/// with the same value: an unchanged matrix does nothing. Nothing happens on an entity
+/// without a splat.
+public func setGaussianSplatToEntity(entityId: EntityID, _ splatToEntity: simd_float4x4) {
+    guard let gaussian = scene.get(component: GaussianComponent.self, for: entityId),
+          gaussian.splatToEntity != splatToEntity
+    else { return }
+    gaussian.splatToEntity = splatToEntity
+
+    guard !entityHasMesh(entityId),
+          let box = gaussian.localBoundingBox,
+          let localTransform = scene.get(component: LocalTransformComponent.self, for: entityId),
+          scene.get(component: GaussianLODComponent.self, for: entityId)?.hasExplicitBoundingBox != true
+    else { return }
+    localTransform.boundingBox = gaussianEntityBoundingBox(box, splatToEntity: splatToEntity)
 }
 
 /// The splat's own box carried into the entity's local space through `splatToEntity`: the box

--- a/Tests/UntoldEngineRenderTests/GaussianSplatAlignmentRenderTest.swift
+++ b/Tests/UntoldEngineRenderTests/GaussianSplatAlignmentRenderTest.swift
@@ -27,8 +27,13 @@ final class GaussianSplatAlignmentRenderTest: BaseRenderSetup {
     /// The far camera of the other Gaussian tests: the whole 200-splat fixture in view, with room
     /// for it to move a metre and grow by half.
     private let camera = (eye: simd_float3(0, 3, 7), target: simd_float3.zero)
+    /// A camera close enough that the whole fixture just fits: the alignment pushes part of it
+    /// past the guard-banded frustum, so the cull has splats to drop.
+    private let nearCamera = (eye: simd_float3(0, 1.5, 3), target: simd_float3.zero)
     /// The alignment under test: a metre along +X, 30° about +Y, 1.5× uniform.
     private let alignment = GaussianSplatAlignment(translation: SIMD3<Float>(1, 0, 0), yawDegrees: 30, scale: 1.5)
+    /// A pose for the entity that is not the identity in any part: the composition order shows.
+    private let entityPose = GaussianSplatAlignment(translation: SIMD3<Float>(2, 0, -1), yawDegrees: 90, scale: 0.8)
 
     override func setUp() async throws {
         try await super.setUp()
@@ -91,6 +96,14 @@ final class GaussianSplatAlignmentRenderTest: BaseRenderSetup {
         XCTAssertGreaterThan(quality.psnr, 55, "\(what): \(quality.psnr) dB over covered pixels", file: file, line: line)
     }
 
+    private func assertEqual(_ a: simd_float4x4, _ b: simd_float4x4, _ what: String, file: StaticString = #filePath, line: UInt = #line) {
+        for column in 0 ..< 4 {
+            for row in 0 ..< 4 {
+                XCTAssertEqual(a[column][row], b[column][row], accuracy: 1e-5, "\(what) [\(column)][\(row)]", file: file, line: line)
+            }
+        }
+    }
+
     // MARK: - Tests
 
     /// A splat at the origin with `splatToEntity = T·R_y·S` renders like the same splat with an
@@ -107,23 +120,87 @@ final class GaussianSplatAlignmentRenderTest: BaseRenderSetup {
         // The reference: the entity itself moved, turned and scaled.
         setEntityTransform(entity, translation: alignment.translation, yawDegrees: alignment.yawDegrees, scale: alignment.scale)
         let world = try XCTUnwrap(scene.get(component: WorldTransformComponent.self, for: entity)).space
-        for column in 0 ..< 4 {
-            for row in 0 ..< 4 {
-                XCTAssertEqual(world[column][row], alignment.matrix[column][row], accuracy: 1e-5, "the entity's T·R·S is the alignment matrix [\(column)][\(row)]")
-            }
-        }
+        assertEqual(world, alignment.matrix, "the entity's T·R·S is the alignment matrix")
         let entityMoved = settledSplatLayer()
         let moved = compareGaussianSplatLayers(atRest, entityMoved)
         XCTAssertGreaterThan(moved.differingPixels, 500, "sanity — the transform visibly moves the splat (\(moved.differingPixels) pixels differ)")
 
         // The entity back at the origin, the same transform on the splat alone.
         setEntityTransform(entity, translation: .zero, yawDegrees: 0, scale: 1)
-        component.splatToEntity = alignment.matrix
+        setGaussianSplatToEntity(entityId: entity, alignment.matrix)
+        XCTAssertEqual(component.splatToEntity, alignment.matrix)
         let splatMoved = settledSplatLayer()
         assertSameImage(entityMoved, splatMoved, "splatToEntity against the entity transform")
 
-        component.splatToEntity = matrix_identity_float4x4
+        setGaussianSplatToEntity(entityId: entity, matrix_identity_float4x4)
         assertSameImage(atRest, settledSplatLayer(), "identity again")
+    }
+
+    /// The order of the composition: `worldTransform × splatToEntity`, the alignment inside the
+    /// entity's frame. With the entity posed under a parent that moves, turns and scales it,
+    /// the splat at local A under that parent renders like the splat at identity under the same
+    /// parent with `splatToEntity = A` — and not like A applied in world space, which the
+    /// identity-entity case above cannot tell apart.
+    func testSplatToEntityComposesUnderTheEntityTransform() throws {
+        placeGaussianTestCamera(eye: camera.eye, target: camera.target)
+        let parent = createEntity()
+        setEntityTransform(parent, translation: entityPose.translation, yawDegrees: entityPose.yawDegrees, scale: entityPose.scale)
+        let entity = createEntity()
+        setEntityGaussian(entityId: entity, filename: "test_gaussians", withExtension: "ply")
+        setParent(childId: entity, parentId: parent)
+        let component = try XCTUnwrap(scene.get(component: GaussianComponent.self, for: entity))
+
+        // The reference: the child at local A under the posed parent.
+        setEntityTransform(entity, translation: alignment.translation, yawDegrees: alignment.yawDegrees, scale: alignment.scale)
+        let composed = simd_mul(entityPose.matrix, alignment.matrix)
+        let world = try XCTUnwrap(scene.get(component: WorldTransformComponent.self, for: entity)).space
+        assertEqual(world, composed, "the child's world transform is E·A")
+        let childMoved = settledSplatLayer()
+
+        // The child back at identity under the parent, A on the splat alone.
+        setEntityTransform(entity, translation: .zero, yawDegrees: 0, scale: 1)
+        let childWorld = try XCTUnwrap(scene.get(component: WorldTransformComponent.self, for: entity)).space
+        assertEqual(childWorld, entityPose.matrix, "the child's world transform is E")
+        setGaussianSplatToEntity(entityId: entity, alignment.matrix)
+        XCTAssertEqual(component.splatToEntity, alignment.matrix)
+        let splatMoved = settledSplatLayer()
+        assertSameImage(childMoved, splatMoved, "splatToEntity under a posed parent against the same local transform")
+
+        // The other order would not pass: A applied to the entity's world pose puts the splat
+        // origin nearly a metre away, far past the tolerance of the comparison above.
+        let swapped = simd_mul(alignment.matrix, entityPose.matrix)
+        XCTAssertGreaterThan(simd_length(swapped.columns.3 - composed.columns.3), 0.5, "sanity — the two orders place the splat apart")
+    }
+
+    /// The cull composes the alignment too: with the fixture at the frustum edge the alignment
+    /// pushes splats out of view, and the visible set of the splatToEntity render is the visible
+    /// set of the entity-transform render, not the unaligned one.
+    func testTheCullComposesTheAlignmentAtTheFrustumEdge() throws {
+        placeGaussianTestCamera(eye: nearCamera.eye, target: nearCamera.target)
+        let entity = createEntity()
+        setEntityGaussian(entityId: entity, filename: "test_gaussians", withExtension: "ply")
+        let component = try XCTUnwrap(scene.get(component: GaussianComponent.self, for: entity))
+        let splatCount = Int(component.splatCount)
+
+        let atRest = settledSplatLayer()
+        let atRestVisible = sharedGaussianVisibleCount()
+        XCTAssertEqual(atRestVisible, splatCount, "sanity — the near camera still holds the unaligned fixture")
+
+        setEntityTransform(entity, translation: alignment.translation, yawDegrees: alignment.yawDegrees, scale: alignment.scale)
+        let entityMoved = settledSplatLayer()
+        let entityMovedVisible = sharedGaussianVisibleCount()
+        XCTAssertLessThan(entityMovedVisible, atRestVisible, "sanity — the transform pushes part of the fixture out of the frustum (\(entityMovedVisible) of \(atRestVisible) left)")
+        XCTAssertGreaterThan(compareGaussianSplatLayers(atRest, entityMoved).differingPixels, 500, "sanity — the transform visibly moves the splat")
+
+        setEntityTransform(entity, translation: .zero, yawDegrees: 0, scale: 1)
+        setGaussianSplatToEntity(entityId: entity, alignment.matrix)
+        let splatMoved = settledSplatLayer()
+        XCTAssertEqual(sharedGaussianVisibleCount(), entityMovedVisible, "the cull sees the splat where the alignment puts it")
+        assertSameImage(entityMoved, splatMoved, "splatToEntity against the entity transform at the frustum edge")
+
+        setGaussianSplatToEntity(entityId: entity, matrix_identity_float4x4)
+        assertSameImage(atRest, settledSplatLayer(), "identity again")
+        XCTAssertEqual(sharedGaussianVisibleCount(), atRestVisible)
     }
 
     /// The chunked (`.untoldgs`) path — chunk cull, fused decode-and-preprocess — composes the
@@ -137,25 +214,61 @@ final class GaussianSplatAlignmentRenderTest: BaseRenderSetup {
         XCTAssertTrue(component.isChunked)
         let legacy = try GaussianLegacyTwin(loaded: GaussianChunkLoader.load(url: url))
 
-        component.splatToEntity = alignment.matrix
+        setGaussianSplatToEntity(entityId: entity, alignment.matrix)
         let chunked = settledSplatLayer()
         let wholeBuffer = legacy.withLegacyBuffers(component) { settledSplatLayer() }
         assertSameImage(chunked, wholeBuffer, "chunked against whole-buffer with an alignment")
 
         // And the alignment moved it: the aligned chunked frame is not the unaligned one.
-        component.splatToEntity = matrix_identity_float4x4
+        setGaussianSplatToEntity(entityId: entity, matrix_identity_float4x4)
         let unaligned = settledSplatLayer()
         XCTAssertGreaterThan(compareGaussianSplatLayers(chunked, unaligned).differingPixels, 500, "sanity — the alignment visibly moves the chunked splat")
     }
 
+    /// The chunk cull and the fused per-chunk preprocess compose the alignment like the
+    /// whole-buffer cull does: at the frustum edge both paths keep the same splats.
+    func testChunkedCullMatchesTheWholeBufferCullAtTheFrustumEdge() throws {
+        placeGaussianTestCamera(eye: nearCamera.eye, target: nearCamera.target)
+        let url = try bakeV3(chunkSplats: 4)
+        let entity = createEntity()
+        setEntityGaussian(entityId: entity, filename: url.deletingPathExtension().path, withExtension: "untoldgs")
+        let component = try XCTUnwrap(scene.get(component: GaussianComponent.self, for: entity))
+        XCTAssertTrue(component.isChunked)
+        let legacy = try GaussianLegacyTwin(loaded: GaussianChunkLoader.load(url: url))
+
+        _ = settledSplatLayer()
+        let unalignedVisible = sharedGaussianVisibleCount()
+        XCTAssertEqual(unalignedVisible, Int(component.splatCount), "sanity — the near camera still holds the unaligned fixture")
+
+        setGaussianSplatToEntity(entityId: entity, alignment.matrix)
+        let chunked = settledSplatLayer()
+        let chunkedVisible = sharedGaussianVisibleCount()
+        XCTAssertLessThan(chunkedVisible, unalignedVisible, "sanity — the alignment pushes part of the fixture out of the frustum (\(chunkedVisible) of \(unalignedVisible) left)")
+        let (wholeBuffer, wholeBufferVisible) = legacy.withLegacyBuffers(component) { (settledSplatLayer(), sharedGaussianVisibleCount()) }
+        XCTAssertEqual(chunkedVisible, wholeBufferVisible, "the chunked path culls the aligned splat like the whole-buffer path")
+        assertSameImage(chunked, wholeBuffer, "chunked against whole-buffer with an alignment at the frustum edge")
+    }
+
     /// The alignment belongs to the entity, not the payload: a reload of the same entity keeps
-    /// it, and a splat-only entity's bounding box is the splat's box carried through it.
+    /// it, and a splat-only entity's bounding box is the splat's box carried through it — as
+    /// soon as it is set, not only at the next load.
     func testAReloadKeepsSplatToEntityAndTheEntityBoxFollowsIt() throws {
         let entity = createEntity()
         setEntityGaussian(entityId: entity, filename: "test_gaussians", withExtension: "ply")
         let component = try XCTUnwrap(scene.get(component: GaussianComponent.self, for: entity))
         let splatBox = try XCTUnwrap(component.localBoundingBox)
-        component.splatToEntity = alignment.matrix
+        let unalignedBox = try XCTUnwrap(scene.get(component: LocalTransformComponent.self, for: entity)).boundingBox
+        XCTAssertEqual(unalignedBox.min, splatBox.min)
+        XCTAssertEqual(unalignedBox.max, splatBox.max)
+
+        // Set on the resident splat: the component and the entity box follow at once.
+        setGaussianSplatToEntity(entityId: entity, alignment.matrix)
+        XCTAssertEqual(component.splatToEntity, alignment.matrix)
+        let expected = gaussianEntityBoundingBox(splatBox, splatToEntity: alignment.matrix)
+        let liveBox = try XCTUnwrap(scene.get(component: LocalTransformComponent.self, for: entity)).boundingBox
+        XCTAssertEqual(liveBox.min, expected.min, "the entity box follows the set, with no reload")
+        XCTAssertEqual(liveBox.max, expected.max)
+        XCTAssertEqual(try XCTUnwrap(component.localBoundingBox).min, splatBox.min, "the splat's own box is untouched")
 
         setEntityGaussian(entityId: entity, filename: "test_gaussians", withExtension: "ply")
         let reloaded = try XCTUnwrap(scene.get(component: GaussianComponent.self, for: entity))
@@ -164,10 +277,19 @@ final class GaussianSplatAlignmentRenderTest: BaseRenderSetup {
         XCTAssertEqual(try XCTUnwrap(reloaded.localBoundingBox).min, splatBox.min, "the splat's own box is the payload's")
 
         let entityBox = try XCTUnwrap(scene.get(component: LocalTransformComponent.self, for: entity)).boundingBox
-        let expected = gaussianEntityBoundingBox(splatBox, splatToEntity: alignment.matrix)
         XCTAssertEqual(entityBox.min, expected.min)
         XCTAssertEqual(entityBox.max, expected.max)
         XCTAssertGreaterThan(entityBox.max.x, splatBox.max.x, "moved a metre along +X and grown: the box followed")
+
+        // Back to identity: the box is the splat's again. On an entity without a splat the
+        // call is a no-op.
+        setGaussianSplatToEntity(entityId: entity, matrix_identity_float4x4)
+        let restored = try XCTUnwrap(scene.get(component: LocalTransformComponent.self, for: entity)).boundingBox
+        XCTAssertEqual(restored.min, splatBox.min)
+        XCTAssertEqual(restored.max, splatBox.max)
+        let bare = createEntity()
+        setGaussianSplatToEntity(entityId: bare, alignment.matrix)
+        XCTAssertNil(scene.get(component: GaussianComponent.self, for: bare))
 
         // The corner sweep: a translated, turned and scaled unit box.
         let unit = (min: simd_float3(repeating: -1), max: simd_float3(repeating: 1))

--- a/Tests/UntoldEngineRenderTests/GaussianSplatAlignmentRenderTest.swift
+++ b/Tests/UntoldEngineRenderTests/GaussianSplatAlignmentRenderTest.swift
@@ -1,0 +1,186 @@
+//
+//  GaussianSplatAlignmentRenderTest.swift
+//  UntoldEngine
+//
+//  `GaussianComponent.splatToEntity`: the splat's placement inside its entity, composed onto the
+//  entity's world transform by the cull, the preprocess and the draw. Moving the splat through it
+//  must render exactly like moving the entity, on both the whole-buffer and the chunked path.
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import CShaderTypes
+import Metal
+import simd
+@testable import UntoldEngine
+import XCTest
+
+final class GaussianSplatAlignmentRenderTest: BaseRenderSetup {
+    private var temporaryFiles: [URL] = []
+    private var savedDisableHZBOcclusionCull = false
+    private var savedDisableChunkCull = false
+    private var savedDisableWorkingSetBudget = false
+
+    /// The far camera of the other Gaussian tests: the whole 200-splat fixture in view, with room
+    /// for it to move a metre and grow by half.
+    private let camera = (eye: simd_float3(0, 3, 7), target: simd_float3.zero)
+    /// The alignment under test: a metre along +X, 30° about +Y, 1.5× uniform.
+    private let alignment = GaussianSplatAlignment(translation: SIMD3<Float>(1, 0, 0), yawDegrees: 30, scale: 1.5)
+
+    override func setUp() async throws {
+        try await super.setUp()
+        savedDisableHZBOcclusionCull = GaussianDebugOptions.shared.disableHZBOcclusionCull
+        savedDisableChunkCull = GaussianDebugOptions.shared.disableChunkCull
+        savedDisableWorkingSetBudget = GaussianDebugOptions.shared.disableWorkingSetBudget
+        // The previous frame's HZB would make the first of two frames differ from the second.
+        GaussianDebugOptions.shared.disableHZBOcclusionCull = true
+        GaussianDebugOptions.shared.disableChunkCull = false
+        GaussianDebugOptions.shared.disableWorkingSetBudget = true
+        GaussianSharedWorkingSet.shared.resetBudgetHysteresis()
+    }
+
+    override func tearDown() async throws {
+        GaussianDebugOptions.shared.disableHZBOcclusionCull = savedDisableHZBOcclusionCull
+        GaussianDebugOptions.shared.disableChunkCull = savedDisableChunkCull
+        GaussianDebugOptions.shared.disableWorkingSetBudget = savedDisableWorkingSetBudget
+        GaussianSharedWorkingSet.shared.resetBudgetHysteresis()
+        destroyAllEntities()
+        for url in temporaryFiles {
+            try? FileManager.default.removeItem(at: url)
+        }
+        temporaryFiles.removeAll()
+        try await super.tearDown()
+    }
+
+    override func initializeAssets() {}
+
+    // MARK: - Helpers
+
+    private func bakeV3(chunkSplats log2: UInt8) throws -> URL {
+        let ply = try XCTUnwrap(LoadingSystem.shared.resourceURL(forResource: "test_gaussians", withExtension: "ply", subResource: nil))
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GaussianSplatAlignmentRenderTest-\(UUID().uuidString)")
+            .appendingPathExtension("untoldgs")
+        var options = UntoldGSCookOptions()
+        options.log2ChunkSplats = log2
+        let result = try bakeGaussianSplatProgressiveTiers(plyURL: ply, outputBaseURL: output, lodFractions: [1.0], cookOptions: options)
+        let url = try XCTUnwrap(result.tiers.first?.url)
+        temporaryFiles.append(url)
+        return url
+    }
+
+    /// Two frames (the first settles the in-flight slots), the second one's splat layer.
+    private func settledSplatLayer() -> [Float16] {
+        _ = renderGaussianSplatLayer()
+        return renderGaussianSplatLayer()
+    }
+
+    private func setEntityTransform(_ entity: EntityID, translation: simd_float3, yawDegrees: Float, scale: Float) {
+        translateTo(entityId: entity, position: translation)
+        rotateTo(entityId: entity, angle: yawDegrees, axis: simd_float3(0, 1, 0))
+        scaleTo(entityId: entity, scale: simd_float3(repeating: scale))
+    }
+
+    private func assertSameImage(_ a: [Float16], _ b: [Float16], _ what: String, file: StaticString = #filePath, line: UInt = #line) {
+        let quality = compareGaussianSplatLayers(a, b)
+        XCTAssertGreaterThan(quality.covered, 500, "sanity — the asset covers part of the frame", file: file, line: line)
+        XCTAssertLessThanOrEqual(quality.differingPixels, 50, "\(what): \(quality.differingPixels) of \(quality.covered) covered pixels differ by more than one 8-bit step", file: file, line: line)
+        XCTAssertGreaterThan(quality.psnr, 55, "\(what): \(quality.psnr) dB over covered pixels", file: file, line: line)
+    }
+
+    // MARK: - Tests
+
+    /// A splat at the origin with `splatToEntity = T·R_y·S` renders like the same splat with an
+    /// identity `splatToEntity` on an entity carrying that very T·R·S.
+    func testSplatToEntityRendersLikeTheSameTransformOnTheEntity() throws {
+        placeGaussianTestCamera(eye: camera.eye, target: camera.target)
+        let entity = createEntity()
+        setEntityGaussian(entityId: entity, filename: "test_gaussians", withExtension: "ply")
+        let component = try XCTUnwrap(scene.get(component: GaussianComponent.self, for: entity))
+        XCTAssertEqual(component.splatToEntity, matrix_identity_float4x4, "identity until set")
+
+        let atRest = settledSplatLayer()
+
+        // The reference: the entity itself moved, turned and scaled.
+        setEntityTransform(entity, translation: alignment.translation, yawDegrees: alignment.yawDegrees, scale: alignment.scale)
+        let world = try XCTUnwrap(scene.get(component: WorldTransformComponent.self, for: entity)).space
+        for column in 0 ..< 4 {
+            for row in 0 ..< 4 {
+                XCTAssertEqual(world[column][row], alignment.matrix[column][row], accuracy: 1e-5, "the entity's T·R·S is the alignment matrix [\(column)][\(row)]")
+            }
+        }
+        let entityMoved = settledSplatLayer()
+        let moved = compareGaussianSplatLayers(atRest, entityMoved)
+        XCTAssertGreaterThan(moved.differingPixels, 500, "sanity — the transform visibly moves the splat (\(moved.differingPixels) pixels differ)")
+
+        // The entity back at the origin, the same transform on the splat alone.
+        setEntityTransform(entity, translation: .zero, yawDegrees: 0, scale: 1)
+        component.splatToEntity = alignment.matrix
+        let splatMoved = settledSplatLayer()
+        assertSameImage(entityMoved, splatMoved, "splatToEntity against the entity transform")
+
+        component.splatToEntity = matrix_identity_float4x4
+        assertSameImage(atRest, settledSplatLayer(), "identity again")
+    }
+
+    /// The chunked (`.untoldgs`) path — chunk cull, fused decode-and-preprocess — composes the
+    /// alignment into its constants like the whole-buffer path does.
+    func testChunkedPathMatchesTheLegacyPathWithAnAlignment() throws {
+        placeGaussianTestCamera(eye: camera.eye, target: camera.target)
+        let url = try bakeV3(chunkSplats: 4)
+        let entity = createEntity()
+        setEntityGaussian(entityId: entity, filename: url.deletingPathExtension().path, withExtension: "untoldgs")
+        let component = try XCTUnwrap(scene.get(component: GaussianComponent.self, for: entity))
+        XCTAssertTrue(component.isChunked)
+        let legacy = try GaussianLegacyTwin(loaded: GaussianChunkLoader.load(url: url))
+
+        component.splatToEntity = alignment.matrix
+        let chunked = settledSplatLayer()
+        let wholeBuffer = legacy.withLegacyBuffers(component) { settledSplatLayer() }
+        assertSameImage(chunked, wholeBuffer, "chunked against whole-buffer with an alignment")
+
+        // And the alignment moved it: the aligned chunked frame is not the unaligned one.
+        component.splatToEntity = matrix_identity_float4x4
+        let unaligned = settledSplatLayer()
+        XCTAssertGreaterThan(compareGaussianSplatLayers(chunked, unaligned).differingPixels, 500, "sanity — the alignment visibly moves the chunked splat")
+    }
+
+    /// The alignment belongs to the entity, not the payload: a reload of the same entity keeps
+    /// it, and a splat-only entity's bounding box is the splat's box carried through it.
+    func testAReloadKeepsSplatToEntityAndTheEntityBoxFollowsIt() throws {
+        let entity = createEntity()
+        setEntityGaussian(entityId: entity, filename: "test_gaussians", withExtension: "ply")
+        let component = try XCTUnwrap(scene.get(component: GaussianComponent.self, for: entity))
+        let splatBox = try XCTUnwrap(component.localBoundingBox)
+        component.splatToEntity = alignment.matrix
+
+        setEntityGaussian(entityId: entity, filename: "test_gaussians", withExtension: "ply")
+        let reloaded = try XCTUnwrap(scene.get(component: GaussianComponent.self, for: entity))
+        XCTAssertTrue(reloaded !== component, "a reload builds a fresh component")
+        XCTAssertEqual(reloaded.splatToEntity, alignment.matrix, "…that keeps the entity's alignment")
+        XCTAssertEqual(try XCTUnwrap(reloaded.localBoundingBox).min, splatBox.min, "the splat's own box is the payload's")
+
+        let entityBox = try XCTUnwrap(scene.get(component: LocalTransformComponent.self, for: entity)).boundingBox
+        let expected = gaussianEntityBoundingBox(splatBox, splatToEntity: alignment.matrix)
+        XCTAssertEqual(entityBox.min, expected.min)
+        XCTAssertEqual(entityBox.max, expected.max)
+        XCTAssertGreaterThan(entityBox.max.x, splatBox.max.x, "moved a metre along +X and grown: the box followed")
+
+        // The corner sweep: a translated, turned and scaled unit box.
+        let unit = (min: simd_float3(repeating: -1), max: simd_float3(repeating: 1))
+        let swept = gaussianEntityBoundingBox(unit, splatToEntity: alignment.matrix)
+        let halfDiagonal = 1.5 * (cos(30 * Float.pi / 180) + sin(30 * Float.pi / 180))
+        XCTAssertEqual(swept.min.x, 1 - halfDiagonal, accuracy: 1e-5)
+        XCTAssertEqual(swept.max.x, 1 + halfDiagonal, accuracy: 1e-5)
+        XCTAssertEqual(swept.min.y, -1.5, accuracy: 1e-5)
+        XCTAssertEqual(swept.max.y, 1.5, accuracy: 1e-5)
+        XCTAssertEqual(swept.min.z, -halfDiagonal, accuracy: 1e-5)
+        XCTAssertEqual(swept.max.z, halfDiagonal, accuracy: 1e-5)
+        let identity = gaussianEntityBoundingBox(unit, splatToEntity: matrix_identity_float4x4)
+        XCTAssertEqual(identity.min, unit.min)
+        XCTAssertEqual(identity.max, unit.max)
+    }
+}

--- a/Tests/UntoldEngineRenderTests/GaussianStreamingTest.swift
+++ b/Tests/UntoldEngineRenderTests/GaussianStreamingTest.swift
@@ -461,6 +461,43 @@ final class GaussianStreamingTest: BaseRenderSetup {
         XCTAssertGreaterThan(gaussian?.splatCount ?? 0, 0, "❌ Reloaded splat count should be nonzero")
     }
 
+    /// The entity's alignment outlives a residency cycle: `unloadGaussian` drops the
+    /// `GaussianComponent`, and the component the reload builds carries the `splatToEntity`
+    /// the evicted one had, with the entity's box carried through it.
+    func testAReloadAfterEvictionKeepsSplatToEntity() async throws {
+        let entity = makeUnloadedGaussianEntity(distance: 0.0, streamingRadius: 10.0, unloadRadius: 20.0)
+        let alignment = GaussianSplatAlignment(translation: SIMD3<Float>(1, 0, 0), yawDegrees: 30, scale: 1.5)
+
+        GeometryStreamingSystem.shared.update(cameraPosition: .zero, deltaTime: 0.1)
+        await scene.get(component: StreamingComponent.self, for: entity)?.loadTask?.value
+        XCTAssertEqual(scene.get(component: StreamingComponent.self, for: entity)?.state, .loaded, "Pre-condition: first load should succeed")
+        let loaded = try XCTUnwrap(scene.get(component: GaussianComponent.self, for: entity))
+        let splatBox = try XCTUnwrap(loaded.localBoundingBox)
+        setGaussianSplatToEntity(entityId: entity, alignment.matrix)
+        XCTAssertNil(scene.get(component: StreamingComponent.self, for: entity)?.retainedSplatToEntity, "nothing stashed while the splat is resident")
+
+        visibleEntityIds = []
+        for _ in 0 ..< 3 {
+            GeometryStreamingSystem.shared.update(cameraPosition: simd_float3(1000, 0, 0), deltaTime: 0.1)
+        }
+        XCTAssertEqual(scene.get(component: StreamingComponent.self, for: entity)?.state, .unloaded, "Pre-condition: entity should unload when far")
+        XCTAssertNil(scene.get(component: GaussianComponent.self, for: entity), "Pre-condition: GaussianComponent should be removed on unload")
+        XCTAssertEqual(scene.get(component: StreamingComponent.self, for: entity)?.retainedSplatToEntity, alignment.matrix, "the eviction stashed the alignment")
+
+        GeometryStreamingSystem.shared.update(cameraPosition: .zero, deltaTime: 0.1)
+        await scene.get(component: StreamingComponent.self, for: entity)?.loadTask?.value
+        XCTAssertEqual(scene.get(component: StreamingComponent.self, for: entity)?.state, .loaded, "Entity should reload after camera re-enters streaming radius")
+
+        let reloaded = try XCTUnwrap(scene.get(component: GaussianComponent.self, for: entity))
+        XCTAssertTrue(reloaded !== loaded, "the reload builds a fresh component")
+        XCTAssertEqual(reloaded.splatToEntity, alignment.matrix, "…that keeps the alignment the evicted one had")
+        XCTAssertNil(scene.get(component: StreamingComponent.self, for: entity)?.retainedSplatToEntity, "the stash is spent on the reload")
+        let entityBox = try XCTUnwrap(scene.get(component: LocalTransformComponent.self, for: entity)).boundingBox
+        let expected = gaussianEntityBoundingBox(splatBox, splatToEntity: alignment.matrix)
+        XCTAssertEqual(entityBox.min, expected.min, "the entity box is the splat's carried through the alignment")
+        XCTAssertEqual(entityBox.max, expected.max)
+    }
+
     // MARK: - Tile ownership / tile unload interaction
 
     /// Regression test: `GeometryStreamingSystem.unloadTile` tears down every scenegraph

--- a/Tests/UntoldEngineRenderTests/MeshOccluderShellRenderTest.swift
+++ b/Tests/UntoldEngineRenderTests/MeshOccluderShellRenderTest.swift
@@ -243,6 +243,7 @@ final class MeshOccluderShellRenderTest: BaseRenderSetup {
         XCTAssertEqual(link.occluderShrinkMeters, 0.03)
         XCTAssertEqual(link.exposureOffsetEV, 0.5)
         XCTAssertEqual(link.swapDistanceMeters, 12)
+        XCTAssertEqual(link.alignment, GaussianSplatAlignment(translation: SIMD3<Float>(0, 0.02, 0), yawDegrees: 90, scale: 1.02), "The record's alignment arrives on the link")
         XCTAssertEqual(link.lodCount, 1)
         XCTAssertEqual(link.lodSplatCounts.count, 1)
         XCTAssertEqual(link.lodSwitchScreenHeights.count, 1)
@@ -398,7 +399,8 @@ final class MeshOccluderShellRenderTest: BaseRenderSetup {
             lodCount: 1,
             occluderShrinkMeters: 0.03,
             exposureOffsetEV: 0.5,
-            swapDistanceMeters: 12
+            swapDistanceMeters: 12,
+            alignment: GaussianSplatAlignment(translation: SIMD3<Float>(0, 0.02, 0), yawDegrees: 90, scale: 1.02)
         )
 
         var header = UntoldFileHeaderV1(

--- a/Tests/UntoldEngineTests/NativeFormatTests.swift
+++ b/Tests/UntoldEngineTests/NativeFormatTests.swift
@@ -304,7 +304,8 @@ final class NativeFormatTests: XCTestCase {
         )
         XCTAssertEqual(record.lodSplatCounts, [20000, 60000, 180_000, 0])
         XCTAssertEqual(record.lodSwitchScreenHeights, [120, 360, 1080, 0])
-        XCTAssertEqual(record.reserved0, [0, 0, 0, 0, 0])
+        XCTAssertNil(record.alignment)
+        XCTAssertEqual(record.alignmentScale, 0, "no alignment: the former reserved words stay zero")
 
         let writer = UntoldBinaryWriter()
         record.encode(to: writer)
@@ -331,6 +332,123 @@ final class NativeFormatTests: XCTestCase {
         XCTAssertEqual(try decoded.string(at: decoded.gaussianAssets[0].payloadPathOffset), "albedo.ktx2")
         XCTAssertTrue(decoded.pluginChunks.isEmpty)
         XCTAssertEqual(decoded.meshes.count, 1)
+    }
+
+    func testGaussianAssetAlignmentRoundTripsInTheFormerReservedWords() throws {
+        let alignment = GaussianSplatAlignment(translation: SIMD3<Float>(0.5, -0.25, 2), yawDegrees: 37.5, scale: 1.25)
+        let record = UntoldGaussianAssetRecordV1(
+            entityId: 3,
+            payloadPathOffset: 25,
+            flags: UntoldGaussianAssetFlags.meshTwin,
+            swapDistanceMeters: 4,
+            alignment: alignment
+        )
+        XCTAssertEqual(record.flags, UntoldGaussianAssetFlags.meshTwin | UntoldGaussianAssetFlags.alignment, "a non-nil alignment sets the flag")
+        XCTAssertEqual(record.alignment, alignment)
+        XCTAssertEqual(record.alignmentTranslation, alignment.translation)
+        XCTAssertEqual(record.alignmentYawDegrees, 37.5)
+        XCTAssertEqual(record.alignmentScale, 1.25)
+
+        let writer = UntoldBinaryWriter()
+        record.encode(to: writer)
+        XCTAssertEqual(writer.count, UntoldGaussianAssetRecordV1.encodedSize, "the record keeps its 80 bytes")
+        let decoded = try UntoldGaussianAssetRecordV1.decode(from: UntoldBinaryReader(data: writer.data))
+        XCTAssertEqual(decoded, record)
+        XCTAssertEqual(decoded.alignment, alignment)
+
+        // The words sit where the reserved words were: bytes 60...79, translation, yaw, scale.
+        let tail = writer.data.subdata(in: 60 ..< 80).withUnsafeBytes { Array($0.bindMemory(to: Float.self)) }
+        XCTAssertEqual(tail, [0.5, -0.25, 2, 37.5, 1.25])
+
+        // Clearing drops the flag and zeroes the words, so the bytes match a pre-alignment record.
+        var cleared = record
+        cleared.alignment = nil
+        XCTAssertEqual(cleared.flags, UntoldGaussianAssetFlags.meshTwin)
+        XCTAssertNil(cleared.alignment)
+        XCTAssertEqual(cleared, UntoldGaussianAssetRecordV1(entityId: 3, payloadPathOffset: 25, flags: UntoldGaussianAssetFlags.meshTwin, swapDistanceMeters: 4))
+    }
+
+    func testGaussianAssetRecordWithoutTheFlagHasNoAlignmentWhateverTheWordsHold() throws {
+        // A file written before the alignment existed: flag clear, words zero.
+        let old = UntoldGaussianAssetRecordV1(entityId: 1, payloadPathOffset: 25, flags: UntoldGaussianAssetFlags.meshTwin)
+        let writer = UntoldBinaryWriter()
+        old.encode(to: writer)
+        XCTAssertEqual(Array(writer.data.suffix(20)), Array(repeating: 0, count: 20))
+        XCTAssertNil(try UntoldGaussianAssetRecordV1.decode(from: UntoldBinaryReader(data: writer.data)).alignment)
+
+        // Words without the flag are kept as read (a byte-for-byte round trip) but mean nothing.
+        var stale = old
+        stale.alignmentScale = 3
+        let staleWriter = UntoldBinaryWriter()
+        stale.encode(to: staleWriter)
+        let decoded = try UntoldGaussianAssetRecordV1.decode(from: UntoldBinaryReader(data: staleWriter.data))
+        XCTAssertEqual(decoded, stale)
+        XCTAssertNil(decoded.alignment)
+    }
+
+    func testGaussianAssetAlignmentMatrixIsTranslationYawScale() {
+        XCTAssertEqual(GaussianSplatAlignment.identity.matrix, matrix_identity_float4x4)
+        XCTAssertTrue(GaussianSplatAlignment.identity.isValid)
+
+        let alignment = GaussianSplatAlignment(translation: SIMD3<Float>(1, 2, 3), yawDegrees: 90, scale: 2)
+        let matrix = alignment.matrix
+        // A point on the splat's +X axis turns about +Y (right-handed) onto -Z, doubled, then offset.
+        let point = simd_mul(matrix, SIMD4<Float>(1, 0, 0, 1))
+        XCTAssertEqual(point.x, 1, accuracy: 1e-5)
+        XCTAssertEqual(point.y, 2, accuracy: 1e-5)
+        XCTAssertEqual(point.z, 3 - 2, accuracy: 1e-5)
+        XCTAssertEqual(point.w, 1)
+        // Same as the engine's own rotation helper composed T · R · S.
+        let expected = simd_mul(
+            matrix4x4Translation(1, 2, 3),
+            simd_mul(matrix4x4Rotation(radians: .pi / 2, axis: SIMD3<Float>(0, 1, 0)), matrix4x4Scale(2, 2, 2))
+        )
+        for column in 0 ..< 4 {
+            for row in 0 ..< 4 {
+                XCTAssertEqual(matrix[column][row], expected[column][row], accuracy: 1e-5, "[\(column)][\(row)]")
+            }
+        }
+
+        XCTAssertFalse(GaussianSplatAlignment(scale: 0).isValid)
+        XCTAssertFalse(GaussianSplatAlignment(scale: -1).isValid)
+        XCTAssertFalse(GaussianSplatAlignment(yawDegrees: .nan).isValid)
+        XCTAssertFalse(GaussianSplatAlignment(translation: SIMD3<Float>(0, .infinity, 0)).isValid)
+    }
+
+    func testGaussianAssetRejectsAnInvalidAlignmentOnlyWhenFlagged() throws {
+        let probe = makeTinyFixture()
+        func fixture(_ record: UntoldGaussianAssetRecordV1) -> Data {
+            let writer = UntoldBinaryWriter()
+            record.encode(to: writer)
+            return makeTinyFixture(pluginChunks: [(.gaussianAssetTable, writer.data, 1)]).fileData
+        }
+        let base = UntoldGaussianAssetRecordV1(entityId: probe.entity.entityId, payloadPathOffset: probe.texture.uriOffset)
+
+        for bad in [
+            GaussianSplatAlignment(scale: 0),
+            GaussianSplatAlignment(scale: -0.5),
+            GaussianSplatAlignment(scale: .infinity),
+            GaussianSplatAlignment(yawDegrees: .nan),
+            GaussianSplatAlignment(translation: SIMD3<Float>(.nan, 0, 0)),
+        ] {
+            var record = base
+            record.alignment = bad
+            XCTAssertThrowsError(try UntoldReader().readAsset(from: fixture(record)), "\(bad)") { error in
+                guard case .invalidGaussianAssetRecord? = error as? UntoldValidationError else {
+                    return XCTFail("unexpected error \(error)")
+                }
+            }
+        }
+
+        var good = base
+        good.alignment = GaussianSplatAlignment(translation: SIMD3<Float>(0, 0.02, 0), yawDegrees: -180, scale: 0.01)
+        XCTAssertEqual(try UntoldReader().readAsset(from: fixture(good)).gaussianAssets, [good])
+
+        // The same words without the flag are not looked at.
+        var unflagged = good
+        unflagged.flags &= ~UntoldGaussianAssetFlags.alignment
+        unflagged.alignmentScale = 0
+        XCTAssertNil(try UntoldReader().readAsset(from: fixture(unflagged)).gaussianAssets.first?.alignment)
     }
 
     func testGaussianAssetWithoutTableDecodesEmpty() throws {

--- a/Tests/UntoldEngineTests/UntoldAssetPatcherTests.swift
+++ b/Tests/UntoldEngineTests/UntoldAssetPatcherTests.swift
@@ -216,6 +216,23 @@ final class UntoldAssetPatcherTests: XCTestCase {
         let flagOnly = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "chair.untoldgs", flags: UntoldGaussianAssetFlags.meshTwin | UntoldGaussianAssetFlags.alignment)
         XCTAssertEqual(flagOnly.flags, UntoldGaussianAssetFlags.meshTwin)
         XCTAssertNil(flagOnly.record(entityId: 0, payloadPathOffset: 0).alignment)
+
+        // Nor is one set on `flags` after the fact, or copied from an aligned record: the link
+        // still validates, writes a record without the bit and reads back with no alignment
+        // instead of failing the read-back with a zero scale.
+        var mutated = plain
+        mutated.flags |= UntoldGaussianAssetFlags.alignment
+        XCTAssertEqual(mutated.flags, UntoldGaussianAssetFlags.meshTwin, "the bit is dropped as it is set")
+        XCTAssertEqual(mutated, plain)
+        var copiedFlags = plain
+        copiedFlags.flags = record.flags
+        XCTAssertEqual(copiedFlags.flags, UntoldGaussianAssetFlags.meshTwin)
+        XCTAssertNoThrow(try copiedFlags.validate())
+        XCTAssertEqual(copiedFlags.record(entityId: 0, payloadPathOffset: 0).flags, UntoldGaussianAssetFlags.meshTwin)
+        XCTAssertNil(copiedFlags.record(entityId: 0, payloadPathOffset: 0).alignment)
+        let written = try UntoldAssetPatcher.settingGaussianAsset(copiedFlags, onEntity: 0, in: data)
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: written), [0: plain])
+        XCTAssertNil(try UntoldReader().readAsset(from: written).gaussianAssets.first?.alignment)
     }
 
     func testRecordOfAnInvalidLinkDoesNotTrap() {

--- a/Tests/UntoldEngineTests/UntoldAssetPatcherTests.swift
+++ b/Tests/UntoldEngineTests/UntoldAssetPatcherTests.swift
@@ -188,6 +188,36 @@ final class UntoldAssetPatcherTests: XCTestCase {
         XCTAssertThrowsError(try long.validate())
     }
 
+    func testAlignmentRoundTripsThroughTheRecordAndTheFile() throws {
+        let alignment = GaussianSplatAlignment(translation: SIMD3<Float>(0.1, 0, -0.3), yawDegrees: 90, scale: 1.02)
+        let aligned = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "chair.untoldgs", lodCount: 1, lodSplatCounts: [300], alignment: alignment)
+        XCTAssertNoThrow(try aligned.validate())
+        XCTAssertEqual(aligned.flags, UntoldGaussianAssetFlags.meshTwin, "the alignment flag is derived, not kept in flags")
+
+        let record = aligned.record(entityId: 0, payloadPathOffset: 0)
+        XCTAssertEqual(record.flags, UntoldGaussianAssetFlags.meshTwin | UntoldGaussianAssetFlags.alignment)
+        XCTAssertEqual(record.alignment, alignment)
+        XCTAssertEqual(UntoldAssetPatcher.GaussianAssetLink(record: record, payloadPath: "chair.untoldgs"), aligned)
+
+        let fixture = makeFixture()
+        let data = try UntoldAssetPatcher.settingGaussianAsset(aligned, onEntity: 0, in: fixture.fileData)
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: data), [0: aligned])
+        XCTAssertEqual(try UntoldReader().readAsset(from: data).gaussianAssets.first?.alignment, alignment)
+
+        // Setting the link again without an alignment clears the flag and the words.
+        let plain = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "chair.untoldgs", lodCount: 1, lodSplatCounts: [300])
+        let cleared = try UntoldAssetPatcher.settingGaussianAsset(plain, onEntity: 0, in: data)
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: cleared), [0: plain])
+        let clearedRecord = try XCTUnwrap(UntoldReader().readAsset(from: cleared).gaussianAssets.first)
+        XCTAssertEqual(clearedRecord.flags, UntoldGaussianAssetFlags.meshTwin)
+        XCTAssertEqual(clearedRecord.alignmentScale, 0)
+
+        // A flags value carrying the bit without an alignment is not written as one.
+        let flagOnly = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "chair.untoldgs", flags: UntoldGaussianAssetFlags.meshTwin | UntoldGaussianAssetFlags.alignment)
+        XCTAssertEqual(flagOnly.flags, UntoldGaussianAssetFlags.meshTwin)
+        XCTAssertNil(flagOnly.record(entityId: 0, payloadPathOffset: 0).alignment)
+    }
+
     func testRecordOfAnInvalidLinkDoesNotTrap() {
         let negative = UntoldAssetPatcher.GaussianAssetLink(payloadPath: "a.untoldgs", lodCount: -1)
         XCTAssertEqual(negative.lodSplatCounts, [])
@@ -330,6 +360,10 @@ final class UntoldAssetPatcherTests: XCTestCase {
         links.append(.init(payloadPath: "chair.untoldgs", exposureOffsetEV: .nan))
         links.append(.init(payloadPath: "chair.untoldgs", swapDistanceMeters: -1))
         links.append(.init(payloadPath: "chair.untoldgs", swapDistanceMeters: .infinity))
+        links.append(.init(payloadPath: "chair.untoldgs", alignment: GaussianSplatAlignment(scale: 0)))
+        links.append(.init(payloadPath: "chair.untoldgs", alignment: GaussianSplatAlignment(scale: -1)))
+        links.append(.init(payloadPath: "chair.untoldgs", alignment: GaussianSplatAlignment(yawDegrees: .nan)))
+        links.append(.init(payloadPath: "chair.untoldgs", alignment: GaussianSplatAlignment(translation: SIMD3<Float>(0, 0, .infinity))))
 
         for link in links {
             XCTAssertThrowsError(try UntoldAssetPatcher.settingGaussianAsset(link, onEntity: 0, in: fixture.fileData), "\(link)") { error in
@@ -347,7 +381,8 @@ final class UntoldAssetPatcherTests: XCTestCase {
             lodSwitchScreenHeights: [1, 2, 3, 4],
             occluderShrinkMeters: 0,
             exposureOffsetEV: -4,
-            swapDistanceMeters: 0
+            swapDistanceMeters: 0,
+            alignment: GaussianSplatAlignment(translation: SIMD3<Float>(-100, 0, 100), yawDegrees: 720, scale: 0.001)
         )
         XCTAssertNoThrow(try UntoldAssetPatcher.settingGaussianAsset(edge, onEntity: 0, in: fixture.fileData))
     }

--- a/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/GaussianLinkCommand.swift
+++ b/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/GaussianLinkCommand.swift
@@ -129,6 +129,9 @@ struct GaussianLinkCommand: ParsableCommand {
             if let alignTranslate {
                 _ = try Self.parseTranslation(alignTranslate)
             }
+            if let alignYawDegrees, !alignYawDegrees.isFinite {
+                throw ValidationError("--align-yaw-degrees must be finite.")
+            }
             if let alignScale, !(alignScale.isFinite && alignScale > 0) {
                 throw ValidationError("--align-scale must be greater than zero.")
             }

--- a/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/GaussianLinkCommand.swift
+++ b/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/GaussianLinkCommand.swift
@@ -10,6 +10,7 @@
 
 import ArgumentParser
 import Foundation
+import simd
 import UntoldEngine
 
 struct GaussianLinkCommand: ParsableCommand {
@@ -31,9 +32,18 @@ struct GaussianLinkCommand: ParsableCommand {
         meshTwin link on an entity without a mesh has nothing to swap from, so the
         command warns and lists the entities that carry meshes.
 
+        The alignment options place the splat inside the entity without a re-cook
+        (translation in metres, yaw about +Y in degrees, uniform scale; the runtime
+        draws the splat with T·R·S composed onto the entity transform). Options
+        left out keep what the entity's existing link already stores;
+        --clear-alignment removes it.
+
         Examples:
           untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \\
             --payload Chair/chair.untoldgs --swap-distance 8 --in-place
+          untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \\
+            --payload Chair/chair.untoldgs --align-translate 0,0.02,-0.1 \\
+            --align-yaw-degrees 90 --align-scale 1.02 --in-place
           untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \\
             --remove --output Chair/chair_plain.untold
           untoldengine gaussian-link --untold Chair/chair.untold --list
@@ -60,6 +70,18 @@ struct GaussianLinkCommand: ParsableCommand {
     @Option(name: .customLong("exposure-offset"), parsing: .unconditional, help: "Exposure offset in EV on top of the payload's capture exposure (negative darkens)")
     var exposureOffset: Float = 0
 
+    @Option(name: .customLong("align-translate"), parsing: .unconditional, help: "Offset of the splat in the entity's local space, metres, as x,y,z")
+    var alignTranslate: String?
+
+    @Option(name: .customLong("align-yaw-degrees"), parsing: .unconditional, help: "Rotation of the splat about the entity's +Y axis, degrees")
+    var alignYawDegrees: Float?
+
+    @Option(name: .customLong("align-scale"), parsing: .unconditional, help: "Uniform scale of the splat, greater than zero")
+    var alignScale: Float?
+
+    @Flag(name: .customLong("clear-alignment"), help: "Drop the alignment the entity's existing link stores")
+    var clearAlignment = false
+
     @Flag(name: .customLong("in-place"), help: "Overwrite the .untold file")
     var inPlace = false
 
@@ -72,9 +94,13 @@ struct GaussianLinkCommand: ParsableCommand {
     @Flag(name: .long, help: "Print the links the file carries and exit")
     var list = false
 
+    private var hasAlignmentOption: Bool {
+        alignTranslate != nil || alignYawDegrees != nil || alignScale != nil
+    }
+
     func validate() throws {
         if list {
-            guard !remove, payload == nil, !inPlace, output == nil else {
+            guard !remove, payload == nil, !inPlace, output == nil, !hasAlignmentOption, !clearAlignment else {
                 throw ValidationError("--list takes no other option than --untold.")
             }
             return
@@ -89,9 +115,21 @@ struct GaussianLinkCommand: ParsableCommand {
             guard payload == nil else {
                 throw ValidationError("--remove takes no --payload.")
             }
+            guard !hasAlignmentOption, !clearAlignment else {
+                throw ValidationError("--remove takes no alignment option.")
+            }
         } else {
             guard payload != nil else {
                 throw ValidationError("Provide --payload, --remove or --list.")
+            }
+            guard !(clearAlignment && hasAlignmentOption) else {
+                throw ValidationError("--clear-alignment takes no --align-* option.")
+            }
+            if let alignTranslate {
+                _ = try Self.parseTranslation(alignTranslate)
+            }
+            if let alignScale, !(alignScale.isFinite && alignScale > 0) {
+                throw ValidationError("--align-scale must be greater than zero.")
             }
         }
     }
@@ -128,18 +166,26 @@ struct GaussianLinkCommand: ParsableCommand {
             if !stored.isRelative {
                 printWarning("\(payloadURL.path) is not inside \(destination.deletingLastPathComponent().path); storing the file name \(stored.path) — keep the payload next to the .untold file that is written")
             }
-            let link = try Self.makeLink(
+            var link = try Self.makeLink(
                 payloadURL: payloadURL,
                 storedPath: stored.path,
                 swapDistance: swapDistance,
                 occluderShrink: occluderShrink,
                 exposureOffset: exposureOffset
             )
+            link.alignment = try Self.mergedAlignment(
+                existing: Self.existingAlignment(entity: entity, in: fileData),
+                translate: alignTranslate.map { try Self.parseTranslation($0) },
+                yawDegrees: alignYawDegrees,
+                scale: alignScale,
+                clear: clearAlignment
+            )
             if let warning = try Self.meshlessEntityWarning(entity: entity, link: link, in: fileData) {
                 printWarning(warning)
             }
             patched = try Self.setting(link, entity: entity, in: fileData)
-            printInfo("Linked entity \(entity) to \(stored.path) (\(link.lodSplatCounts.first ?? 0) splats, swap at \(swapDistance) m, shrink \(occluderShrink) m, \(exposureOffset) EV)")
+            let alignment = link.alignment.map { ", \(Self.describe($0))" } ?? ""
+            printInfo("Linked entity \(entity) to \(stored.path) (\(link.lodSplatCounts.first ?? 0) splats, swap at \(swapDistance) m, shrink \(occluderShrink) m, \(exposureOffset) EV\(alignment))")
         }
 
         try patched.write(to: destination, options: .atomic)
@@ -225,6 +271,52 @@ struct GaussianLinkCommand: ParsableCommand {
         )
     }
 
+    /// `x,y,z` as three finite floats (spaces around the commas allowed).
+    static func parseTranslation(_ text: String) throws -> SIMD3<Float> {
+        let parts = text.split(separator: ",", omittingEmptySubsequences: false).map { $0.trimmingCharacters(in: .whitespaces) }
+        guard parts.count == 3 else {
+            throw ValidationError("--align-translate takes x,y,z; got '\(text)'.")
+        }
+        let values = parts.compactMap(Float.init)
+        guard values.count == 3, values.allSatisfy(\.isFinite) else {
+            throw ValidationError("--align-translate takes three finite numbers; got '\(text)'.")
+        }
+        return SIMD3<Float>(values[0], values[1], values[2])
+    }
+
+    /// The alignment the entity's link in `fileData` stores, nil without a link or alignment.
+    static func existingAlignment(entity: UInt32, in fileData: Data) throws -> GaussianSplatAlignment? {
+        do {
+            return try UntoldAssetPatcher.gaussianAssets(in: fileData)[entity]?.alignment
+        } catch let error as UntoldAssetPatcher.Error {
+            throw GaussianLinkError.patchFailed(error.description)
+        }
+    }
+
+    /// What the new link stores: nothing with `clear`; `existing` untouched when no field is
+    /// given; otherwise the given fields over `existing` (identity when there is none).
+    static func mergedAlignment(
+        existing: GaussianSplatAlignment?,
+        translate: SIMD3<Float>?,
+        yawDegrees: Float?,
+        scale: Float?,
+        clear: Bool
+    ) -> GaussianSplatAlignment? {
+        if clear { return nil }
+        guard translate != nil || yawDegrees != nil || scale != nil else { return existing }
+        var alignment = existing ?? .identity
+        if let translate { alignment.translation = translate }
+        if let yawDegrees { alignment.yawDegrees = yawDegrees }
+        if let scale { alignment.scale = scale }
+        return alignment
+    }
+
+    /// `align (x, y, z) m, yaw d°, scale s` for the listing and the info line.
+    static func describe(_ alignment: GaussianSplatAlignment) -> String {
+        let t = alignment.translation
+        return "align (\(t.x), \(t.y), \(t.z)) m, yaw \(alignment.yawDegrees)°, scale \(alignment.scale)"
+    }
+
     static func setting(_ link: UntoldAssetPatcher.GaussianAssetLink, entity: UInt32, in fileData: Data) throws -> Data {
         do {
             return try UntoldAssetPatcher.settingGaussianAsset(link, onEntity: entity, in: fileData)
@@ -259,7 +351,8 @@ struct GaussianLinkCommand: ParsableCommand {
             ]
             let flags = names.filter { link.flags & $0.0 != 0 }.map(\.1)
             let levels = link.lodCount == 0 ? "1 level" : "\(link.lodCount) level\(link.lodCount == 1 ? "" : "s") \(link.lodSplatCounts)"
-            return "entity \(entity): \(link.payloadPath) [\(flags.joined(separator: ","))] \(levels), swap \(link.swapDistanceMeters) m, shrink \(link.occluderShrinkMeters) m, \(link.exposureOffsetEV) EV"
+            let alignment = link.alignment.map { ", \(describe($0))" } ?? ""
+            return "entity \(entity): \(link.payloadPath) [\(flags.joined(separator: ","))] \(levels), swap \(link.swapDistanceMeters) m, shrink \(link.occluderShrinkMeters) m, \(link.exposureOffsetEV) EV\(alignment)"
         }
     }
 }

--- a/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/GaussianLinkCommand.swift
+++ b/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/GaussianLinkCommand.swift
@@ -35,8 +35,9 @@ struct GaussianLinkCommand: ParsableCommand {
         The alignment options place the splat inside the entity without a re-cook
         (translation in metres, yaw about +Y in degrees, uniform scale; the runtime
         draws the splat with T·R·S composed onto the entity transform). Options
-        left out keep what the entity's existing link already stores;
-        --clear-alignment removes it.
+        left out keep what the entity's existing link already stores — also when
+        --payload names a different capture, with a warning, since an alignment
+        registers one capture to one mesh; --clear-alignment removes it.
 
         Examples:
           untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \\
@@ -173,13 +174,17 @@ struct GaussianLinkCommand: ParsableCommand {
                 occluderShrink: occluderShrink,
                 exposureOffset: exposureOffset
             )
+            let existing = try Self.existingLink(entity: entity, in: fileData)
             link.alignment = try Self.mergedAlignment(
-                existing: Self.existingAlignment(entity: entity, in: fileData),
+                existing: existing?.alignment,
                 translate: alignTranslate.map { try Self.parseTranslation($0) },
                 yawDegrees: alignYawDegrees,
                 scale: alignScale,
                 clear: clearAlignment
             )
+            if let warning = Self.carriedAlignmentWarning(from: existing, to: stored.path, alignmentGiven: hasAlignmentOption || clearAlignment) {
+                printWarning(warning)
+            }
             if let warning = try Self.meshlessEntityWarning(entity: entity, link: link, in: fileData) {
                 printWarning(warning)
             }
@@ -284,13 +289,31 @@ struct GaussianLinkCommand: ParsableCommand {
         return SIMD3<Float>(values[0], values[1], values[2])
     }
 
-    /// The alignment the entity's link in `fileData` stores, nil without a link or alignment.
-    static func existingAlignment(entity: UInt32, in fileData: Data) throws -> GaussianSplatAlignment? {
+    /// The link the entity carries in `fileData`, nil without one.
+    static func existingLink(entity: UInt32, in fileData: Data) throws -> UntoldAssetPatcher.GaussianAssetLink? {
         do {
-            return try UntoldAssetPatcher.gaussianAssets(in: fileData)[entity]?.alignment
+            return try UntoldAssetPatcher.gaussianAssets(in: fileData)[entity]
         } catch let error as UntoldAssetPatcher.Error {
             throw GaussianLinkError.patchFailed(error.description)
         }
+    }
+
+    /// The alignment the entity's link in `fileData` stores, nil without a link or alignment.
+    static func existingAlignment(entity: UInt32, in fileData: Data) throws -> GaussianSplatAlignment? {
+        try existingLink(entity: entity, in: fileData)?.alignment
+    }
+
+    /// A warning when the stored alignment is carried over onto another capture: `existing`
+    /// has an alignment, its payload path is not `storedPath`, and no alignment option
+    /// (`alignmentGiven`: an --align-* value or --clear-alignment) says what the new payload
+    /// gets. An alignment registers one capture to one mesh, so the carried one is likely
+    /// wrong for the new file — but dropping it silently would lose a tuned value, so it is
+    /// kept and named. Nil otherwise.
+    static func carriedAlignmentWarning(from existing: UntoldAssetPatcher.GaussianAssetLink?, to storedPath: String, alignmentGiven: Bool) -> String? {
+        guard !alignmentGiven, let existing, let alignment = existing.alignment, existing.payloadPath != storedPath else {
+            return nil
+        }
+        return "keeping the alignment stored for \(existing.payloadPath) on \(storedPath) (\(describe(alignment))) — an alignment is per capture; pass --clear-alignment or the --align-* values \(storedPath) needs"
     }
 
     /// What the new link stores: nothing with `clear`; `existing` untouched when no field is

--- a/Tools/UntoldEngineCLI/Tests/UntoldEngineCLITests/GaussianLinkCommandTests.swift
+++ b/Tools/UntoldEngineCLI/Tests/UntoldEngineCLITests/GaussianLinkCommandTests.swift
@@ -281,6 +281,26 @@ final class GaussianLinkCommandTests: XCTestCase {
         let turned = try GaussianLinkCommand.setting(again, entity: 0, in: kept)
         XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: turned)[0]?.alignment, GaussianSplatAlignment(translation: alignment.translation, yawDegrees: -30, scale: 1.02))
 
+        // Another payload with no alignment option: the stored alignment is carried over, and
+        // the command says so; the same payload, an option or --clear-alignment say nothing.
+        let otherURL = directory.appendingPathComponent("chairB.untoldgs")
+        try makePayload(splatCount: 7).write(to: otherURL)
+        let otherStored = GaussianLinkCommand.storedPayloadPath(payloadURL: otherURL, untoldURL: untoldURL)
+        var other = try GaussianLinkCommand.makeLink(payloadURL: otherURL, storedPath: otherStored.path, swapDistance: 0, occluderShrink: 0.02, exposureOffset: 0)
+        let before = try XCTUnwrap(GaussianLinkCommand.existingLink(entity: 0, in: turned))
+        XCTAssertEqual(before.payloadPath, stored.path)
+        other.alignment = GaussianLinkCommand.mergedAlignment(existing: before.alignment, translate: nil, yawDegrees: nil, scale: nil, clear: false)
+        let carried = try GaussianLinkCommand.setting(other, entity: 0, in: turned)
+        let carriedLink = try XCTUnwrap(UntoldAssetPatcher.gaussianAssets(in: carried)[0])
+        XCTAssertEqual(carriedLink.payloadPath, "chairB.untoldgs")
+        XCTAssertEqual(carriedLink.alignment, GaussianSplatAlignment(translation: alignment.translation, yawDegrees: -30, scale: 1.02), "carried onto the new capture")
+        let warning = try XCTUnwrap(GaussianLinkCommand.carriedAlignmentWarning(from: before, to: otherStored.path, alignmentGiven: false))
+        XCTAssertTrue(warning.hasPrefix("keeping the alignment stored for chair.untoldgs on chairB.untoldgs (align (0.0, 0.02, -0.1) m, yaw -30.0°, scale 1.02)"), warning)
+        XCTAssertNil(GaussianLinkCommand.carriedAlignmentWarning(from: before, to: stored.path, alignmentGiven: false), "same payload: kept without a word")
+        XCTAssertNil(GaussianLinkCommand.carriedAlignmentWarning(from: before, to: otherStored.path, alignmentGiven: true), "an alignment option or --clear-alignment decides")
+        XCTAssertNil(GaussianLinkCommand.carriedAlignmentWarning(from: nil, to: otherStored.path, alignmentGiven: false), "no link, nothing carried")
+        XCTAssertNil(GaussianLinkCommand.carriedAlignmentWarning(from: link.with(alignment: nil), to: otherStored.path, alignmentGiven: false), "no alignment, nothing carried")
+
         // The loader hands it to the entity's link.
         try turned.write(to: untoldURL)
         let asset = try NativeFormatLoader().loadAssetSync(from: untoldURL)
@@ -420,5 +440,13 @@ final class GaussianLinkCommandTests: XCTestCase {
             writer.writeData(data)
         }
         return writer.data
+    }
+}
+
+private extension UntoldAssetPatcher.GaussianAssetLink {
+    func with(alignment: GaussianSplatAlignment?) -> Self {
+        var copy = self
+        copy.alignment = alignment
+        return copy
     }
 }

--- a/Tools/UntoldEngineCLI/Tests/UntoldEngineCLITests/GaussianLinkCommandTests.swift
+++ b/Tools/UntoldEngineCLI/Tests/UntoldEngineCLITests/GaussianLinkCommandTests.swift
@@ -174,6 +174,7 @@ final class GaussianLinkCommandTests: XCTestCase {
         XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--align-translate", "1,2", "--in-place"]), "three components")
         XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--align-translate", "1,x,2", "--in-place"]), "numbers")
         XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--align-scale", "0", "--in-place"]), "scale > 0")
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--align-yaw-degrees", "nan", "--in-place"]), "yaw finite")
         XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--align-scale", "1", "--clear-alignment", "--in-place"]), "clear takes no align option")
         XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--remove", "--align-yaw-degrees", "1", "--in-place"]), "remove takes no alignment")
         XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--remove", "--clear-alignment", "--in-place"]), "remove takes no alignment")

--- a/Tools/UntoldEngineCLI/Tests/UntoldEngineCLITests/GaussianLinkCommandTests.swift
+++ b/Tools/UntoldEngineCLI/Tests/UntoldEngineCLITests/GaussianLinkCommandTests.swift
@@ -167,6 +167,17 @@ final class GaussianLinkCommandTests: XCTestCase {
         XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--in-place"]), "needs --payload or --remove")
         XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--remove", "--payload", "a.untoldgs", "--in-place"]), "remove takes no payload")
         XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--list", "--remove"]), "list is alone")
+
+        // Alignment options: with a payload only, negative values as they are, x,y,z checked.
+        XCTAssertNoThrow(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--align-translate", "-1,0.5,2", "--align-yaw-degrees", "-90", "--align-scale", "1.02", "--in-place"]))
+        XCTAssertNoThrow(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--clear-alignment", "--in-place"]))
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--align-translate", "1,2", "--in-place"]), "three components")
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--align-translate", "1,x,2", "--in-place"]), "numbers")
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--align-scale", "0", "--in-place"]), "scale > 0")
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--payload", "a.untoldgs", "--align-scale", "1", "--clear-alignment", "--in-place"]), "clear takes no align option")
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--remove", "--align-yaw-degrees", "1", "--in-place"]), "remove takes no alignment")
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--entity", "0", "--remove", "--clear-alignment", "--in-place"]), "remove takes no alignment")
+        XCTAssertThrowsError(try GaussianLinkCommand.parse(["--untold", "a.untold", "--list", "--align-scale", "1"]), "list is alone")
         XCTAssertThrowsError(try GaussianLinkCommand.parse(["--entity", "0", "--list"]), "untold is required")
     }
 
@@ -207,6 +218,80 @@ final class GaussianLinkCommandTests: XCTestCase {
         XCTAssertThrowsError(try GaussianLinkCommand.setting(link, entity: 7, in: patched)) { error in
             XCTAssertEqual((error as? GaussianLinkError)?.errorDescription, "entity 7 is not in the entity table")
         }
+    }
+
+    func testTranslationParsing() throws {
+        XCTAssertEqual(try GaussianLinkCommand.parseTranslation("1,2,3"), SIMD3<Float>(1, 2, 3))
+        XCTAssertEqual(try GaussianLinkCommand.parseTranslation(" -0.5, 0 ,1e-2"), SIMD3<Float>(-0.5, 0, 0.01))
+        XCTAssertThrowsError(try GaussianLinkCommand.parseTranslation("1,2"))
+        XCTAssertThrowsError(try GaussianLinkCommand.parseTranslation("1,2,3,4"))
+        XCTAssertThrowsError(try GaussianLinkCommand.parseTranslation("1,,3"))
+        XCTAssertThrowsError(try GaussianLinkCommand.parseTranslation("inf,0,0"))
+    }
+
+    func testAlignmentOptionsMergeOverTheExistingAlignment() {
+        let existing = GaussianSplatAlignment(translation: SIMD3<Float>(1, 2, 3), yawDegrees: 45, scale: 2)
+
+        XCTAssertNil(GaussianLinkCommand.mergedAlignment(existing: existing, translate: nil, yawDegrees: nil, scale: nil, clear: true), "clear drops it")
+        XCTAssertNil(GaussianLinkCommand.mergedAlignment(existing: nil, translate: nil, yawDegrees: nil, scale: nil, clear: false), "nothing given, nothing stored")
+        XCTAssertEqual(GaussianLinkCommand.mergedAlignment(existing: existing, translate: nil, yawDegrees: nil, scale: nil, clear: false), existing, "nothing given keeps the existing one")
+        XCTAssertEqual(
+            GaussianLinkCommand.mergedAlignment(existing: existing, translate: nil, yawDegrees: 90, scale: nil, clear: false),
+            GaussianSplatAlignment(translation: SIMD3<Float>(1, 2, 3), yawDegrees: 90, scale: 2),
+            "one field over the existing one"
+        )
+        XCTAssertEqual(
+            GaussianLinkCommand.mergedAlignment(existing: nil, translate: SIMD3<Float>(0, 0.02, 0), yawDegrees: nil, scale: nil, clear: false),
+            GaussianSplatAlignment(translation: SIMD3<Float>(0, 0.02, 0), yawDegrees: 0, scale: 1),
+            "one field over identity"
+        )
+    }
+
+    func testAlignmentIsWrittenKeptAndClearedOnAFixture() throws {
+        let directory = try makeTemporaryDirectory()
+        let untoldURL = directory.appendingPathComponent("chair.untold")
+        try makeUntoldFixture().write(to: untoldURL)
+        let payloadURL = directory.appendingPathComponent("chair.untoldgs")
+        try makePayload(splatCount: 12).write(to: payloadURL)
+        let stored = GaussianLinkCommand.storedPayloadPath(payloadURL: payloadURL, untoldURL: untoldURL)
+
+        // Set with an alignment.
+        var link = try GaussianLinkCommand.makeLink(payloadURL: payloadURL, storedPath: stored.path, swapDistance: 0, occluderShrink: 0.02, exposureOffset: 0)
+        XCTAssertNil(link.alignment, "makeLink stores no alignment of its own")
+        let alignment = GaussianSplatAlignment(translation: SIMD3<Float>(0, 0.02, -0.1), yawDegrees: 90, scale: 1.02)
+        link.alignment = try GaussianLinkCommand.mergedAlignment(
+            existing: GaussianLinkCommand.existingAlignment(entity: 0, in: Data(contentsOf: untoldURL)),
+            translate: alignment.translation, yawDegrees: alignment.yawDegrees, scale: alignment.scale, clear: false
+        )
+        let aligned = try GaussianLinkCommand.setting(link, entity: 0, in: Data(contentsOf: untoldURL))
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: aligned)[0]?.alignment, alignment)
+        let lines = try GaussianLinkCommand.listing(of: aligned)
+        XCTAssertEqual(lines.count, 1)
+        XCTAssertTrue(lines[0].hasSuffix("align (0.0, 0.02, -0.1) m, yaw 90.0°, scale 1.02"), lines[0])
+        XCTAssertEqual(try GaussianLinkCommand.existingAlignment(entity: 0, in: aligned), alignment)
+
+        // Set again with no alignment option: the stored one is kept, one field changes it.
+        var again = try GaussianLinkCommand.makeLink(payloadURL: payloadURL, storedPath: stored.path, swapDistance: 5, occluderShrink: 0.02, exposureOffset: 0)
+        again.alignment = try GaussianLinkCommand.mergedAlignment(existing: GaussianLinkCommand.existingAlignment(entity: 0, in: aligned), translate: nil, yawDegrees: nil, scale: nil, clear: false)
+        let kept = try GaussianLinkCommand.setting(again, entity: 0, in: aligned)
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: kept)[0]?.alignment, alignment)
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: kept)[0]?.swapDistanceMeters, 5)
+
+        again.alignment = try GaussianLinkCommand.mergedAlignment(existing: GaussianLinkCommand.existingAlignment(entity: 0, in: kept), translate: nil, yawDegrees: -30, scale: nil, clear: false)
+        let turned = try GaussianLinkCommand.setting(again, entity: 0, in: kept)
+        XCTAssertEqual(try UntoldAssetPatcher.gaussianAssets(in: turned)[0]?.alignment, GaussianSplatAlignment(translation: alignment.translation, yawDegrees: -30, scale: 1.02))
+
+        // The loader hands it to the entity's link.
+        try turned.write(to: untoldURL)
+        let asset = try NativeFormatLoader().loadAssetSync(from: untoldURL)
+        XCTAssertEqual(asset.nodes.first { $0.id == 0 }?.gaussianAsset?.alignment, GaussianSplatAlignment(translation: alignment.translation, yawDegrees: -30, scale: 1.02))
+
+        // Cleared.
+        again.alignment = try GaussianLinkCommand.mergedAlignment(existing: GaussianLinkCommand.existingAlignment(entity: 0, in: turned), translate: nil, yawDegrees: nil, scale: nil, clear: true)
+        let cleared = try GaussianLinkCommand.setting(again, entity: 0, in: turned)
+        XCTAssertNil(try UntoldAssetPatcher.gaussianAssets(in: cleared)[0]?.alignment)
+        XCTAssertFalse(try GaussianLinkCommand.listing(of: cleared)[0].contains("align"), "no alignment, none listed")
+        XCTAssertNil(try GaussianLinkCommand.existingAlignment(entity: 3, in: cleared), "no link, no alignment")
     }
 
     func testAPayloadThatIsNotAVersion3UntoldgsIsRejected() throws {

--- a/docs/API/UsingGaussianSystem.md
+++ b/docs/API/UsingGaussianSystem.md
@@ -265,18 +265,21 @@ link:
 
 - **`GaussianComponent.splatToEntity`** (`simd_float4x4`, identity by default) is where the
   splat sits in its entity's local space. The splat is drawn with `entityWorld × splatToEntity`
-  by the cull, the preprocess, the chunk cull and the draw alike, so setting it moves, turns or
-  scales the splat exactly as moving the entity would, while the mesh the twin stands in for
-  stays put. It belongs to the entity, not the payload: tier swaps and reloads of the same
-  entity keep it. A splat-only entity's bounding box is the splat's box carried through it; a
-  twin entity keeps the mesh's box.
+  by the cull, the preprocess, the chunk cull and the draw alike, so setting it — through
+  `setGaussianSplatToEntity(entityId:_:)` — moves, turns or scales the splat exactly as moving
+  the entity would, while the mesh the twin stands in for stays put. It belongs to the entity,
+  not the payload: tier swaps, reloads of the same entity and a streaming eviction and reload
+  keep it (`StreamingComponent` holds it while the splat is out). A splat-only entity's
+  bounding box is the splat's box carried through it, kept in step by the setter as well as by
+  every load; a twin entity keeps the mesh's box, and a progressive entity whose box the caller
+  supplied keeps that one.
 - **`GaussianSplatAlignment`** (`translation`, `yawDegrees`, `scale`; `matrix` = `T · R_y · S`,
   yaw about +Y, right-handed, uniform scale) is the authored form: the `gaussianAsset` record
   stores it in its last five words under `UntoldGaussianAssetFlags.alignment`, the loader hands
   it over as `GaussianAssetLinkComponent.alignment` (`RuntimeGaussianAssetLink.alignment`), and
-  whoever loads the payload applies `alignment.matrix` to `splatToEntity` — a twin policy such
-  as `GaussianTwinOptions.alignment` in UntoldGaussianTwins does this every tick, so an editor
-  can change the value live. Files written before the flag existed read as no alignment.
+  whoever loads the payload applies `alignment.matrix` through `setGaussianSplatToEntity` — a
+  twin policy such as `GaussianTwinOptions.alignment` in UntoldGaussianTwins does this every
+  tick (an unchanged matrix costs nothing), so an editor can change the value live. Files written before the flag existed read as no alignment.
 - The `.untoldgs` header's `splatToMesh` stays the record of the cook transform; the
   alignment composes on top of whatever the cook baked. A full three-axis rotation is left to
   a later extension: captures are up-axis corrected at cook time.

--- a/docs/API/UsingGaussianSystem.md
+++ b/docs/API/UsingGaussianSystem.md
@@ -227,8 +227,8 @@ application-side system built on these pieces (see the proposal's §4.5).
   left out of the shell and stop drawing with the colour.
 - **`GaussianAssetLinkComponent`** carries a `.untold` scene's `gaussianAsset` record
   (`UntoldGaussianAssetRecordV1`: payload path resolved next to the scene file, flags such as
-  `meshTwin`, occluder margin, exposure offset, swap distance) onto the entity as data.
-  `setEntityMesh`/`setEntityMeshAsync` attach it; nothing is loaded.
+  `meshTwin`, occluder margin, exposure offset, swap distance, alignment) onto the entity as
+  data. `setEntityMesh`/`setEntityMeshAsync` attach it; nothing is loaded.
 - A mesh carrying a `MeshOccluderComponent` or `MeshFadeComponent` is excluded from static
   batching when the batcher next evaluates it, and re-admitted once they are gone. The system
   that adds or removes them tells the batcher with
@@ -240,7 +240,7 @@ application-side system built on these pieces (see the proposal's §4.5).
 author a link after the export: `UntoldAssetPatcher` (Sources/UntoldEngine/AssetFormat) rewrites
 just the gaussianAsset table. `settingGaussianAsset(_:onEntity:in:)` takes the file's bytes and a
 `GaussianAssetLink` (payload path relative to the `.untold` file's directory, flags, LOD table,
-occluder shrink, exposure offset, swap distance) and returns the patched bytes with every other
+occluder shrink, exposure offset, swap distance, alignment) and returns the patched bytes with every other
 chunk copied unchanged, the path appended to the string table (or an identical string reused),
 offsets re-laid out on 16-byte alignment and the content hash recomputed;
 `removingGaussianAsset(onEntity:in:)` drops a record (and the chunk when empty);
@@ -254,6 +254,37 @@ A typical swap: load the payload with `opacityScale: 0` when the camera is near;
 `MeshOccluderComponent`; add a `MeshFadeComponent` with `direction = .fadeOut` and raise its
 `progress` and the splat's `opacityScale` together to 1 over 250 ms; then set `drawsColor =
 false` and remove the fade. Reverse the steps when the camera leaves.
+
+### Aligning a twin
+
+A capture never shares its mesh's frame: the scanner picks the origin, the up axis and the
+scale. Registering the two used to mean baking a transform at cook time
+(`UntoldGSCookOptions.transform`, recorded in the `.untoldgs` header's `splatToMesh`), and that
+is still possible — but an alignment can also be edited after the cook and saved with the
+link:
+
+- **`GaussianComponent.splatToEntity`** (`simd_float4x4`, identity by default) is where the
+  splat sits in its entity's local space. The splat is drawn with `entityWorld × splatToEntity`
+  by the cull, the preprocess, the chunk cull and the draw alike, so setting it moves, turns or
+  scales the splat exactly as moving the entity would, while the mesh the twin stands in for
+  stays put. It belongs to the entity, not the payload: tier swaps and reloads of the same
+  entity keep it. A splat-only entity's bounding box is the splat's box carried through it; a
+  twin entity keeps the mesh's box.
+- **`GaussianSplatAlignment`** (`translation`, `yawDegrees`, `scale`; `matrix` = `T · R_y · S`,
+  yaw about +Y, right-handed, uniform scale) is the authored form: the `gaussianAsset` record
+  stores it in its last five words under `UntoldGaussianAssetFlags.alignment`, the loader hands
+  it over as `GaussianAssetLinkComponent.alignment` (`RuntimeGaussianAssetLink.alignment`), and
+  whoever loads the payload applies `alignment.matrix` to `splatToEntity` — a twin policy such
+  as `GaussianTwinOptions.alignment` in UntoldGaussianTwins does this every tick, so an editor
+  can change the value live. Files written before the flag existed read as no alignment.
+- The `.untoldgs` header's `splatToMesh` stays the record of the cook transform; the
+  alignment composes on top of whatever the cook baked. A full three-axis rotation is left to
+  a later extension: captures are up-axis corrected at cook time.
+
+`UntoldAssetPatcher.GaussianAssetLink.alignment` writes it (the flag follows the optional; a
+non-finite value or a scale of zero is rejected), and `untoldengine gaussian-link` takes
+`--align-translate x,y,z`, `--align-yaw-degrees`, `--align-scale` (each defaulting to what the
+entity's link already stores) and `--clear-alignment`; `--list` prints it.
 
 ### Calibrating the capture
 

--- a/docs/API/UsingUntoldEngineCLI.md
+++ b/docs/API/UsingUntoldEngineCLI.md
@@ -290,8 +290,12 @@ twin](UsingGaussianSystem.md#aligning-a-twin)): `--align-translate x,y,z` in met
 `--align-yaw-degrees` about the entity's +Y axis, `--align-scale` uniform and greater than
 zero. Each option left out keeps the value the entity's existing link stores (identity when
 there is none and at least one is given); `--clear-alignment` drops the alignment; with no
-alignment option at all the stored alignment is carried over unchanged. `--list` prints it
-after the exposure (`align (x, y, z) m, yaw d°, scale s`).
+alignment option at all the stored alignment is carried over unchanged — also when
+`--payload` names a different capture than the link had, with a warning that names the old
+payload: an alignment registers one capture to one mesh, so pass `--clear-alignment` or the
+new capture's `--align-*` values then (the other tunables go back to their option defaults
+on every re-link). `--list` prints it after the exposure (`align (x, y, z) m, yaw d°,
+scale s`).
 
 ---
 

--- a/docs/API/UsingUntoldEngineCLI.md
+++ b/docs/API/UsingUntoldEngineCLI.md
@@ -271,6 +271,11 @@ patcher API.
 untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \
   --payload Chair/chair.untoldgs --swap-distance 8 --occluder-shrink 0.02 --in-place
 untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \
+  --payload Chair/chair.untoldgs --align-translate 0,0.02,-0.1 \
+  --align-yaw-degrees 90 --align-scale 1.02 --in-place
+untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \
+  --payload Chair/chair.untoldgs --clear-alignment --in-place
+untoldengine gaussian-link --untold Chair/chair.untold --entity 0 \
   --remove --output Chair/chair_plain.untold
 untoldengine gaussian-link --untold Chair/chair.untold --list
 ```
@@ -278,7 +283,15 @@ untoldengine gaussian-link --untold Chair/chair.untold --list
 `--entity` is the entity table's `entityId` (`--list` prints the ids that already carry a
 link); a `meshTwin` link on an entity without a mesh — the root of a multi-node asset —
 is written with a warning that names the mesh-bearing entities. Negative values are
-accepted as they are (`--exposure-offset -0.5`).
+accepted as they are (`--exposure-offset -0.5`, `--align-translate -1,0,0`).
+
+The alignment options place the splat inside the entity without a re-cook (see [Aligning a
+twin](UsingGaussianSystem.md#aligning-a-twin)): `--align-translate x,y,z` in metres,
+`--align-yaw-degrees` about the entity's +Y axis, `--align-scale` uniform and greater than
+zero. Each option left out keeps the value the entity's existing link stores (identity when
+there is none and at least one is given); `--clear-alignment` drops the alignment; with no
+alignment option at all the stored alignment is carried over unchanged. `--list` prints it
+after the exposure (`align (x, y, z) m, yaw d°, scale s`).
 
 ---
 

--- a/docs/Architecture/assetFormat.md
+++ b/docs/Architecture/assetFormat.md
@@ -500,21 +500,30 @@ Types 22–24 are reserved for the morph-target channel.
 ```text
 entityId                     UInt32
 payloadPathOffset            UInt32   // string table, path relative to this file
-flags                        UInt32   // 1 = meshTwin, 2 = environment, 4 = windowWorld
+flags                        UInt32   // 1 = meshTwin, 2 = environment, 4 = windowWorld, 8 = alignment
 lodCount                     UInt32   // valid LOD entries, 0...4 (0 means one level)
 lodSplatCounts               UInt32 x 4   // per level, coarsest first
 lodSwitchScreenHeights       Float32 x 4  // pixels above which the next finer level is preferred
 occluderShrinkMeters         Float32  // mesh twin depth-only shell shrink along normals
 exposureOffsetEV             Float32  // editor offset on top of the payload's capture exposure
 swapDistanceMeters           Float32  // 0 = always armed
-reserved0                    UInt32 x 5
+alignmentTranslation         Float32 x 3  // splat offset in entity space, metres (flag 8)
+alignmentYawDegrees          Float32  // splat rotation about entity +Y, degrees (flag 8)
+alignmentScale               Float32  // uniform splat scale, > 0 (flag 8)
 ```
+
+The alignment fields were the record's five reserved words: they are read only when
+`flags` has the `alignment` bit (8) and are written as zero otherwise, so a file from
+before the bit existed decodes as no alignment (identity). The runtime draws the splat with
+`entityWorld × T(translation) · R_y(yaw) · S(scale)` (`GaussianComponent.splatToEntity`);
+the cook transform in the `.untoldgs` header (`splatToMesh`) is untouched by it.
 
 Rules:
 
 - `entityId` must be present in the entity table
 - `payloadPathOffset` must resolve to a non-empty string
 - `lodCount <= 4`; `occluderShrinkMeters` and `swapDistanceMeters` are non-negative
+- with the `alignment` bit set, the three alignment fields are finite and `alignmentScale > 0`
 - registration onto the mesh twin and capture exposure live in the `.untoldgs` header,
   not here; this record holds what the scene author tunes
 - a file whose only geometry is a splat may omit the vertex and index chunks


### PR DESCRIPTION
Aligns a captured splat to its mesh twin without a re-cook: an offset, a yaw and a uniform scale stored in the scene's `gaussianAsset` link record and applied by the runtime as the splat's placement inside its entity.

**Why.** A capture (scanner frame, Z-up, arbitrary origin) never shares the mesh's frame. Today the only fix is baking a transform at cook time (`UntoldGSCookOptions.transform`, recorded in the `.untoldgs` header's `splatToMesh`, which the runtime ignores). Aligning is an authoring step that belongs in the scene, next to the swap distance and the occluder shrink, so the editor can tune it live and the same `.untoldgs` can serve several scenes.

**Format.** `UntoldGaussianAssetRecordV1` stays 80 bytes: the five reserved words become `alignmentTranslation` (3 × Float), `alignmentYawDegrees` and `alignmentScale`, valid only with the new flag `UntoldGaussianAssetFlags.alignment` (1 << 3). Files written before this read as no alignment (flag clear, words zero). `UntoldReader` rejects a flagged record that is not finite or whose scale is not greater than zero. `GaussianSplatAlignment { translation, yawDegrees, scale }` is the public value; `matrix` is `T · R_y · S` (yaw about the entity's +Y, like `rotateTo(entityId:angle:axis:)`).

**Runtime.** `GaussianComponent.splatToEntity` (identity by default) is composed on the right of the entity's world transform everywhere the splat's model matrix is built: the cull and preprocess uniforms (`GaussianEntityFrameMatrices`), the chunk cull view-projections for both eyes, and the per-eye draw constants. It is set through `setGaussianSplatToEntity(entityId:_:)`, which also carries a splat-only entity's bounding box through the matrix; it survives tier swaps, reloads and a streaming eviction of the same entity. `RuntimeGaussianAssetLink.alignment` and `GaussianAssetLinkComponent.alignment` carry the record's value to whoever loads the payload (the twins package applies it every tick).

**Patcher and CLI.** `UntoldAssetPatcher.GaussianAssetLink.alignment` writes and reads the record (the flag is derived from non-nil, never kept in `flags`). `untoldengine gaussian-link` gains `--align-translate x,y,z`, `--align-yaw-degrees`, `--align-scale` and `--clear-alignment`; each keeps the entity's stored value when omitted, and the command warns when a stored alignment is carried onto a different payload; `--list` prints it.

**Tests.** Format round trip in the former reserved words, unflagged words decode to no alignment, the matrix is translation·yaw·scale, invalid alignment rejected only when flagged; patcher round trip through the record and the file, invalid links throw; render tests prove a translated, rotated and scaled `splatToEntity` draws the same pixels as the same transform on the entity, also under a posed parent, at the frustum edge where the cull has splats to drop, and on the chunked path; a streaming eviction and reload keeps the matrix; CLI option and fixture tests.

Filtered engine suite 269 tests with the known local-only cv2 case as the single failure; CLI 11/11; the twins package 17/17 against this branch; swiftformat 0.60.1 and a strict-concurrency build clean.

**Docs.** `UsingGaussianSystem.md` ("Aligning a twin"), `assetFormat.md` record table, CLI docs.

No shader changes. The same branch is fork PR miolabs/UntoldEngine#41 for the fork's own testing.
