### PR TITLE
Add .spz Gaussian splat export support

### DIFF
--- a/Sources/UntoldEngine/Systems/RegistrationSystem.swift
+++ b/Sources/UntoldEngine/Systems/RegistrationSystem.swift
@@ -4856,13 +4856,50 @@ public func bakeGaussianSplatProgressiveTiers(
     lodFractions: [Float],
     cookOptions: UntoldGSCookOptions = UntoldGSCookOptions()
 ) throws -> GaussianProgressiveBakeResult {
+    let sourceAsset = try PLYReader.readGaussianAsset(from: plyURL)
+    return try bakeGaussianSplatProgressiveTiers(
+        sourceAsset: sourceAsset,
+        emptySourceDescription: "source .ply contains no splats",
+        outputBaseURL: outputBaseURL,
+        lodFractions: lodFractions,
+        cookOptions: cookOptions
+    )
+}
+
+/// Bakes progressive `.untoldgs` Gaussian tiers from a source `.spz` (legacy gzip versions 2-3
+/// only -- see `SPZReader`). Same tiering behavior as the `.ply` overload above; `SPZReader`
+/// produces the same format-neutral `GaussianSplatAsset` shape `PLYReader` does, so cooking and
+/// writing are identical from here on.
+public func bakeGaussianSplatProgressiveTiers(
+    spzURL: URL,
+    outputBaseURL: URL,
+    lodFractions: [Float],
+    cookOptions: UntoldGSCookOptions = UntoldGSCookOptions()
+) throws -> GaussianProgressiveBakeResult {
+    let sourceAsset = try SPZReader.readGaussianAsset(from: spzURL)
+    return try bakeGaussianSplatProgressiveTiers(
+        sourceAsset: sourceAsset,
+        emptySourceDescription: "source .spz contains no splats",
+        outputBaseURL: outputBaseURL,
+        lodFractions: lodFractions,
+        cookOptions: cookOptions
+    )
+}
+
+/// Shared tiering core behind both the `.ply` and `.spz` overloads above, operating on the
+/// format-neutral `GaussianSplatAsset` either reader produces.
+private func bakeGaussianSplatProgressiveTiers(
+    sourceAsset: GaussianSplatAsset,
+    emptySourceDescription: String,
+    outputBaseURL: URL,
+    lodFractions: [Float],
+    cookOptions: UntoldGSCookOptions
+) throws -> GaussianProgressiveBakeResult {
     guard !lodFractions.isEmpty else {
         throw UntoldGSError.sizeMismatch("lodFractions must contain at least one entry")
     }
-
-    let sourceAsset = try PLYReader.readGaussianAsset(from: plyURL)
     guard !sourceAsset.splats.isEmpty else {
-        throw UntoldGSError.sizeMismatch("source .ply contains no splats")
+        throw UntoldGSError.sizeMismatch(emptySourceDescription)
     }
     // Registration transform, opacity floor, crop and SH degree are applied once here so the
     // ranking, bounding box and every tier below see the cooked splats.
@@ -4923,16 +4960,36 @@ public func bakeGaussianSplatProgressiveTiers(
     levelCount: Int,
     cookOptions: UntoldGSCookOptions = UntoldGSCookOptions()
 ) throws -> GaussianProgressiveBakeResult {
-    guard levelCount > 0 else {
-        throw UntoldGSError.sizeMismatch("levelCount must be at least 1, got \(levelCount)")
-    }
-    let fractions = (0 ..< levelCount).map { Float(1.0) / Float(1 << $0) }
+    let fractions = try progressiveLODFractions(levelCount: levelCount)
     return try bakeGaussianSplatProgressiveTiers(
         plyURL: plyURL,
         outputBaseURL: outputBaseURL,
         lodFractions: fractions,
         cookOptions: cookOptions
     )
+}
+
+/// `.spz` counterpart of the `.ply` `levelCount` overload above.
+public func bakeGaussianSplatProgressiveTiers(
+    spzURL: URL,
+    outputBaseURL: URL,
+    levelCount: Int,
+    cookOptions: UntoldGSCookOptions = UntoldGSCookOptions()
+) throws -> GaussianProgressiveBakeResult {
+    let fractions = try progressiveLODFractions(levelCount: levelCount)
+    return try bakeGaussianSplatProgressiveTiers(
+        spzURL: spzURL,
+        outputBaseURL: outputBaseURL,
+        lodFractions: fractions,
+        cookOptions: cookOptions
+    )
+}
+
+private func progressiveLODFractions(levelCount: Int) throws -> [Float] {
+    guard levelCount > 0 else {
+        throw UntoldGSError.sizeMismatch("levelCount must be at least 1, got \(levelCount)")
+    }
+    return (0 ..< levelCount).map { Float(1.0) / Float(1 << $0) }
 }
 
 public struct PackedGaussianSphericalHarmonics {

--- a/Sources/UntoldEngine/Utils/PLYReader.swift
+++ b/Sources/UntoldEngine/Utils/PLYReader.swift
@@ -65,6 +65,53 @@ public struct GaussianSplatAsset {
     public let sphericalHarmonics: GaussianSphericalHarmonics?
 }
 
+/// A splat's peak alpha (at its own center, where the Gaussian falloff is 1) equals its
+/// opacity — see fragmentGaussianTBDRShader's `alpha = opacity * exp(power)`, power <= 0.
+/// The shader itself discards any fragment below this same threshold, so a splat whose
+/// opacity never reaches it can never contribute a visible pixel anywhere in its extent.
+/// Dropping it here removes it from vertex shading, rasterization, and per-fragment ALU
+/// entirely instead of paying that cost every frame only to discard the result — this is
+/// a lossless cull (identical rendered image), not a quality/perf tradeoff. Shared by every
+/// Gaussian source reader (PLY, SPZ, ...) so the cull threshold can't drift between formats.
+let minRetainedGaussianOpacity: Float = 1.0 / 255.0
+
+func filterNegligibleOpacityGaussianSplats(
+    splats: [GaussianSplat],
+    shCoefficients: [Float],
+    coefficientsPerSplat: Int,
+    sourceTag: String
+) -> ([GaussianSplat], [Float]) {
+    guard splats.contains(where: { $0.opacity < minRetainedGaussianOpacity }) else {
+        return (splats, shCoefficients)
+    }
+
+    var keptSplats: [GaussianSplat] = []
+    keptSplats.reserveCapacity(splats.count)
+    var keptCoefficients: [Float] = []
+    if coefficientsPerSplat > 0 {
+        keptCoefficients.reserveCapacity(shCoefficients.count)
+    }
+
+    for (index, splat) in splats.enumerated() {
+        guard splat.opacity >= minRetainedGaussianOpacity else { continue }
+        keptSplats.append(splat)
+        if coefficientsPerSplat > 0 {
+            let start = index * coefficientsPerSplat
+            keptCoefficients.append(contentsOf: shCoefficients[start ..< start + coefficientsPerSplat])
+        }
+    }
+
+    Logger.log(
+        message: String(
+            format: "[Gaussian][%@] Culled %d/%d splats below visibility threshold (opacity < %.4f)",
+            sourceTag, splats.count - keptSplats.count, splats.count, minRetainedGaussianOpacity
+        ),
+        category: LogCategory.gaussian.rawValue
+    )
+
+    return (keptSplats, keptCoefficients)
+}
+
 public class PLYReader {
     // MARK: - Public Methods
 
@@ -119,10 +166,11 @@ public class PLYReader {
             throw PLYError.invalidData("Spherical-harmonic coefficient data is incomplete")
         }
 
-        let (filteredSplats, filteredCoefficients) = filterNegligibleOpacitySplats(
+        let (filteredSplats, filteredCoefficients) = filterNegligibleOpacityGaussianSplats(
             splats: parsed.0,
             shCoefficients: parsed.1,
-            coefficientsPerSplat: shSchema?.coefficientsPerSplat ?? 0
+            coefficientsPerSplat: shSchema?.coefficientsPerSplat ?? 0,
+            sourceTag: "PLY"
         )
 
         let sphericalHarmonics = shSchema.map {
@@ -133,51 +181,6 @@ public class PLYReader {
             )
         }
         return GaussianSplatAsset(splats: filteredSplats, sphericalHarmonics: sphericalHarmonics)
-    }
-
-    /// A splat's peak alpha (at its own center, where the Gaussian falloff is 1) equals its
-    /// opacity — see fragmentGaussianTBDRShader's `alpha = opacity * exp(power)`, power <= 0.
-    /// The shader itself discards any fragment below this same threshold, so a splat whose
-    /// opacity never reaches it can never contribute a visible pixel anywhere in its extent.
-    /// Dropping it here removes it from vertex shading, rasterization, and per-fragment ALU
-    /// entirely instead of paying that cost every frame only to discard the result — this is
-    /// a lossless cull (identical rendered image), not a quality/perf tradeoff.
-    private static let minRetainedOpacity: Float = 1.0 / 255.0
-
-    private static func filterNegligibleOpacitySplats(
-        splats: [GaussianSplat],
-        shCoefficients: [Float],
-        coefficientsPerSplat: Int
-    ) -> ([GaussianSplat], [Float]) {
-        guard splats.contains(where: { $0.opacity < minRetainedOpacity }) else {
-            return (splats, shCoefficients)
-        }
-
-        var keptSplats: [GaussianSplat] = []
-        keptSplats.reserveCapacity(splats.count)
-        var keptCoefficients: [Float] = []
-        if coefficientsPerSplat > 0 {
-            keptCoefficients.reserveCapacity(shCoefficients.count)
-        }
-
-        for (index, splat) in splats.enumerated() {
-            guard splat.opacity >= minRetainedOpacity else { continue }
-            keptSplats.append(splat)
-            if coefficientsPerSplat > 0 {
-                let start = index * coefficientsPerSplat
-                keptCoefficients.append(contentsOf: shCoefficients[start ..< start + coefficientsPerSplat])
-            }
-        }
-
-        Logger.log(
-            message: String(
-                format: "[Gaussian][PLY] Culled %d/%d splats below visibility threshold (opacity < %.4f)",
-                splats.count - keptSplats.count, splats.count, minRetainedOpacity
-            ),
-            category: LogCategory.gaussian.rawValue
-        )
-
-        return (keptSplats, keptCoefficients)
     }
 
     // MARK: - Header Parsing

--- a/Sources/UntoldEngine/Utils/SPZReader.swift
+++ b/Sources/UntoldEngine/Utils/SPZReader.swift
@@ -1,0 +1,408 @@
+//
+//  SPZReader.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Compression
+import CShaderTypes
+import Foundation
+import simd
+
+/// Reads Niantic's SPZ Gaussian-splat container (legacy gzip versions 2-3 only) into the same
+/// `GaussianSplatAsset` shape `PLYReader` produces, so every downstream consumer (the `.untoldgs`
+/// cooker/writer) is format-neutral.
+///
+/// SPZ version 1 used an unreleased float16 position encoding and is rejected. SPZ version 4
+/// (NGSP magic at the start of the raw file, ZSTD-compressed attribute streams) is a different
+/// container entirely and is explicitly out of scope — reject it too. Verified against Niantic's
+/// reference implementation (`nianticlabs/spz`, `src/cc/load-spz.cc` / `splat-utils.h`), not a
+/// secondhand summary of the format.
+public class SPZReader {
+    // MARK: - Format constants
+
+    /// `NGSP` read as a little-endian `UInt32` — both the legacy gzip payload's embedded header
+    /// magic and the raw first 4 bytes of an (unsupported) v4 NGSP file.
+    private static let ngspMagic: UInt32 = 0x5053_474E
+
+    private static let minSupportedVersion: UInt32 = 2
+    private static let maxSupportedVersion: UInt32 = 3
+    /// Versions at or above this store rotations with `packQuaternionSmallestThree` (4 bytes:
+    /// 2-bit largest-component index + three signed 9-bit magnitudes). Below it, versions store
+    /// `packQuaternionFirstThree` (3 bytes: xyz only, w reconstructed as non-negative).
+    private static let smallestThreeQuaternionVersion: UInt32 = 3
+
+    /// SH DC-component scale factor: colors are quantized as `byte = round((dc*colorScale+0.5)*255)`.
+    /// Not the same constant as `C0` below — this one only exists to keep the byte quantization
+    /// centered, matching Niantic's `colorScale` in `splat-utils.h`.
+    private static let colorScale: Float = 0.15
+    /// SH0 -> RGB constant: `rgb = 0.5 + C0 * dc`. Same value `PLYReader` uses for `f_dc_*`, since
+    /// both formats store the same raw SH DC coefficient underneath their own byte quantization.
+    private static let C0: Float = 0.282_094_79
+
+    /// `1/sqrt(2)`, the smallest-three encoding's magnitude scale (each non-largest quaternion
+    /// component is at most `1/sqrt(2)` once the largest component is factored out).
+    private static let sqrt1_2: Float = 0.707_106_78
+
+    /// RUB (SPZ's coordinate system) -> RDF (this engine's, matching `PLYReader`'s zero-conversion
+    /// convention) is a within-family flip: X unchanged, Y and Z negated. Verified against
+    /// Niantic's `coordinateConverter(RUB, RDF, ...)`, not assumed from the axis names.
+    private static let flipP = SIMD3<Float>(1, -1, -1)
+    /// Same flip applied to a quaternion's x, y, z components; w is never flipped.
+    private static let flipQ = SIMD3<Float>(1, -1, -1)
+    /// Per-rest-coefficient sign flip for RUB->RDF, indices 0...14 (degree 0...3, the engine's SH
+    /// cap). Same value applies to a coefficient's R, G and B channel alike. Derived from
+    /// Niantic's `coordinateConverter`'s `flipSh` table with x=1,y=-1,z=-1 substituted in — not
+    /// hand-derived, since a sign error here corrupts higher SH bands silently (the DC term/base
+    /// color would still look right).
+    private static let flipSh: [Float] = [-1, -1, 1, -1, 1, 1, -1, 1, -1, 1, -1, -1, 1, -1, 1]
+
+    // MARK: - Public Methods
+
+    /// Reads Gaussian geometry and preserves all spherical-harmonic coefficients, mirroring
+    /// `PLYReader.readGaussianAsset(from:)`'s output shape exactly.
+    public static func readGaussianAsset(from url: URL) throws -> GaussianSplatAsset {
+        let fileData = try Data(contentsOf: url)
+        let bytes = [UInt8](fileData)
+        guard bytes.count >= 4 else {
+            throw SPZError.invalidFormat("File too short to contain an SPZ magic number")
+        }
+        if readUInt32LE(bytes, at: 0) == ngspMagic {
+            throw SPZError.unsupportedVersion(4)
+        }
+        guard bytes.count >= 2, bytes[0] == 0x1F, bytes[1] == 0x8B else {
+            throw SPZError.invalidFormat("Not a gzip-wrapped SPZ file (only legacy versions 2-3 are supported)")
+        }
+        let decompressed = try gunzip(bytes)
+        return try parseLegacyPayload(decompressed)
+    }
+
+    // MARK: - Gzip container
+
+    /// Strips the gzip wrapper and inflates the raw DEFLATE body via `Compression`'s
+    /// `COMPRESSION_ZLIB` (raw DEFLATE, no zlib header — the same framework already used for LZ4
+    /// in `UntoldReader.swift`, so no new dependency). `Compression` has no gzip *container*
+    /// decoder, only the underlying algorithms, so the 10+-byte header and 8-byte trailer are
+    /// parsed here by hand.
+    private static func gunzip(_ bytes: [UInt8]) throws -> [UInt8] {
+        guard bytes.count >= 18, bytes[2] == 8 else { // CM must be 8 (deflate); 18 = 10-byte header + 8-byte trailer minimum
+            throw SPZError.invalidFormat("Not a valid gzip stream")
+        }
+        let flags = bytes[3]
+        var offset = 10
+        if flags & 0x04 != 0 { // FEXTRA
+            guard offset + 2 <= bytes.count else {
+                throw SPZError.invalidFormat("Truncated gzip FEXTRA field")
+            }
+            let xlen = Int(bytes[offset]) | (Int(bytes[offset + 1]) << 8)
+            offset += 2 + xlen
+        }
+        if flags & 0x08 != 0 { // FNAME
+            offset = try skipNullTerminatedField(bytes, from: offset)
+        }
+        if flags & 0x10 != 0 { // FCOMMENT
+            offset = try skipNullTerminatedField(bytes, from: offset)
+        }
+        if flags & 0x02 != 0 { // FHCRC
+            offset += 2
+        }
+        guard offset + 8 <= bytes.count else {
+            throw SPZError.invalidFormat("Truncated gzip header")
+        }
+
+        // The trailer is the LAST 8 bytes of the stream: [CRC32 4B][ISIZE 4B]. ISIZE (the
+        // uncompressed size, mod 2^32) is the file's final 4 bytes -- not the first 4 of the
+        // trailer, which is CRC32. Getting this backwards reads the wrong output size and either
+        // truncates the decode or crashes on the size mismatch below.
+        let isizeOffset = bytes.count - 4
+        let isize = UInt32(bytes[isizeOffset])
+            | (UInt32(bytes[isizeOffset + 1]) << 8)
+            | (UInt32(bytes[isizeOffset + 2]) << 16)
+            | (UInt32(bytes[isizeOffset + 3]) << 24)
+        guard isize > 0 else {
+            throw SPZError.invalidFormat("Gzip trailer declares an empty payload")
+        }
+
+        let deflateEnd = bytes.count - 8
+        guard offset < deflateEnd else {
+            throw SPZError.invalidFormat("Gzip stream has no deflate body")
+        }
+        let deflateBody = Array(bytes[offset ..< deflateEnd])
+
+        var output = [UInt8](repeating: 0, count: Int(isize))
+        let written = output.withUnsafeMutableBytes { outBuf -> Int in
+            deflateBody.withUnsafeBytes { inBuf -> Int in
+                compression_decode_buffer(
+                    outBuf.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                    Int(isize),
+                    inBuf.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                    deflateBody.count,
+                    nil,
+                    COMPRESSION_ZLIB
+                )
+            }
+        }
+        guard written == Int(isize) else {
+            throw SPZError.decompressionFailed("expected \(isize) bytes, got \(written)")
+        }
+        return output
+    }
+
+    private static func skipNullTerminatedField(_ bytes: [UInt8], from start: Int) throws -> Int {
+        var i = start
+        while i < bytes.count, bytes[i] != 0 {
+            i += 1
+        }
+        guard i < bytes.count else {
+            throw SPZError.invalidFormat("Unterminated gzip header field")
+        }
+        return i + 1
+    }
+
+    // MARK: - Legacy payload (versions 2-3)
+
+    /// Layout: 16-byte header, then six non-interleaved streams back to back in this exact order
+    /// -- positions, alphas, colors, scales, rotations, sh -- matching
+    /// `serializePackedGaussians` in the reference implementation. Each stream's length is
+    /// derived from the header (`numPoints`, `shDegree`, `version`), not stored, so a truncated
+    /// or corrupt file is only caught by the bounds check on each stream read below.
+    private static func parseLegacyPayload(_ bytes: [UInt8]) throws -> GaussianSplatAsset {
+        guard bytes.count >= 16 else {
+            throw SPZError.invalidFormat("Decompressed payload shorter than the 16-byte header")
+        }
+        guard readUInt32LE(bytes, at: 0) == ngspMagic else {
+            throw SPZError.invalidFormat("Missing NGSP magic in decompressed payload")
+        }
+        let version = readUInt32LE(bytes, at: 4)
+        guard version >= minSupportedVersion, version <= maxSupportedVersion else {
+            throw SPZError.unsupportedVersion(version)
+        }
+        let numPointsRaw = readUInt32LE(bytes, at: 8)
+        guard numPointsRaw > 0, numPointsRaw <= UInt32(Int32.max) else {
+            throw SPZError.invalidData("Invalid point count: \(numPointsRaw)")
+        }
+        let numPoints = Int(numPointsRaw)
+        let shDegree = Int(bytes[12])
+        // The engine caps SH at degree 3 everywhere (UntoldGSCookOptions, PLYReader); SPZ itself
+        // allows degree 4, which is rejected here rather than silently truncated.
+        guard shDegree <= 3 else {
+            throw SPZError.unsupportedSHDegree(shDegree)
+        }
+        let fractionalBits = Int32(bytes[13])
+        let flags = bytes[14]
+        if flags & 0x02 != 0 { // FlagHasExtensions
+            Logger.log(
+                message: "[Gaussian][SPZ] File declares extensions; ignoring them (unsupported here) -- point data itself is unaffected",
+                category: LogCategory.gaussian.rawValue
+            )
+        }
+
+        let usesQuaternionSmallestThree = version >= smallestThreeQuaternionVersion
+        let shDim = shDimForDegree(shDegree) // rest coefficients per channel: 0, 3, 8, 15 for degree 0...3
+
+        var offset = 16
+        func takeStream(_ count: Int, name: String) throws -> [UInt8] {
+            guard offset + count <= bytes.count else {
+                throw SPZError.invalidData("Truncated \(name) stream")
+            }
+            defer { offset += count }
+            return Array(bytes[offset ..< offset + count])
+        }
+
+        let positions = try takeStream(numPoints * 9, name: "positions")
+        let alphas = try takeStream(numPoints, name: "alphas")
+        let colors = try takeStream(numPoints * 3, name: "colors")
+        let scales = try takeStream(numPoints * 3, name: "scales")
+        let rotations = try takeStream(numPoints * (usesQuaternionSmallestThree ? 4 : 3), name: "rotations")
+        let shBytes = try takeStream(numPoints * shDim * 3, name: "sh")
+
+        let positionScale: Float = 1.0 / Float(1 << fractionalBits)
+        var splats: [GaussianSplat] = []
+        splats.reserveCapacity(numPoints)
+        var shCoefficients: [Float] = []
+        let coefficientsPerChannel = shDim + 1
+        if shDim > 0 {
+            shCoefficients.reserveCapacity(numPoints * coefficientsPerChannel * 3)
+        }
+
+        for i in 0 ..< numPoints {
+            let position = decodePosition(positions, at: i, scale: positionScale)
+            let scale = decodeScale(scales, at: i)
+            let quat = decodeRotation(rotations, at: i, usesQuaternionSmallestThree: usesQuaternionSmallestThree)
+            let opacity = Float(alphas[i]) / 255.0
+            let (dcR, dcG, dcB) = decodeColorDC(colors, at: i)
+
+            splats.append(GaussianSplat(
+                center: simd_float4(position.x, position.y, position.z, 1.0),
+                scale: simd_float4(scale.x, scale.y, scale.z, 1.0),
+                color: simd_float4(dcR * C0 + 0.5, dcG * C0 + 0.5, dcB * C0 + 0.5, opacity),
+                quat: quat,
+                opacity: opacity
+            ))
+
+            // Transpose SPZ's on-disk coefficient-major/channel-minor SH layout (R,G,B triple per
+            // coefficient) into the engine's channel-major layout (all of R, then all of G, then
+            // all of B) that PLYReader's GaussianSphericalHarmonics.coefficients already uses.
+            if shDim > 0 {
+                let shBase = i * shDim * 3
+                for channel in 0 ..< 3 {
+                    let dc = channel == 0 ? dcR : (channel == 1 ? dcG : dcB)
+                    shCoefficients.append(dc)
+                    for k in 0 ..< shDim {
+                        let raw = unquantizeSH(shBytes[shBase + k * 3 + channel])
+                        shCoefficients.append(raw * flipSh[k])
+                    }
+                }
+            } else {
+                shCoefficients.append(dcR)
+                shCoefficients.append(dcG)
+                shCoefficients.append(dcB)
+            }
+        }
+
+        let (filteredSplats, filteredCoefficients) = filterNegligibleOpacityGaussianSplats(
+            splats: splats,
+            shCoefficients: shCoefficients,
+            coefficientsPerSplat: coefficientsPerChannel * 3,
+            sourceTag: "SPZ"
+        )
+
+        let sphericalHarmonics = GaussianSphericalHarmonics(
+            degree: shDegree,
+            coefficientsPerChannel: coefficientsPerChannel,
+            coefficients: filteredCoefficients
+        )
+        return GaussianSplatAsset(splats: filteredSplats, sphericalHarmonics: sphericalHarmonics)
+    }
+
+    // MARK: - Per-splat decoding
+
+    private static func decodePosition(_ positions: [UInt8], at i: Int, scale: Float) -> SIMD3<Float> {
+        let base = i * 9
+        var raw = SIMD3<Float>(repeating: 0)
+        for axis in 0 ..< 3 {
+            let b0 = positions[base + axis * 3 + 0]
+            let b1 = positions[base + axis * 3 + 1]
+            let b2 = positions[base + axis * 3 + 2]
+            var fixed = Int32(b0) | (Int32(b1) << 8) | (Int32(b2) << 16)
+            if fixed & 0x0080_0000 != 0 { fixed -= 0x0100_0000 } // sign-extend a 24-bit value
+            raw[axis] = Float(fixed) * scale
+        }
+        return raw * flipP
+    }
+
+    private static func decodeScale(_ scales: [UInt8], at i: Int) -> SIMD3<Float> {
+        let base = i * 3
+        // Log-scale byte, same convention PLYReader's scale_0/1/2 use -- exp() gives the linear
+        // scale. No coordinate flip: these are unsigned ellipsoid axis lengths in the splat's own
+        // local frame: the quaternion (already flipped) carries all orientation information.
+        let logScale = SIMD3<Float>(
+            Float(scales[base]), Float(scales[base + 1]), Float(scales[base + 2])
+        ) / 16.0 - 10.0
+        return SIMD3<Float>(exp(logScale.x), exp(logScale.y), exp(logScale.z))
+    }
+
+    /// Returns the engine's `(w, x, y, z)` quaternion convention (see `GaussianSplat.quat` /
+    /// `UntoldGSPacking.swift`'s `simd_quatf(ix: .y, iy: .z, iz: .w, r: .x)`), already RUB->RDF
+    /// flipped.
+    private static func decodeRotation(_ rotations: [UInt8], at i: Int, usesQuaternionSmallestThree: Bool) -> simd_float4 {
+        var x: Float
+        var y: Float
+        var z: Float
+        var w: Float
+        if usesQuaternionSmallestThree {
+            let base = i * 4
+            let comp = UInt32(rotations[base])
+                | (UInt32(rotations[base + 1]) << 8)
+                | (UInt32(rotations[base + 2]) << 16)
+                | (UInt32(rotations[base + 3]) << 24)
+            let largest = Int(comp >> 30)
+            let mask: UInt32 = (1 << 9) - 1
+            var components: [Float] = [0, 0, 0, 0]
+            var sumSquares: Float = 0
+            var remaining = comp
+            for idx in stride(from: 3, through: 0, by: -1) where idx != largest {
+                let mag = remaining & mask
+                let negative = (remaining >> 9) & 1 == 1
+                remaining >>= 10
+                var value = sqrt1_2 * Float(mag) / Float(mask)
+                if negative { value = -value }
+                components[idx] = value
+                sumSquares += value * value
+            }
+            components[largest] = sqrt(max(0, 1 - sumSquares))
+            x = components[0]; y = components[1]; z = components[2]; w = components[3]
+        } else {
+            let base = i * 3
+            x = Float(rotations[base]) / 127.5 - 1
+            y = Float(rotations[base + 1]) / 127.5 - 1
+            z = Float(rotations[base + 2]) / 127.5 - 1
+            w = sqrt(max(0, 1 - (x * x + y * y + z * z)))
+        }
+        // RUB -> RDF flip on x, y, z; w is never flipped.
+        x *= flipQ.x
+        y *= flipQ.y
+        z *= flipQ.z
+        return simd_float4(w, x, y, z)
+    }
+
+    private static func decodeColorDC(_ colors: [UInt8], at i: Int) -> (Float, Float, Float) {
+        let base = i * 3
+        let dcR = (Float(colors[base]) / 255.0 - 0.5) / colorScale
+        let dcG = (Float(colors[base + 1]) / 255.0 - 0.5) / colorScale
+        let dcB = (Float(colors[base + 2]) / 255.0 - 0.5) / colorScale
+        return (dcR, dcG, dcB)
+    }
+
+    private static func unquantizeSH(_ byte: UInt8) -> Float {
+        (Float(byte) - 128.0) / 128.0
+    }
+
+    private static func shDimForDegree(_ degree: Int) -> Int {
+        switch degree {
+        case 0: return 0
+        case 1: return 3
+        case 2: return 8
+        case 3: return 15
+        default: return 0
+        }
+    }
+
+    private static func readUInt32LE(_ bytes: [UInt8], at offset: Int) -> UInt32 {
+        UInt32(bytes[offset])
+            | (UInt32(bytes[offset + 1]) << 8)
+            | (UInt32(bytes[offset + 2]) << 16)
+            | (UInt32(bytes[offset + 3]) << 24)
+    }
+}
+
+// MARK: - Errors
+
+public enum SPZError: Error, CustomStringConvertible {
+    case invalidFormat(String)
+    case unsupportedVersion(UInt32)
+    case unsupportedSHDegree(Int)
+    case invalidData(String)
+    case decompressionFailed(String)
+
+    public var description: String {
+        switch self {
+        case let .invalidFormat(msg):
+            return "Invalid SPZ format: \(msg)"
+        case let .unsupportedVersion(version):
+            return version == 4
+                ? "Unsupported SPZ version: 4 (NGSP/ZSTD container is not yet supported; only legacy gzip versions 2-3 are)"
+                : "Unsupported SPZ version: \(version) (only legacy gzip versions 2-3 are supported)"
+        case let .unsupportedSHDegree(degree):
+            return "Unsupported spherical-harmonic degree: \(degree) (this engine supports 0...3)"
+        case let .invalidData(msg):
+            return "Invalid data: \(msg)"
+        case let .decompressionFailed(msg):
+            return "Gzip decompression failed: \(msg)"
+        }
+    }
+}

--- a/Tests/UntoldEngineTests/SPZReaderTest.swift
+++ b/Tests/UntoldEngineTests/SPZReaderTest.swift
@@ -1,0 +1,410 @@
+//
+//  SPZReaderTest.swift
+//  UntoldEngine
+//
+// Copyright (C) Untold Engine Studios
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Compression
+import CShaderTypes
+import Foundation
+import simd
+@testable import UntoldEngine
+import XCTest
+
+/// Fixtures build a *real* gzip envelope (header + raw-DEFLATE body via `compression_encode_buffer`
+/// + trailer) around a hand-built legacy SPZ payload, then round-trip it through `SPZReader`'s
+/// actual gzip unwrapper — not a mocked decompression step. This is deliberate: a previous pass at
+/// this reader had a bug where the gzip trailer's ISIZE field (the uncompressed size, the *last* 4
+/// bytes of the file) was read from the wrong offset (the CRC32 field, the *first* 4 of the 8-byte
+/// trailer), and only a fixture that exercises the real gzip envelope catches that class of bug.
+@MainActor
+final class SPZReaderTest: XCTestCase {
+    var tempFileURL: URL?
+
+    override func tearDown() async throws {
+        if let url = tempFileURL {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    // MARK: - Position / coordinate flip
+
+    func test_readGaussianAsset_decodesPositionWithRUBtoRDFFlip() throws {
+        let payload = makeLegacyPayload(
+            version: 2, numPoints: 1, shDegree: 0, fractionalBits: 0,
+            positions: encode24BitPosition(x: 5, y: 7, z: -3),
+            alphas: [255],
+            colors: [128, 128, 128],
+            scales: [160, 160, 160],
+            rotations: [127, 127, 127],
+            sh: []
+        )
+        let url = writeGzippedFixture(payload)
+        tempFileURL = url
+
+        let asset = try SPZReader.readGaussianAsset(from: url)
+        XCTAssertEqual(asset.splats.count, 1)
+        let splat = asset.splats[0]
+
+        // RUB -> RDF: X unchanged, Y and Z negated.
+        XCTAssertEqual(splat.center.x, 5.0, accuracy: 1e-5)
+        XCTAssertEqual(splat.center.y, -7.0, accuracy: 1e-5)
+        XCTAssertEqual(splat.center.z, 3.0, accuracy: 1e-5)
+        XCTAssertEqual(splat.center.w, 1.0, accuracy: 1e-5)
+
+        // scale byte 160 -> logScale = 160/16 - 10 = 0 -> exp(0) = 1
+        XCTAssertEqual(splat.scale.x, 1.0, accuracy: 1e-4)
+        XCTAssertEqual(splat.scale.y, 1.0, accuracy: 1e-4)
+        XCTAssertEqual(splat.scale.z, 1.0, accuracy: 1e-4)
+    }
+
+    // MARK: - Rotation decoding
+
+    /// Version 2 uses `packQuaternionFirstThree` (3 bytes: xyz only, w reconstructed and clamped
+    /// non-negative). Byte values are chosen so x, y, z decode to exact binary fractions
+    /// (153/127.5 - 1 = 0.2, 255/127.5 - 1 = 1.0, 0/127.5 - 1 = -1.0), including the clamp-to-zero
+    /// path for w since y and z alone already exceed unit length.
+    func test_readGaussianAsset_version2FirstThreeQuaternion_decodesExactValues() throws {
+        let payload = makeLegacyPayload(
+            version: 2, numPoints: 1, shDegree: 0, fractionalBits: 0,
+            positions: encode24BitPosition(x: 0, y: 0, z: 0),
+            alphas: [255],
+            colors: [128, 128, 128],
+            scales: [160, 160, 160],
+            rotations: [153, 255, 0],
+            sh: []
+        )
+        let url = writeGzippedFixture(payload)
+        tempFileURL = url
+
+        let asset = try SPZReader.readGaussianAsset(from: url)
+        let splat = try XCTUnwrap(asset.splats.first)
+
+        let x: Float = 153.0 / 127.5 - 1.0
+        let y: Float = 255.0 / 127.5 - 1.0
+        let z: Float = 0.0 / 127.5 - 1.0
+        let w: Float = 0.0 // sqrt(max(0, 1 - (x*x+y*y+z*z))): y and z alone already exceed 1
+
+        // Engine convention: quat.x is the real (w) part; .y/.z/.w are the imaginary x/y/z parts
+        // (see UntoldGSPacking.swift's simd_quatf(ix: .y, iy: .z, iz: .w, r: .x)). flipQ negates
+        // the imaginary y and z parts, not x.
+        XCTAssertEqual(splat.quat.x, w, accuracy: 1e-5)
+        XCTAssertEqual(splat.quat.y, x, accuracy: 1e-5)
+        XCTAssertEqual(splat.quat.z, -y, accuracy: 1e-5)
+        XCTAssertEqual(splat.quat.w, -z, accuracy: 1e-5)
+    }
+
+    /// Version 3 uses `packQuaternionSmallestThree` (4 bytes: 2-bit largest-component index + three
+    /// signed 9-bit magnitudes). `comp = 0xC0000000` selects index 3 (w) as the reconstructed
+    /// component with the other three magnitudes all zero, decoding to an exact identity
+    /// quaternion -- and an identity quaternion's zero components are unaffected by the RUB->RDF
+    /// sign flip, so this is a fully deterministic round-trip with no quantization tolerance needed.
+    func test_readGaussianAsset_version3SmallestThreeQuaternion_decodesExactIdentity() throws {
+        let payload = makeLegacyPayload(
+            version: 3, numPoints: 1, shDegree: 0, fractionalBits: 0,
+            positions: encode24BitPosition(x: 0, y: 0, z: 0),
+            alphas: [255],
+            colors: [128, 128, 128],
+            scales: [160, 160, 160],
+            rotations: [0x00, 0x00, 0x00, 0xC0],
+            sh: []
+        )
+        let url = writeGzippedFixture(payload)
+        tempFileURL = url
+
+        let asset = try SPZReader.readGaussianAsset(from: url)
+        let splat = try XCTUnwrap(asset.splats.first)
+
+        XCTAssertEqual(splat.quat.x, 1.0, accuracy: 1e-6, "real part")
+        XCTAssertEqual(splat.quat.y, 0.0, accuracy: 1e-6)
+        XCTAssertEqual(splat.quat.z, 0.0, accuracy: 1e-6)
+        XCTAssertEqual(splat.quat.w, 0.0, accuracy: 1e-6)
+    }
+
+    // MARK: - Spherical harmonics: coefficient-major -> channel-major transpose + flip
+
+    /// SPZ stores SH bytes on disk coefficient-major/channel-minor (an R,G,B triple per
+    /// coefficient); the engine's `GaussianSphericalHarmonics.coefficients` (matching PLYReader)
+    /// is channel-major (all of R, then all of G, then all of B). Distinct byte values per
+    /// (coefficient, channel) make a transposition bug show up as a wrong value rather than a
+    /// coincidentally-matching one.
+    func test_readGaussianAsset_sphericalHarmonics_transposesAndFlipsCorrectly() throws {
+        let shBytes: [UInt8] = [136, 137, 138, 140, 141, 142, 144, 145, 146] // coeff-major: c0(R,G,B), c1(R,G,B), c2(R,G,B)
+        let payload = makeLegacyPayload(
+            version: 3, numPoints: 1, shDegree: 1, fractionalBits: 0,
+            positions: encode24BitPosition(x: 0, y: 0, z: 0),
+            alphas: [255],
+            colors: [0, 0, 0],
+            scales: [160, 160, 160],
+            rotations: [0x00, 0x00, 0x00, 0xC0],
+            sh: shBytes
+        )
+        let url = writeGzippedFixture(payload)
+        tempFileURL = url
+
+        let asset = try SPZReader.readGaussianAsset(from: url)
+        let sh = try XCTUnwrap(asset.sphericalHarmonics)
+        XCTAssertEqual(sh.degree, 1)
+        XCTAssertEqual(sh.coefficientsPerChannel, 4) // 1 DC + 3 rest, dimForDegree(1) == 3
+        XCTAssertEqual(sh.coefficients.count, 12)
+
+        let dc: Float = (0.0 / 255.0 - 0.5) / 0.15
+        func unquantize(_ byte: UInt8) -> Float {
+            (Float(byte) - 128.0) / 128.0
+        }
+        // flipSh for indices 0, 1, 2 (RUB -> RDF, x=1,y=-1,z=-1 substituted into Niantic's table).
+        let flip: [Float] = [-1, -1, 1]
+
+        let expected: [Float] = [
+            dc, unquantize(136) * flip[0], unquantize(140) * flip[1], unquantize(144) * flip[2], // R: dc, c0, c1, c2
+            dc, unquantize(137) * flip[0], unquantize(141) * flip[1], unquantize(145) * flip[2], // G
+            dc, unquantize(138) * flip[0], unquantize(142) * flip[1], unquantize(146) * flip[2], // B
+        ]
+        for (index, value) in expected.enumerated() {
+            XCTAssertEqual(sh.coefficients[index], value, accuracy: 1e-6, "coefficient index \(index)")
+        }
+    }
+
+    func test_readGaussianAsset_shDegreeZero_stillProducesDCOnlySphericalHarmonics() throws {
+        let payload = makeLegacyPayload(
+            version: 2, numPoints: 1, shDegree: 0, fractionalBits: 0,
+            positions: encode24BitPosition(x: 0, y: 0, z: 0),
+            alphas: [255],
+            colors: [200, 100, 50],
+            scales: [160, 160, 160],
+            rotations: [127, 127, 127],
+            sh: []
+        )
+        let url = writeGzippedFixture(payload)
+        tempFileURL = url
+
+        let asset = try SPZReader.readGaussianAsset(from: url)
+        let sh = try XCTUnwrap(asset.sphericalHarmonics)
+        XCTAssertEqual(sh.degree, 0)
+        XCTAssertEqual(sh.coefficientsPerChannel, 1)
+        XCTAssertEqual(sh.coefficients.count, 3)
+
+        let C0: Float = 0.28209479177387814
+        let dcR: Float = (200.0 / 255.0 - 0.5) / 0.15
+        XCTAssertEqual(sh.coefficients[0], dcR, accuracy: 1e-6)
+        XCTAssertEqual(asset.splats[0].color.x, dcR * C0 + 0.5, accuracy: 1e-6)
+    }
+
+    // MARK: - Negligible-opacity culling parity with PLYReader
+
+    func test_readGaussianAsset_dropsNegligibleOpacitySplats() throws {
+        let payload = makeLegacyPayload(
+            version: 2, numPoints: 3, shDegree: 0, fractionalBits: 0,
+            positions: encode24BitPosition(x: 0, y: 0, z: 0)
+                + encode24BitPosition(x: 1, y: 0, z: 0)
+                + encode24BitPosition(x: 2, y: 0, z: 0),
+            alphas: [0, 128, 128], // first splat's opacity (0/255) is below the 1/255 retention threshold
+            colors: [128, 128, 128, 128, 128, 128, 128, 128, 128],
+            scales: [160, 160, 160, 160, 160, 160, 160, 160, 160],
+            rotations: [127, 127, 127, 127, 127, 127, 127, 127, 127],
+            sh: []
+        )
+        let url = writeGzippedFixture(payload)
+        tempFileURL = url
+
+        let asset = try SPZReader.readGaussianAsset(from: url)
+        XCTAssertEqual(asset.splats.count, 2, "The negligible-opacity splat should be dropped")
+        XCTAssertEqual(asset.splats[0].center.x, 1.0, accuracy: 1e-5, "Surviving splats keep their original order")
+        XCTAssertEqual(asset.splats[1].center.x, 2.0, accuracy: 1e-5)
+        for splat in asset.splats {
+            XCTAssertGreaterThan(splat.opacity, 1.0 / 255.0)
+        }
+    }
+
+    // MARK: - Format rejection
+
+    func test_readGaussianAsset_rejectsVersion1() throws {
+        try assertRejects(version: 1) { error in
+            guard case SPZError.unsupportedVersion(1) = error else {
+                XCTFail("Expected unsupportedVersion(1), got \(error)"); return
+            }
+        }
+    }
+
+    func test_readGaussianAsset_rejectsVersionAboveLegacyRange() throws {
+        try assertRejects(version: 5) { error in
+            guard case SPZError.unsupportedVersion(5) = error else {
+                XCTFail("Expected unsupportedVersion(5), got \(error)"); return
+            }
+        }
+    }
+
+    func test_readGaussianAsset_rejectsRawNGSPv4Container() throws {
+        // The raw (un-gzipped) NGSP magic at the start of the file signals a v4/ZSTD container --
+        // a different format entirely, out of scope here even though it shares the magic number
+        // with the legacy gzip payload's embedded header.
+        var bytes: [UInt8] = []
+        appendUInt32LE(0x5053_474E, to: &bytes)
+        bytes.append(contentsOf: [UInt8](repeating: 0, count: 28)) // pad to a plausible NgspFileHeader size
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("test_\(UUID().uuidString).spz")
+        try Data(bytes).write(to: url)
+        tempFileURL = url
+
+        XCTAssertThrowsError(try SPZReader.readGaussianAsset(from: url)) { error in
+            guard case SPZError.unsupportedVersion(4) = error else {
+                XCTFail("Expected unsupportedVersion(4), got \(error)"); return
+            }
+        }
+    }
+
+    func test_readGaussianAsset_rejectsUnrecognizedBytes() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("test_\(UUID().uuidString).spz")
+        try Data([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).write(to: url)
+        tempFileURL = url
+
+        XCTAssertThrowsError(try SPZReader.readGaussianAsset(from: url)) { error in
+            guard case SPZError.invalidFormat = error else {
+                XCTFail("Expected invalidFormat, got \(error)"); return
+            }
+        }
+    }
+
+    func test_readGaussianAsset_rejectsSHDegreeAboveThree() throws {
+        try assertRejects(version: 2, shDegree: 4) { error in
+            guard case SPZError.unsupportedSHDegree(4) = error else {
+                XCTFail("Expected unsupportedSHDegree(4), got \(error)"); return
+            }
+        }
+    }
+
+    func test_readGaussianAsset_rejectsTruncatedStream() throws {
+        // numPoints = 2, but the positions stream is one byte short of the 18 the header's point
+        // count requires, and nothing follows it -- the bounds check on the very first stream
+        // read is guaranteed to be what fails, regardless of any later stream's size.
+        let twoPointPositions = encode24BitPosition(x: 0, y: 0, z: 0) + encode24BitPosition(x: 1, y: 0, z: 0)
+        let payload = makeLegacyPayload(
+            version: 2, numPoints: 2, shDegree: 0, fractionalBits: 0,
+            positions: Array(twoPointPositions.dropLast()),
+            alphas: [], colors: [], scales: [], rotations: [], sh: []
+        )
+        let url = writeGzippedFixture(payload)
+        tempFileURL = url
+
+        XCTAssertThrowsError(try SPZReader.readGaussianAsset(from: url)) { error in
+            guard case let SPZError.invalidData(message) = error else {
+                XCTFail("Expected invalidData, got \(error)"); return
+            }
+            XCTAssertTrue(message.contains("positions"), "Should name the truncated stream")
+        }
+    }
+
+    // MARK: - External diagnostic (opt-in)
+
+    func test_externalGaussianDiagnosticAsset() throws {
+        guard let path = ProcessInfo.processInfo.environment["UNTOLD_GAUSSIAN_DIAGNOSTIC_SPZ"] else {
+            throw XCTSkip("Set UNTOLD_GAUSSIAN_DIAGNOSTIC_SPZ to audit a production .spz capture")
+        }
+        let asset = try SPZReader.readGaussianAsset(from: URL(fileURLWithPath: path))
+        XCTAssertGreaterThan(asset.splats.count, 0)
+        print("SPZ diagnostic: splats=\(asset.splats.count), degree=\(asset.sphericalHarmonics?.degree ?? -1), "
+            + "coefficients=\(asset.sphericalHarmonics?.coefficients.count ?? 0)")
+    }
+
+    // MARK: - Fixture helpers
+
+    private func assertRejects(
+        version: UInt32,
+        shDegree: Int = 0,
+        _ verify: (Error) -> Void
+    ) throws {
+        let payload = makeLegacyPayload(
+            version: version, numPoints: 1, shDegree: shDegree, fractionalBits: 0,
+            positions: [], alphas: [], colors: [], scales: [], rotations: [], sh: []
+        )
+        let url = writeGzippedFixture(payload)
+        tempFileURL = url
+        XCTAssertThrowsError(try SPZReader.readGaussianAsset(from: url), "", verify)
+    }
+
+    /// A single 24-bit little-endian two's-complement fixed-point axis value, times three (x, y, z).
+    private func encode24BitPosition(x: Int32, y: Int32, z: Int32) -> [UInt8] {
+        [x, y, z].flatMap { value -> [UInt8] in
+            let unsigned = UInt32(bitPattern: value) & 0x00FF_FFFF
+            return [UInt8(unsigned & 0xFF), UInt8((unsigned >> 8) & 0xFF), UInt8((unsigned >> 16) & 0xFF)]
+        }
+    }
+
+    private func appendUInt32LE(_ value: UInt32, to bytes: inout [UInt8]) {
+        bytes.append(UInt8(value & 0xFF))
+        bytes.append(UInt8((value >> 8) & 0xFF))
+        bytes.append(UInt8((value >> 16) & 0xFF))
+        bytes.append(UInt8((value >> 24) & 0xFF))
+    }
+
+    /// The 16-byte legacy header (magic, version, numPoints, shDegree, fractionalBits, flags,
+    /// reserved) followed by the six streams in the exact order `serializePackedGaussians` writes
+    /// them: positions, alphas, colors, scales, rotations, sh.
+    private func makeLegacyPayload(
+        version: UInt32,
+        numPoints: Int,
+        shDegree: Int,
+        fractionalBits: UInt8,
+        positions: [UInt8],
+        alphas: [UInt8],
+        colors: [UInt8],
+        scales: [UInt8],
+        rotations: [UInt8],
+        sh: [UInt8],
+        flags: UInt8 = 0
+    ) -> [UInt8] {
+        var bytes: [UInt8] = []
+        appendUInt32LE(0x5053_474E, to: &bytes) // "NGSP"
+        appendUInt32LE(version, to: &bytes)
+        appendUInt32LE(UInt32(numPoints), to: &bytes)
+        bytes.append(UInt8(shDegree))
+        bytes.append(fractionalBits)
+        bytes.append(flags)
+        bytes.append(0) // reserved
+        bytes.append(contentsOf: positions)
+        bytes.append(contentsOf: alphas)
+        bytes.append(contentsOf: colors)
+        bytes.append(contentsOf: scales)
+        bytes.append(contentsOf: rotations)
+        bytes.append(contentsOf: sh)
+        return bytes
+    }
+
+    /// Compresses `payload` with raw DEFLATE via `compression_encode_buffer` (mirroring
+    /// `SPZReader`'s own use of `compression_decode_buffer`) and wraps it in a real minimal gzip
+    /// envelope (10-byte header, no optional fields; 8-byte trailer with a zeroed CRC32 -- the
+    /// reader never validates it -- and the true ISIZE), then writes it to a temp file.
+    private func writeGzippedFixture(_ payload: [UInt8]) -> URL {
+        let deflated = rawDeflate(payload)
+        var bytes: [UInt8] = [0x1F, 0x8B, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF]
+        bytes.append(contentsOf: deflated)
+        bytes.append(contentsOf: [0, 0, 0, 0]) // CRC32, unchecked by SPZReader
+        appendUInt32LE(UInt32(payload.count), to: &bytes) // ISIZE: the *last* 4 bytes of the file
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("test_\(UUID().uuidString).spz")
+        try? Data(bytes).write(to: url)
+        return url
+    }
+
+    private func rawDeflate(_ data: [UInt8]) -> [UInt8] {
+        guard !data.isEmpty else { return [] }
+        let destinationCapacity = data.count * 2 + 128
+        var destination = [UInt8](repeating: 0, count: destinationCapacity)
+        let written = destination.withUnsafeMutableBytes { destBuffer -> Int in
+            data.withUnsafeBytes { sourceBuffer -> Int in
+                compression_encode_buffer(
+                    destBuffer.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                    destinationCapacity,
+                    sourceBuffer.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                    data.count,
+                    nil,
+                    COMPRESSION_ZLIB
+                )
+            }
+        }
+        precondition(written > 0, "compression_encode_buffer failed to compress the fixture payload")
+        return Array(destination.prefix(written))
+    }
+}

--- a/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/ExportCommand.swift
+++ b/Tools/UntoldEngineCLI/Sources/UntoldEngineCLI/ExportCommand.swift
@@ -26,7 +26,10 @@ struct ExportCommand: ParsableCommand {
         references — equivalent to running --compress-geometry followed by
         `untoldengine texbake --dir` and `untoldengine texbake --patch-refs`.
 
-        Gaussian `.ply` inputs skip Blender and export directly to `.untoldgs`.
+        Gaussian `.ply` or `.spz` inputs skip Blender and export directly to
+        `.untoldgs`. `.spz` support is limited to legacy gzip versions 2-3;
+        newer v4 (NGSP/ZSTD) files are rejected with a clear error --
+        re-export from the source tool as v2/v3, or convert through `.ply`.
         The --splat-* flags register the capture onto its mesh twin (up axis,
         scale, yaw, translation), crop away floaters and the
         captured floor, drop near-transparent splats, and pick the
@@ -51,12 +54,13 @@ struct ExportCommand: ParsableCommand {
           untoldengine export --input model.blend --output walk.untoldanim --animation
           untoldengine export --input splats.ply --output splats.untoldgs
           untoldengine export --input splats.ply --output splats.untoldgs --lod-levels 4
+          untoldengine export --input capture.spz --output capture.untoldgs
           untoldengine export --input sofa.ply --output sofa.untoldgs --splat-up-axis z \\
             --splat-scale 0.5 --splat-translate 0,0.4,0 --splat-crop=-1,0,-1,1,1.2,1 --splat-sh-degree 2
         """
     )
 
-    @Option(name: .long, help: "Source .usd, .usda, .usdc, .usdz, .blend, or Gaussian .ply asset")
+    @Option(name: .long, help: "Source .usd, .usda, .usdc, .usdz, .blend, or Gaussian .ply/.spz asset")
     var input: String
 
     @Option(name: .long, help: "Destination .untold, .untoldanim (with --animation), or .untoldgs file")
@@ -92,46 +96,46 @@ struct ExportCommand: ParsableCommand {
     @Option(name: .customLong("color-grade-lut"), help: "Path to an externally-authored standard .cube 3D LUT to stage and apply as a post-tonemap creative grade. Nothing is rendered from Blender -- the .cube is copied as-is and loaded directly by the engine")
     var colorGradeLUT: String?
 
-    @Option(name: .customLong("lod-levels"), help: "Gaussian .ply export only: number of progressive .untoldgs tiers to generate. Default 1 writes --output directly; values greater than 1 write <name>_lod0.untoldgs, <name>_lod1.untoldgs, ...")
+    @Option(name: .customLong("lod-levels"), help: "Gaussian .ply/.spz export only: number of progressive .untoldgs tiers to generate. Default 1 writes --output directly; values greater than 1 write <name>_lod0.untoldgs, <name>_lod1.untoldgs, ...")
     var lodLevels: Int = 1
 
-    @Option(name: .customLong("splat-chunk-splats"), help: "Gaussian .ply export only: splats per chunk, a power of two between 2 and 16384 (1024 for objects, 4096 for environments)")
+    @Option(name: .customLong("splat-chunk-splats"), help: "Gaussian .ply/.spz export only: splats per chunk, a power of two between 2 and 16384 (1024 for objects, 4096 for environments)")
     var splatChunkSplats: Int = 1024
 
-    @Option(name: .customLong("splat-sh-degree"), help: "Gaussian .ply export only: spherical-harmonics degree to keep, 0...3 (default: the source degree)")
+    @Option(name: .customLong("splat-sh-degree"), help: "Gaussian .ply/.spz export only: spherical-harmonics degree to keep, 0...3 (default: the source degree)")
     var splatSHDegree: Int?
 
-    @Option(name: .customLong("splat-min-opacity"), help: "Gaussian .ply export only: drop splats with a lower opacity")
+    @Option(name: .customLong("splat-min-opacity"), help: "Gaussian .ply/.spz export only: drop splats with a lower opacity")
     var splatMinOpacity: Float = 0.005
 
-    @Option(name: .customLong("splat-max-count"), help: "Gaussian .ply export only: keep at most this many splats, the most important by opacity and size (0 = no limit). The runtime loads at most \(UntoldGSCookOptions.splatBudgetMobile) per entity on Vision Pro, iPhone, iPad and Apple TV and \(UntoldGSCookOptions.splatBudgetMac) on the Mac.")
+    @Option(name: .customLong("splat-max-count"), help: "Gaussian .ply/.spz export only: keep at most this many splats, the most important by opacity and size (0 = no limit). The runtime loads at most \(UntoldGSCookOptions.splatBudgetMobile) per entity on Vision Pro, iPhone, iPad and Apple TV and \(UntoldGSCookOptions.splatBudgetMac) on the Mac.")
     var splatMaxCount: Int = 0
 
-    @Option(name: .customLong("splat-crop"), help: "Gaussian .ply export only: crop box in the output space, minX,minY,minZ,maxX,maxY,maxZ")
+    @Option(name: .customLong("splat-crop"), help: "Gaussian .ply/.spz export only: crop box in the output space, minX,minY,minZ,maxX,maxY,maxZ")
     var splatCrop: String?
 
-    @Option(name: .customLong("splat-crop-margin"), help: "Gaussian .ply export only: grow the crop box on every side, in metres")
+    @Option(name: .customLong("splat-crop-margin"), help: "Gaussian .ply/.spz export only: grow the crop box on every side, in metres")
     var splatCropMargin: Float = 0
 
-    @Option(name: .customLong("splat-scale"), help: "Gaussian .ply export only: uniform scale applied to the capture")
+    @Option(name: .customLong("splat-scale"), help: "Gaussian .ply/.spz export only: uniform scale applied to the capture")
     var splatScale: Float = 1
 
-    @Option(name: .customLong("splat-yaw-degrees"), help: "Gaussian .ply export only: rotation about +Y applied after --splat-flip-yz, in degrees")
+    @Option(name: .customLong("splat-yaw-degrees"), help: "Gaussian .ply/.spz export only: rotation about +Y applied after --splat-flip-yz, in degrees")
     var splatYawDegrees: Float = 0
 
-    @Option(name: .customLong("splat-translate"), help: "Gaussian .ply export only: translation applied after rotation and scale, x,y,z")
+    @Option(name: .customLong("splat-translate"), help: "Gaussian .ply/.spz export only: translation applied after rotation and scale, x,y,z")
     var splatTranslate: String?
 
-    @Option(name: .customLong("splat-up-axis"), help: "Gaussian .ply export only: which axis points up in the capture: y (engine convention, default), z (scanner/CAD, rotated to Y-up), or -y (3DGS training convention)")
+    @Option(name: .customLong("splat-up-axis"), help: "Gaussian .ply/.spz export only: which axis points up in the capture: y (engine convention, default), z (scanner/CAD, rotated to Y-up), or -y (3DGS training convention)")
     var splatUpAxis: String = "y"
 
-    @Flag(name: .customLong("splat-flip-yz"), help: "Gaussian .ply export only: same as --splat-up-axis=-y")
+    @Flag(name: .customLong("splat-flip-yz"), help: "Gaussian .ply/.spz export only: same as --splat-up-axis=-y")
     var splatFlipYZ = false
 
-    @Flag(name: .customLong("splat-environment"), help: "Gaussian .ply export only: cook as an environment payload")
+    @Flag(name: .customLong("splat-environment"), help: "Gaussian .ply/.spz export only: cook as an environment payload")
     var splatEnvironment = false
 
-    @Flag(name: .customLong("splat-antialiased"), help: "Gaussian .ply export only: mark the payload as cooked with the anti-aliased (3D smoothing) convention")
+    @Flag(name: .customLong("splat-antialiased"), help: "Gaussian .ply/.spz export only: mark the payload as cooked with the anti-aliased (3D smoothing) convention")
     var splatAntialiased = false
 
     func run() throws {
@@ -142,9 +146,10 @@ struct ExportCommand: ParsableCommand {
             throw ExportError.inputNotFound(inputURL.path)
         }
 
-        if inputURL.pathExtension.lowercased() == "ply" {
+        let inputExtension = inputURL.pathExtension.lowercased()
+        if inputExtension == "ply" || inputExtension == "spz" {
             guard outputURL.pathExtension.lowercased() == "untoldgs" else {
-                throw ExportError.unsupportedPLYExportOutput(outputURL.pathExtension)
+                throw ExportError.unsupportedGaussianExportOutput(outputURL.pathExtension)
             }
             guard lodLevels > 0 else {
                 throw ExportError.invalidLODLevels(lodLevels)
@@ -292,14 +297,30 @@ struct ExportCommand: ParsableCommand {
         printInfo("Exporting Gaussian splats \(inputURL.path)")
         let bakeResult: GaussianProgressiveBakeResult
         do {
-            bakeResult = try bakeGaussianSplatProgressiveTiers(
-                plyURL: inputURL,
-                outputBaseURL: outputURL,
-                levelCount: lodLevels,
-                cookOptions: cookOptions
-            )
+            switch inputURL.pathExtension.lowercased() {
+            case "spz":
+                bakeResult = try bakeGaussianSplatProgressiveTiers(
+                    spzURL: inputURL,
+                    outputBaseURL: outputURL,
+                    levelCount: lodLevels,
+                    cookOptions: cookOptions
+                )
+            default:
+                bakeResult = try bakeGaussianSplatProgressiveTiers(
+                    plyURL: inputURL,
+                    outputBaseURL: outputURL,
+                    levelCount: lodLevels,
+                    cookOptions: cookOptions
+                )
+            }
         } catch let error as UntoldGSCookError {
             throw ExportError.splatCookFailed(error.description)
+        } catch let error as SPZError {
+            // Most commonly a v4/NGSP (ZSTD) file -- a different, unsupported container, not a
+            // parse failure -- so this needs to reach the user as a clear message, not a crash.
+            throw ExportError.splatSourceReadFailed(error.description)
+        } catch let error as PLYError {
+            throw ExportError.splatSourceReadFailed(error.description)
         }
         let report = bakeResult.cookReport
         printInfo("Splats: \(report.keptSplatCount) of \(report.inputSplatCount) kept "
@@ -424,10 +445,11 @@ enum ExportError: LocalizedError {
     case exporterNotInstalled(String)
     case exportFailed(Int32)
     case optimizeFailed(Int32)
-    case unsupportedPLYExportOutput(String)
+    case unsupportedGaussianExportOutput(String)
     case invalidLODLevels(Int)
     case colorGradeLUTNotFound(String)
     case splatCookFailed(String)
+    case splatSourceReadFailed(String)
     case invalidSplatUpAxis(String)
     case invalidSplatFlag(String)
     case packManifestUnreadable(String)
@@ -443,15 +465,17 @@ enum ExportError: LocalizedError {
             return "Blender exporter failed with exit status \(status)"
         case let .optimizeFailed(status):
             return "Texture optimization (texbake) failed with exit status \(status)"
-        case let .unsupportedPLYExportOutput(pathExtension):
+        case let .unsupportedGaussianExportOutput(pathExtension):
             let suffix = pathExtension.isEmpty ? "<none>" : ".\(pathExtension)"
-            return "Gaussian .ply export supports only .untoldgs output, got \(suffix)"
+            return "Gaussian .ply/.spz export supports only .untoldgs output, got \(suffix)"
         case let .invalidLODLevels(value):
             return "--lod-levels must be a positive integer, got \(value)"
         case let .colorGradeLUTNotFound(path):
             return "--color-grade-lut path does not exist: \(path)"
         case let .splatCookFailed(reason):
             return "Gaussian splat cook failed: \(reason)"
+        case let .splatSourceReadFailed(reason):
+            return "Failed to read Gaussian source: \(reason)"
         case let .invalidSplatUpAxis(value):
             return "--splat-up-axis must be y, z or -y, got \(value)"
         case let .invalidSplatFlag(reason):

--- a/docs/API/UsingUntoldEngineCLI.md
+++ b/docs/API/UsingUntoldEngineCLI.md
@@ -130,7 +130,7 @@ and installs the `Pillow`/`lz4` Python packages, so `untoldengine export
 ## Exporting Assets
 
 Run the exporter from the game project or any other directory. Input can be a
-USD/USDZ asset, a `.blend` file, or a Gaussian `.ply` splat capture:
+USD/USDZ asset, a `.blend` file, or a Gaussian `.ply`/`.spz` splat capture:
 
 ```bash
 untoldengine export \
@@ -194,16 +194,21 @@ with `setEntityAnimations(entityId:filename:withExtension:name:)` instead.
 
 ### Gaussian splats → `.untoldgs`
 
-Gaussian `.ply` inputs skip Blender entirely and export straight to
+Gaussian `.ply` or `.spz` inputs skip Blender entirely and export straight to
 `.untoldgs`:
 
 ```bash
 # Single tier
 untoldengine export --input splats.ply --output splats.untoldgs
+untoldengine export --input splats.spz --output splats.untoldgs
 
 # Progressive LOD tiers (splats_lod0.untoldgs, splats_lod1.untoldgs, ...)
 untoldengine export --input splats.ply --output splats.untoldgs --lod-levels 4
 ```
+
+`.spz` support covers legacy gzip versions 2 and 3 only. Newer v4 files (the
+NGSP/ZSTD container) are rejected with a clear error rather than a crash —
+re-export from the source tool as v2/v3, or convert through `.ply` instead.
 
 ### Other export flags
 
@@ -222,16 +227,21 @@ Run `untoldengine export --help` for the full, current flag list.
 
 ### Gaussian splat captures
 
-A Gaussian splat `.ply` exports directly to `.untoldgs` (see [Gaussian Splat
+A Gaussian splat `.ply` or `.spz` exports directly to `.untoldgs` (see [Gaussian Splat
 Format](../Architecture/untoldgsFormat.md)); `--lod-levels N` writes progressive tiers.
 The `--splat-*` flags cook the capture on the way: register it onto its mesh twin, crop
 away floaters and the captured floor, drop near-transparent splats, and choose the
-spherical-harmonics degree and chunk size.
+spherical-harmonics degree and chunk size. They apply identically regardless of which
+source format was used, since both are read into the same in-memory representation before
+any cooking happens.
 
 ```bash
 untoldengine export --input sofa.ply --output Gaussians/sofa.untoldgs \
   --splat-up-axis z --splat-scale 0.5 --splat-yaw-degrees 90 --splat-translate 0,0.4,0 \
   --splat-crop=-1,0,-1,1,1.2,1 --splat-crop-margin 0.05 --splat-sh-degree 2
+
+untoldengine export --input sofa.spz --output Gaussians/sofa.untoldgs \
+  --splat-up-axis z --splat-scale 0.5 --splat-sh-degree 2
 ```
 
 `--splat-up-axis` names the capture's up axis (`y` is the engine convention and the default,

--- a/docs/Architecture/untoldgsFormat.md
+++ b/docs/Architecture/untoldgsFormat.md
@@ -3,8 +3,9 @@
 ## Overview
 
 `.untoldgs` is the engine-native container for Gaussian splat assets. It is a
-regeneratable cache of a source capture (`.ply`): `untoldengine export` bakes it, and a
-version bump means "re-bake". It is **not** an interchange format.
+regeneratable cache of a source capture (`.ply` or `.spz`, legacy gzip versions 2-3 only):
+`untoldengine export` bakes it, and a version bump means "re-bake". It is **not** an
+interchange format.
 
 Versions 1 and 2 stored one flat array of GPU-encoded splats and were read whole.
 **Version 3** stores quantised splats in page-aligned chunks so the runtime can read any


### PR DESCRIPTION
## Summary
  - New `SPZReader.swift` decodes legacy gzip SPZ (v2/v3 only) into the same `GaussianSplatAsset` shape `PLYReader` produces; v4 (NGSP/ZSTD) is rejected with a clear error, not a crash
  - `untoldengine export --input x.spz --output x.untoldgs` now works alongside `.ply`, including `--lod-levels`, every `--splat-*` cook flag, and `gaussian-link` — all identical regardless of source format
  - Updated `docs/API/UsingUntoldEngineCLI.md` and `docs/Architecture/untoldgsFormat.md`